### PR TITLE
Fix `CaretLineVisible` default value

### DIFF
--- a/Shared/Scintilla.cs
+++ b/Shared/Scintilla.cs
@@ -4092,7 +4092,7 @@ namespace ScintillaNET
         /// Gets or sets whether the caret line is visible (highlighted).
         /// </summary>
         /// <returns>true if the caret line is visible; otherwise, false. The default is false.</returns>
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         [Category("Caret")]
         [Description("Determines whether to highlight the current caret line.")]
         public bool CaretLineVisible


### PR DESCRIPTION
Default for this property in Scintilla seems to be true, making it impossible to set it to false in the designer since it doesn't actually generate any code for default values.