### PR TITLE
Fix scintilla5.net.targets for ClickOnce

### DIFF
--- a/native/scintilla5.net.targets
+++ b/native/scintilla5.net.targets
@@ -1,9 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeLibraries Include="$(MSBuildThisFileDirectory)**\*.dll" />
-    <None Include="@(NativeLibraries)">
-      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+    <Content Include="$(MSBuildThisFileDirectory)**\*.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixed a bug in which the DLL path at build time is referenced at runtime when an application using Scintilla.NET is distributed via ClickOnce.