### PR TITLE
Make Scintilla.NET compatible with C# 7.3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,8 +33,7 @@ indent_size = 2
 [[Aa]pp.{config,manifest}]
 indent_size = 2
 
-# C# files
-[*.cs]
+[*]
 
 #### .NET Coding Conventions ####
 
@@ -44,63 +43,108 @@ dotnet_sort_system_directives_first = true
 file_header_template = unset
 
 # this. and Me. preferences
-dotnet_style_qualification_for_event = false
-dotnet_style_qualification_for_field = true
-dotnet_style_qualification_for_method = false
-dotnet_style_qualification_for_property = false
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = true:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
 
 # Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true
-dotnet_style_predefined_type_for_member_access = true
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
 
 # Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary
-dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary
-dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:silent
 
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
 
 # Expression-level preferences
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_collection_initializer = true
-dotnet_style_explicit_tuple_names = true
-dotnet_style_namespace_match_folder = true
+dotnet_style_coalesce_expression = false:silent
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_collection_expression = when_types_loosely_match
-dotnet_style_prefer_compound_assignment = true
-dotnet_style_prefer_conditional_expression_over_assignment = true
-dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_collection_expression = never:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
-dotnet_style_prefer_inferred_anonymous_type_member_names = true
-dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_simplified_boolean_expressions = true
-dotnet_style_prefer_simplified_interpolation = true
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
 
 # Field preferences
-dotnet_style_readonly_field = true
+dotnet_style_readonly_field = true:suggestion
 
 # Parameter preferences
-dotnet_code_quality_unused_parameters = non_public
+dotnet_code_quality_unused_parameters = non_public:suggestion
 
 # Suppression preferences
 dotnet_remove_unnecessary_suppression_exclusions = none
 
 # New line preferences
-dotnet_style_allow_multiple_blank_lines_experimental = false
-dotnet_style_allow_statement_immediately_after_block_experimental = false
+dotnet_style_allow_multiple_blank_lines_experimental = false:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = false:silent
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# C# files
+[*.cs]
 
 #### C# Coding Conventions ####
 
 # var preferences
-csharp_style_var_elsewhere = false
-csharp_style_var_for_built_in_types = false
-csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = false:silent
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = true:silent
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = when_on_single_line:silent
@@ -113,54 +157,54 @@ csharp_style_expression_bodied_operators = when_on_single_line:silent
 csharp_style_expression_bodied_properties = when_on_single_line:silent
 
 # Pattern matching preferences
-csharp_style_pattern_matching_over_as_with_null_check = true
-csharp_style_pattern_matching_over_is_with_cast_check = true
-csharp_style_prefer_extended_property_pattern = true
-csharp_style_prefer_not_pattern = true
-csharp_style_prefer_pattern_matching = true
-csharp_style_prefer_switch_expression = false
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_prefer_not_pattern = false:suggestion
+csharp_style_prefer_pattern_matching = false:silent
+csharp_style_prefer_switch_expression = false:suggestion
 
 # Null-checking preferences
-csharp_style_conditional_delegate_call = true
+csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences
-csharp_prefer_static_local_function = true
+csharp_prefer_static_local_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
-csharp_style_prefer_readonly_struct = true
-csharp_style_prefer_readonly_struct_member = true
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
 
 # Code-block preferences
 csharp_prefer_braces = when_multiline:silent
-csharp_prefer_simple_using_statement = true:silent
-csharp_style_namespace_declarations = file_scoped:silent
+csharp_prefer_simple_using_statement = false:silent
+csharp_style_namespace_declarations = block_scoped:silent
 csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_primary_constructors = false:suggestion
 csharp_style_prefer_top_level_statements = false:silent
 
 # Expression-level preferences
-csharp_prefer_simple_default_expression = true
-csharp_style_deconstructed_variable_declaration = true
-csharp_style_implicit_object_creation_when_type_is_apparent = true
-csharp_style_inlined_variable_declaration = true
-csharp_style_prefer_index_operator = false
-csharp_style_prefer_local_over_anonymous_function = true
-csharp_style_prefer_null_check_over_type_check = true
-csharp_style_prefer_range_operator = true
-csharp_style_prefer_tuple_swap = true
-csharp_style_prefer_utf8_string_literals = true
-csharp_style_throw_expression = true
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = false:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_prefer_index_operator = false:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_range_operator = false:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_throw_expression = true:suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:silent
-csharp_style_unused_value_expression_statement_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
 # 'using' directive preferences
 csharp_using_directive_placement = outside_namespace:silent
 
 # New line preferences
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
-csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
-csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
-csharp_style_allow_embedded_statements_on_same_line_experimental = false
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false:silent
+csharp_style_allow_embedded_statements_on_same_line_experimental = false:silent
 
 #### C# Formatting Rules ####
 
@@ -208,45 +252,3 @@ csharp_space_between_square_brackets = false
 # Wrapping preferences
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
-
-#### Naming styles ####
-
-# Naming rules
-
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
-
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
-
-# Symbol specifications
-
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
-
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
-
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
-
-# Naming styles
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
-dotnet_naming_style.begins_with_i.capitalization = pascal_case

--- a/Scintilla.NET.TestApp/FormMain.cs
+++ b/Scintilla.NET.TestApp/FormMain.cs
@@ -6,279 +6,286 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 
-namespace ScintillaNET.TestApp;
-
-public partial class FormMain : Form
+namespace ScintillaNET.TestApp
 {
-    string baseTitle;
-    string? currentFileName = null;
-
-    public string? CurrentFileName
+    public partial class FormMain : Form
     {
-        get => this.currentFileName;
-        set
+        private string baseTitle;
+        private string currentFileName = null;
+
+        public string CurrentFileName
         {
-            BaseTitle = Path.GetFileName(this.currentFileName = value);
-        }
-    }
-
-    public string BaseTitle
-    {
-        get => this.baseTitle;
-        set
-        {
-            this.Text = (this.baseTitle = value) + (scintilla.Modified ? " *" : "");
-        }
-    }
-
-    public FormMain()
-    {
-        InitializeComponent();
-
-        baseTitle = this.Text;
-
-        scintilla.AssignCmdKey(Keys.Control | Keys.Shift | Keys.Z, Command.Redo);
-
-        scintilla.LexerName = "cpp";
-
-        SetScintillaStyles(scintilla);
-        AdjustLineNumberMargin(scintilla);
-        AdjustMarkerMargin(scintilla);
-        AdjustFoldMargin(scintilla);
-
-        Version scintillaNetVersion = scintilla.GetType().Assembly.GetName().Version;
-        string version = scintillaNetVersion.Revision == 0 ? scintillaNetVersion.ToString(3) : scintillaNetVersion.ToString();
-        string scintillaVersion = scintilla.ScintillaVersion;
-        string lexillaVersion = scintilla.LexillaVersion;
-
-        toolStripStatusLabel_Version.Text = $"ScintillaNET v{version} (Scintilla v{scintillaVersion}, Lexilla v{lexillaVersion})";
-
-        foreach (var group in Lexilla.GetLexerNames().ToArray().OrderBy(x => x).GroupBy(x => char.ToUpperInvariant(x[0])))
-        {
-            char first = group.Key;
-
-            if (group.Count() > 1)
+            get => this.currentFileName;
+            set
             {
-                var item = (ToolStripMenuItem)lexersToolStripMenuItem.DropDownItems.Add(first.ToString());
-
-                foreach (string lexer in group)
-                    item.DropDownItems.Add(lexer, null, Lexer_Click);
+                BaseTitle = Path.GetFileName(this.currentFileName = value);
             }
-            else
-                lexersToolStripMenuItem.DropDownItems.Add(group.Single(), null, Lexer_Click);
-        }
-    }
-
-    private void Lexer_Click(object sender, EventArgs e)
-    {
-        ToolStripItem item = (ToolStripItem)sender;
-        scintilla.LexerName = item.Text;
-        SetScintillaStyles(scintilla);
-        scintilla.Colorize(0, scintilla.TextLength);
-        AdjustFoldMargin(scintilla);
-    }
-
-    private void FormMain_Shown(object sender, EventArgs e)
-    {
-        scintilla.Select();
-    }
-
-    private static void SetScintillaStyles(Scintilla scintilla)
-    {
-        scintilla.StyleClearAll();
-
-        // Configure the CPP (C#) lexer styles
-        scintilla.Styles[1].ForeColor = Color.FromArgb(0x00, 0x80, 0x00);  // COMMENT
-        scintilla.Styles[2].ForeColor = Color.FromArgb(0x00, 0x80, 0x00);  // COMMENT LINE
-        scintilla.Styles[3].ForeColor = Color.FromArgb(0x00, 0x80, 0x80);  // COMMENT DOC
-        scintilla.Styles[4].ForeColor = Color.FromArgb(0xFF, 0x80, 0x00);  // NUMBER
-        scintilla.Styles[5].ForeColor = Color.FromArgb(0x00, 0x00, 0xFF);  // INSTRUCTION WORD
-        scintilla.Styles[6].ForeColor = Color.FromArgb(0x80, 0x80, 0x80);  // STRING
-        scintilla.Styles[7].ForeColor = Color.FromArgb(0x80, 0x80, 0x80);  // CHARACTER
-        scintilla.Styles[9].ForeColor = Color.FromArgb(0x80, 0x40, 0x00);  // PREPROCESSOR
-        scintilla.Styles[10].ForeColor = Color.FromArgb(0x00, 0x00, 0x80); // OPERATOR
-        scintilla.Styles[11].ForeColor = Color.FromArgb(0x00, 0x00, 0x00); // DEFAULT
-        scintilla.Styles[13].ForeColor = Color.FromArgb(0x00, 0x00, 0x00); // VERBATIM
-        scintilla.Styles[14].ForeColor = Color.FromArgb(0x00, 0x00, 0x00); // REGEX
-        scintilla.Styles[15].ForeColor = Color.FromArgb(0x00, 0x80, 0x80); // COMMENT LINE DOC
-        scintilla.Styles[16].ForeColor = Color.FromArgb(0x80, 0x00, 0xFF); // TYPE WORD
-        scintilla.Styles[17].ForeColor = Color.FromArgb(0x00, 0x80, 0x80); // COMMENT DOC KEYWORD
-        scintilla.Styles[18].ForeColor = Color.FromArgb(0x00, 0x80, 0x80); // COMMENT DOC KEYWORD ERROR
-        scintilla.Styles[23].ForeColor = Color.FromArgb(0x00, 0x80, 0x00); // PREPROCESSOR COMMENT
-        scintilla.Styles[24].ForeColor = Color.FromArgb(0x00, 0x80, 0x80); // PREPROCESSOR COMMENT DOC
-        scintilla.Styles[5].Bold = true;
-        scintilla.Styles[10].Bold = true;
-        scintilla.Styles[14].Bold = true;
-        scintilla.Styles[17].Bold = true;
-
-        scintilla.SetKeywords(0,
-            "abstract add alias as ascending async await base break case catch checked continue default delegate descending do dynamic else event explicit extern false finally fixed for foreach from get global goto group if implicit in interface internal into is join let lock nameof namespace new null object operator orderby out override params partial private protected public readonly ref remove return sealed select set sizeof stackalloc switch this throw true try typeof unchecked unsafe using value virtual when where while yield");
-        scintilla.SetKeywords(1,
-            "bool byte char class const decimal double enum float int long nint nuint sbyte short static string struct uint ulong ushort var void");
-    }
-
-    private static byte CountDigits(int x)
-    {
-        if (x == 0)
-            return 1;
-
-        byte result = 0;
-        while (x > 0)
-        {
-            result++;
-            x /= 10;
         }
 
-        return result;
-    }
-
-    private static readonly Dictionary<Scintilla, int> maxLineNumberCharLengthMap = [];
-
-    private static void AdjustLineNumberMargin(Scintilla scintilla)
-    {
-        int maxLineNumberCharLength = CountDigits(scintilla.Lines.Count);
-        if (maxLineNumberCharLength == (maxLineNumberCharLengthMap.TryGetValue(scintilla, out int charLen) ? charLen : 0))
-            return;
-
-        const int padding = 2;
-        scintilla.Margins[0].Width = scintilla.TextWidth(Style.LineNumber, new string('0', maxLineNumberCharLength + 1)) + padding;
-        maxLineNumberCharLengthMap[scintilla] = maxLineNumberCharLength;
-    }
-
-    private static void AdjustMarkerMargin(Scintilla scintilla)
-    {
-        scintilla.Margins[1].Width = 16;
-        scintilla.Margins[1].Sensitive = false;
-        //scintilla.Markers[Marker.HistoryRevertedToModified].SetForeColor(Color.Orange);
-        //scintilla.Markers[Marker.HistoryRevertedToModified].SetBackColor(scintilla.Margins[1].BackColor);
-        //scintilla.Markers[Marker.HistoryRevertedToOrigin].SetForeColor(Color.Orange);
-        //scintilla.Markers[Marker.HistoryRevertedToOrigin].SetBackColor(scintilla.Margins[1].BackColor);
-    }
-
-    private static void AdjustFoldMargin(Scintilla scintilla)
-    {
-        // Instruct the lexer to calculate folding
-        scintilla.SetProperty("fold", "1");
-
-        // Configure a margin to display folding symbols
-        scintilla.Margins[2].Type = MarginType.Symbol;
-        scintilla.Margins[2].Mask = Marker.MaskFolders;
-        scintilla.Margins[2].Sensitive = true;
-        scintilla.Margins[2].Width = 20;
-
-        // Set colors for all folding markers
-        for (int i = 25; i <= 31; i++)
+        public string BaseTitle
         {
-            scintilla.Markers[i].SetForeColor(SystemColors.ControlLightLight);
-            scintilla.Markers[i].SetBackColor(SystemColors.ControlDark);
+            get => this.baseTitle;
+            set
+            {
+                Text = (this.baseTitle = value) + (this.scintilla.Modified ? " *" : "");
+            }
         }
 
-        // Configure folding markers with respective symbols
-        scintilla.Markers[Marker.Folder].Symbol = MarkerSymbol.BoxPlus;
-        scintilla.Markers[Marker.FolderOpen].Symbol = MarkerSymbol.BoxMinus;
-        scintilla.Markers[Marker.FolderEnd].Symbol = MarkerSymbol.BoxPlusConnected;
-        scintilla.Markers[Marker.FolderMidTail].Symbol = MarkerSymbol.TCorner;
-        scintilla.Markers[Marker.FolderOpenMid].Symbol = MarkerSymbol.BoxMinusConnected;
-        scintilla.Markers[Marker.FolderSub].Symbol = MarkerSymbol.VLine;
-        scintilla.Markers[Marker.FolderTail].Symbol = MarkerSymbol.LCorner;
-
-        // Enable automatic folding
-        scintilla.AutomaticFold = AutomaticFold.Show | AutomaticFold.Click | AutomaticFold.Change;
-    }
-
-    private void openToolStripMenuItem_Click(object sender, EventArgs e)
-    {
-        if (openFileDialog.ShowDialog(this) == DialogResult.OK)
+        public FormMain()
         {
-            CurrentFileName = openFileDialog.FileName;
-            scintilla.Text = File.ReadAllText(CurrentFileName, Encoding.UTF8);
-            scintilla.ClearChangeHistory();
-            scintilla.SetSavePoint();
+            InitializeComponent();
+
+            this.baseTitle = Text;
+
+            this.scintilla.AssignCmdKey(Keys.Control | Keys.Shift | Keys.Z, Command.Redo);
+
+            this.scintilla.LexerName = "cpp";
+
+            SetScintillaStyles(this.scintilla);
+            AdjustLineNumberMargin(this.scintilla);
+            AdjustMarkerMargin(this.scintilla);
+            AdjustFoldMargin(this.scintilla);
+
+            Version scintillaNetVersion = this.scintilla.GetType().Assembly.GetName().Version;
+            string version = scintillaNetVersion.Revision == 0 ? scintillaNetVersion.ToString(3) : scintillaNetVersion.ToString();
+            string scintillaVersion = this.scintilla.ScintillaVersion;
+            string lexillaVersion = this.scintilla.LexillaVersion;
+
+            this.toolStripStatusLabel_Version.Text = $"ScintillaNET v{version} (Scintilla v{scintillaVersion}, Lexilla v{lexillaVersion})";
+
+            foreach (IGrouping<char, string> group in Lexilla.GetLexerNames().ToArray().OrderBy(x => x).GroupBy(x => char.ToUpperInvariant(x[0])))
+            {
+                char first = group.Key;
+
+                if (group.Count() > 1)
+                {
+                    var item = (ToolStripMenuItem)this.lexersToolStripMenuItem.DropDownItems.Add(first.ToString());
+
+                    foreach (string lexer in group)
+                        item.DropDownItems.Add(lexer, null, Lexer_Click);
+                }
+                else
+                {
+                    this.lexersToolStripMenuItem.DropDownItems.Add(group.Single(), null, Lexer_Click);
+                }
+            }
         }
-    }
 
-    private void saveToolStripMenuItem_Click(object sender, EventArgs e)
-    {
-        if (CurrentFileName is null && saveFileDialog.ShowDialog(this) == DialogResult.OK)
-            CurrentFileName = saveFileDialog.FileName;
-
-        if (CurrentFileName is not null)
+        private void Lexer_Click(object sender, EventArgs e)
         {
-            File.WriteAllText(CurrentFileName, scintilla.Text, Encoding.UTF8);
-            scintilla.SetSavePoint();
+            var item = (ToolStripItem)sender;
+            this.scintilla.LexerName = item.Text;
+            SetScintillaStyles(this.scintilla);
+            this.scintilla.Colorize(0, this.scintilla.TextLength);
+            AdjustFoldMargin(this.scintilla);
         }
-    }
 
-    private void FormMain_FormClosing(object sender, FormClosingEventArgs e)
-    {
-        //if (scintilla.Modified)
-        //{
-        //    if (MessageBox.Show("You have unsaved changes, are you sure to exit?", "Scintilla", MessageBoxButtons.OKCancel, MessageBoxIcon.Question, MessageBoxDefaultButton.Button2) == DialogResult.Cancel)
-        //        e.Cancel = true;
-        //}
-    }
-
-    private void describeKeywordSetsToolStripMenuItem_Click(object sender, EventArgs e)
-    {
-        scintilla.ReplaceSelection(scintilla.DescribeKeywordSets());
-    }
-
-    private void scintilla_TextChanged(object sender, EventArgs e)
-    {
-        AdjustLineNumberMargin(scintilla);
-    }
-
-    private void scintilla_SavePointLeft(object sender, EventArgs e)
-    {
-        Text = BaseTitle + " *";
-    }
-
-    private void scintilla_SavePointReached(object sender, EventArgs e)
-    {
-        Text = BaseTitle;
-    }
-
-    private void toolStripMenuItem_Find_Click(object sender, EventArgs e)
-    {
-        Search(toolStripTextBox_Find.Text);
-    }
-
-    private void Search(string text, bool reverse = false)
-    {
-        if (string.IsNullOrEmpty(text))
-            return;
-
-        int start = reverse ? scintilla.AnchorPosition : scintilla.CurrentPosition;
-        int end = reverse ? 0 : scintilla.TextLength;
-        int pos = scintilla.FindText(SearchFlags.None, text, start, end);
-        if (pos == -1)
+        private void FormMain_Shown(object sender, EventArgs e)
         {
-            start = reverse ? scintilla.TextLength : 0;
-            end = reverse ? scintilla.AnchorPosition - text.Length : scintilla.CurrentPosition + text.Length;
-            pos = scintilla.FindText(SearchFlags.None, text, start, end);
+            this.scintilla.Select();
+        }
+
+        private static void SetScintillaStyles(Scintilla scintilla)
+        {
+            scintilla.StyleClearAll();
+
+            // Configure the CPP (C#) lexer styles
+            scintilla.Styles[1].ForeColor = Color.FromArgb(0x00, 0x80, 0x00);  // COMMENT
+            scintilla.Styles[2].ForeColor = Color.FromArgb(0x00, 0x80, 0x00);  // COMMENT LINE
+            scintilla.Styles[3].ForeColor = Color.FromArgb(0x00, 0x80, 0x80);  // COMMENT DOC
+            scintilla.Styles[4].ForeColor = Color.FromArgb(0xFF, 0x80, 0x00);  // NUMBER
+            scintilla.Styles[5].ForeColor = Color.FromArgb(0x00, 0x00, 0xFF);  // INSTRUCTION WORD
+            scintilla.Styles[6].ForeColor = Color.FromArgb(0x80, 0x80, 0x80);  // STRING
+            scintilla.Styles[7].ForeColor = Color.FromArgb(0x80, 0x80, 0x80);  // CHARACTER
+            scintilla.Styles[9].ForeColor = Color.FromArgb(0x80, 0x40, 0x00);  // PREPROCESSOR
+            scintilla.Styles[10].ForeColor = Color.FromArgb(0x00, 0x00, 0x80); // OPERATOR
+            scintilla.Styles[11].ForeColor = Color.FromArgb(0x00, 0x00, 0x00); // DEFAULT
+            scintilla.Styles[13].ForeColor = Color.FromArgb(0x00, 0x00, 0x00); // VERBATIM
+            scintilla.Styles[14].ForeColor = Color.FromArgb(0x00, 0x00, 0x00); // REGEX
+            scintilla.Styles[15].ForeColor = Color.FromArgb(0x00, 0x80, 0x80); // COMMENT LINE DOC
+            scintilla.Styles[16].ForeColor = Color.FromArgb(0x80, 0x00, 0xFF); // TYPE WORD
+            scintilla.Styles[17].ForeColor = Color.FromArgb(0x00, 0x80, 0x80); // COMMENT DOC KEYWORD
+            scintilla.Styles[18].ForeColor = Color.FromArgb(0x00, 0x80, 0x80); // COMMENT DOC KEYWORD ERROR
+            scintilla.Styles[23].ForeColor = Color.FromArgb(0x00, 0x80, 0x00); // PREPROCESSOR COMMENT
+            scintilla.Styles[24].ForeColor = Color.FromArgb(0x00, 0x80, 0x80); // PREPROCESSOR COMMENT DOC
+            scintilla.Styles[5].Bold = true;
+            scintilla.Styles[10].Bold = true;
+            scintilla.Styles[14].Bold = true;
+            scintilla.Styles[17].Bold = true;
+
+            scintilla.SetKeywords(0,
+                "abstract add alias as ascending async await base break case catch checked continue default delegate descending do dynamic else event explicit extern false finally fixed for foreach from get global goto group if implicit in interface internal into is join let lock nameof namespace new null object operator orderby out override params partial private protected public readonly ref remove return sealed select set sizeof stackalloc switch this throw true try typeof unchecked unsafe using value virtual when where while yield");
+            scintilla.SetKeywords(1,
+                "bool byte char class const decimal double enum float int long nint nuint sbyte short static string struct uint ulong ushort var void");
+        }
+
+        private static byte CountDigits(int x)
+        {
+            if (x == 0)
+                return 1;
+
+            byte result = 0;
+            while (x > 0)
+            {
+                result++;
+                x /= 10;
+            }
+
+            return result;
+        }
+
+        private static readonly Dictionary<Scintilla, int> maxLineNumberCharLengthMap = new Dictionary<Scintilla, int>();
+
+        private static void AdjustLineNumberMargin(Scintilla scintilla)
+        {
+            int maxLineNumberCharLength = CountDigits(scintilla.Lines.Count);
+            if (maxLineNumberCharLength == (maxLineNumberCharLengthMap.TryGetValue(scintilla, out int charLen) ? charLen : 0))
+                return;
+
+            const int padding = 2;
+            scintilla.Margins[0].Width = scintilla.TextWidth(Style.LineNumber, new string('0', maxLineNumberCharLength + 1)) + padding;
+            maxLineNumberCharLengthMap[scintilla] = maxLineNumberCharLength;
+        }
+
+        private static void AdjustMarkerMargin(Scintilla scintilla)
+        {
+            scintilla.Margins[1].Width = 16;
+            scintilla.Margins[1].Sensitive = false;
+            //scintilla.Markers[Marker.HistoryRevertedToModified].SetForeColor(Color.Orange);
+            //scintilla.Markers[Marker.HistoryRevertedToModified].SetBackColor(scintilla.Margins[1].BackColor);
+            //scintilla.Markers[Marker.HistoryRevertedToOrigin].SetForeColor(Color.Orange);
+            //scintilla.Markers[Marker.HistoryRevertedToOrigin].SetBackColor(scintilla.Margins[1].BackColor);
+        }
+
+        private static void AdjustFoldMargin(Scintilla scintilla)
+        {
+            // Instruct the lexer to calculate folding
+            scintilla.SetProperty("fold", "1");
+
+            // Configure a margin to display folding symbols
+            scintilla.Margins[2].Type = MarginType.Symbol;
+            scintilla.Margins[2].Mask = Marker.MaskFolders;
+            scintilla.Margins[2].Sensitive = true;
+            scintilla.Margins[2].Width = 20;
+
+            // Set colors for all folding markers
+            for (int i = 25; i <= 31; i++)
+            {
+                scintilla.Markers[i].SetForeColor(SystemColors.ControlLightLight);
+                scintilla.Markers[i].SetBackColor(SystemColors.ControlDark);
+            }
+
+            // Configure folding markers with respective symbols
+            scintilla.Markers[Marker.Folder].Symbol = MarkerSymbol.BoxPlus;
+            scintilla.Markers[Marker.FolderOpen].Symbol = MarkerSymbol.BoxMinus;
+            scintilla.Markers[Marker.FolderEnd].Symbol = MarkerSymbol.BoxPlusConnected;
+            scintilla.Markers[Marker.FolderMidTail].Symbol = MarkerSymbol.TCorner;
+            scintilla.Markers[Marker.FolderOpenMid].Symbol = MarkerSymbol.BoxMinusConnected;
+            scintilla.Markers[Marker.FolderSub].Symbol = MarkerSymbol.VLine;
+            scintilla.Markers[Marker.FolderTail].Symbol = MarkerSymbol.LCorner;
+
+            // Enable automatic folding
+            scintilla.AutomaticFold = AutomaticFold.Show | AutomaticFold.Click | AutomaticFold.Change;
+        }
+
+        private void openToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (this.openFileDialog.ShowDialog(this) == DialogResult.OK)
+            {
+                CurrentFileName = this.openFileDialog.FileName;
+                this.scintilla.Text = File.ReadAllText(CurrentFileName, Encoding.UTF8);
+                this.scintilla.ClearChangeHistory();
+                this.scintilla.SetSavePoint();
+            }
+        }
+
+        private void saveToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (CurrentFileName is null && this.saveFileDialog.ShowDialog(this) == DialogResult.OK)
+                CurrentFileName = this.saveFileDialog.FileName;
+
+            if (CurrentFileName != null)
+            {
+                File.WriteAllText(CurrentFileName, this.scintilla.Text, Encoding.UTF8);
+                this.scintilla.SetSavePoint();
+            }
+        }
+
+        private void FormMain_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            //if (scintilla.Modified)
+            //{
+            //    if (MessageBox.Show("You have unsaved changes, are you sure to exit?", "Scintilla", MessageBoxButtons.OKCancel, MessageBoxIcon.Question, MessageBoxDefaultButton.Button2) == DialogResult.Cancel)
+            //        e.Cancel = true;
+            //}
+        }
+
+        private void describeKeywordSetsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this.scintilla.ReplaceSelection(this.scintilla.DescribeKeywordSets());
+        }
+
+        private void scintilla_TextChanged(object sender, EventArgs e)
+        {
+            AdjustLineNumberMargin(this.scintilla);
+        }
+
+        private void scintilla_SavePointLeft(object sender, EventArgs e)
+        {
+            Text = BaseTitle + " *";
+        }
+
+        private void scintilla_SavePointReached(object sender, EventArgs e)
+        {
+            Text = BaseTitle;
+        }
+
+        private void toolStripMenuItem_Find_Click(object sender, EventArgs e)
+        {
+            Search(this.toolStripTextBox_Find.Text);
+        }
+
+        private void Search(string text, bool reverse = false)
+        {
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            int start = reverse ? this.scintilla.AnchorPosition : this.scintilla.CurrentPosition;
+            int end = reverse ? 0 : this.scintilla.TextLength;
+            int pos = this.scintilla.FindText(SearchFlags.None, text, start, end);
             if (pos == -1)
             {
-                toolStripStatusLabel.Text = $"\"{text}\" not found in document.";
-                return;
+                start = reverse ? this.scintilla.TextLength : 0;
+                end = reverse ? this.scintilla.AnchorPosition - text.Length : this.scintilla.CurrentPosition + text.Length;
+                pos = this.scintilla.FindText(SearchFlags.None, text, start, end);
+                if (pos == -1)
+                {
+                    this.toolStripStatusLabel.Text = $"\"{text}\" not found in document.";
+                    return;
+                }
+                else
+                {
+                    this.toolStripStatusLabel.Text = $"Search wrapped.";
+                }
             }
             else
-                toolStripStatusLabel.Text = $"Search wrapped.";
+            {
+                this.toolStripStatusLabel.Text = "";
+            }
+
+            int caret = pos + text.Length, anchor = pos;
+            this.scintilla.SetSelection(caret, anchor);
+            this.scintilla.ScrollRange(anchor, caret);
         }
-        else
-            toolStripStatusLabel.Text = "";
 
-        int caret = pos + text.Length, anchor = pos;
-        scintilla.SetSelection(caret, anchor);
-        scintilla.ScrollRange(anchor, caret);
-    }
-
-    private void toolStripTextBox_Find_KeyDown(object sender, KeyEventArgs e)
-    {
-        if (e.KeyCode == Keys.Enter && (e.Modifiers & ~Keys.Shift) == 0)
+        private void toolStripTextBox_Find_KeyDown(object sender, KeyEventArgs e)
         {
-            Search(toolStripTextBox_Find.Text, e.Shift);
-            e.Handled = true;
-            e.SuppressKeyPress = true;
+            if (e.KeyCode == Keys.Enter && (e.Modifiers & ~Keys.Shift) == 0)
+            {
+                Search(this.toolStripTextBox_Find.Text, e.Shift);
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+            }
         }
     }
 }

--- a/Scintilla.NET.TestApp/Program.cs
+++ b/Scintilla.NET.TestApp/Program.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Windows.Forms;
 
-namespace ScintillaNET.TestApp;
-
-static class Program
+namespace ScintillaNET.TestApp
 {
-    /// <summary>
-    /// The main entry point for the application.
-    /// </summary>
-    [STAThread]
-    static void Main()
+    internal static class Program
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
-        Application.Run(new FormMain());
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new FormMain());
+        }
     }
 }

--- a/Scintilla.NET.TestApp/Scintilla.NET.TestApp.csproj
+++ b/Scintilla.NET.TestApp/Scintilla.NET.TestApp.csproj
@@ -9,11 +9,9 @@
     <Authors>desjarlais</Authors>
     <Description>A test application to validate that the ScintillaNET control is working.</Description>
     <UseWindowsForms>true</UseWindowsForms>
-    <LangVersion>latest</LangVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <RootNamespace>ScintillaNET.TestApp</RootNamespace>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="FormMain.cs">

--- a/Scintilla.NET/Annotation.cs
+++ b/Scintilla.NET/Annotation.cs
@@ -1,27 +1,28 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Visibility and location of annotations in a <see cref="Scintilla" /> control
-/// </summary>
-public enum Annotation
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Annotations are not displayed. This is the default.
+    /// Visibility and location of annotations in a <see cref="Scintilla" /> control
     /// </summary>
-    Hidden = NativeMethods.ANNOTATION_HIDDEN,
+    public enum Annotation
+    {
+        /// <summary>
+        /// Annotations are not displayed. This is the default.
+        /// </summary>
+        Hidden = NativeMethods.ANNOTATION_HIDDEN,
 
-    /// <summary>
-    /// Annotations are drawn left justified with no adornment.
-    /// </summary>
-    Standard = NativeMethods.ANNOTATION_STANDARD,
+        /// <summary>
+        /// Annotations are drawn left justified with no adornment.
+        /// </summary>
+        Standard = NativeMethods.ANNOTATION_STANDARD,
 
-    /// <summary>
-    /// Annotations are indented to match the text and are surrounded by a box.
-    /// </summary>
-    Boxed = NativeMethods.ANNOTATION_BOXED,
+        /// <summary>
+        /// Annotations are indented to match the text and are surrounded by a box.
+        /// </summary>
+        Boxed = NativeMethods.ANNOTATION_BOXED,
 
-    /// <summary>
-    /// Annotations are indented to match the text.
-    /// </summary>
-    Indented = NativeMethods.ANNOTATION_INDENTED
+        /// <summary>
+        /// Annotations are indented to match the text.
+        /// </summary>
+        Indented = NativeMethods.ANNOTATION_INDENTED
+    }
 }

--- a/Scintilla.NET/AutoCSelectionChangeEventArgs.cs
+++ b/Scintilla.NET/AutoCSelectionChangeEventArgs.cs
@@ -27,7 +27,7 @@ namespace ScintillaNET
         {
             get
             {
-                this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
                 return (int)this.position;
             }

--- a/Scintilla.NET/AutoCSelectionEventArgs.cs
+++ b/Scintilla.NET/AutoCSelectionEventArgs.cs
@@ -1,81 +1,82 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.AutoCSelection" /> event.
-/// </summary>
-public class AutoCSelectionEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly IntPtr textPtr;
-    private readonly int bytePosition;
-    private int? position;
-    private string text;
-
     /// <summary>
-    /// Gets the fillup character that caused the completion.
+    /// Provides data for the <see cref="Scintilla.AutoCSelection" /> event.
     /// </summary>
-    /// <returns>The fillup character used to cause the completion; otherwise, 0.</returns>
-    /// <remarks>Only a <see cref="ListCompletionMethod" /> of <see cref="ScintillaNET.ListCompletionMethod.FillUp" /> will return a non-zero character.</remarks>
-    /// <seealso cref="Scintilla.AutoCSetFillUps" />
-    public int Char { get; private set; }
-
-    /// <summary>
-    /// Gets a value indicating how the completion occurred.
-    /// </summary>
-    /// <returns>One of the <see cref="ScintillaNET.ListCompletionMethod" /> enumeration values.</returns>
-    public ListCompletionMethod ListCompletionMethod { get; private set; }
-
-    /// <summary>
-    /// Gets the start position of the word being completed.
-    /// </summary>
-    /// <returns>The zero-based document position of the word being completed.</returns>
-    public int Position
+    public class AutoCSelectionEventArgs : EventArgs
     {
-        get
-        {
-            this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+        private readonly Scintilla scintilla;
+        private readonly IntPtr textPtr;
+        private readonly int bytePosition;
+        private int? position;
+        private string text;
 
-            return (int)this.position;
-        }
-    }
+        /// <summary>
+        /// Gets the fillup character that caused the completion.
+        /// </summary>
+        /// <returns>The fillup character used to cause the completion; otherwise, 0.</returns>
+        /// <remarks>Only a <see cref="ListCompletionMethod" /> of <see cref="ScintillaNET.ListCompletionMethod.FillUp" /> will return a non-zero character.</remarks>
+        /// <seealso cref="Scintilla.AutoCSetFillUps" />
+        public int Char { get; private set; }
 
-    /// <summary>
-    /// Gets the text of the selected autocompletion item.
-    /// </summary>
-    /// <returns>The selected autocompletion item text.</returns>
-    public unsafe string Text
-    {
-        get
+        /// <summary>
+        /// Gets a value indicating how the completion occurred.
+        /// </summary>
+        /// <returns>One of the <see cref="ScintillaNET.ListCompletionMethod" /> enumeration values.</returns>
+        public ListCompletionMethod ListCompletionMethod { get; private set; }
+
+        /// <summary>
+        /// Gets the start position of the word being completed.
+        /// </summary>
+        /// <returns>The zero-based document position of the word being completed.</returns>
+        public int Position
         {
-            if (this.text == null)
+            get
             {
-                int len = 0;
-                while (((byte*)this.textPtr)[len] != 0)
-                    len++;
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
-                this.text = Helpers.GetString(this.textPtr, len, this.scintilla.Encoding);
+                return (int)this.position;
             }
-
-            return this.text;
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AutoCSelectionEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="bytePosition">The zero-based byte position within the document of the word being completed.</param>
-    /// <param name="text">A pointer to the selected autocompletion text.</param>
-    /// <param name="ch">The character that caused the completion.</param>
-    /// <param name="listCompletionMethod">A value indicating the way in which the completion occurred.</param>
-    public AutoCSelectionEventArgs(Scintilla scintilla, int bytePosition, IntPtr text, int ch, ListCompletionMethod listCompletionMethod)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
-        this.textPtr = text;
-        Char = ch;
-        ListCompletionMethod = listCompletionMethod;
+        /// <summary>
+        /// Gets the text of the selected autocompletion item.
+        /// </summary>
+        /// <returns>The selected autocompletion item text.</returns>
+        public unsafe string Text
+        {
+            get
+            {
+                if (this.text == null)
+                {
+                    int len = 0;
+                    while (((byte*)this.textPtr)[len] != 0)
+                        len++;
+
+                    this.text = Helpers.GetString(this.textPtr, len, this.scintilla.Encoding);
+                }
+
+                return this.text;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoCSelectionEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="bytePosition">The zero-based byte position within the document of the word being completed.</param>
+        /// <param name="text">A pointer to the selected autocompletion text.</param>
+        /// <param name="ch">The character that caused the completion.</param>
+        /// <param name="listCompletionMethod">A value indicating the way in which the completion occurred.</param>
+        public AutoCSelectionEventArgs(Scintilla scintilla, int bytePosition, IntPtr text, int ch, ListCompletionMethod listCompletionMethod)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+            this.textPtr = text;
+            Char = ch;
+            ListCompletionMethod = listCompletionMethod;
+        }
     }
 }

--- a/Scintilla.NET/AutomaticFold.cs
+++ b/Scintilla.NET/AutomaticFold.cs
@@ -1,31 +1,32 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Configuration options for automatic code folding.
-/// </summary>
-/// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
-[Flags]
-public enum AutomaticFold
+namespace ScintillaNET
 {
     /// <summary>
-    /// Automatic folding is disabled. This is the default.
+    /// Configuration options for automatic code folding.
     /// </summary>
-    None = 0,
+    /// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
+    [Flags]
+    public enum AutomaticFold
+    {
+        /// <summary>
+        /// Automatic folding is disabled. This is the default.
+        /// </summary>
+        None = 0,
 
-    /// <summary>
-    /// Automatically show lines as needed. The <see cref="Scintilla.NeedShown" /> event is not raised when this value is used.
-    /// </summary>
-    Show = NativeMethods.SC_AUTOMATICFOLD_SHOW,
+        /// <summary>
+        /// Automatically show lines as needed. The <see cref="Scintilla.NeedShown" /> event is not raised when this value is used.
+        /// </summary>
+        Show = NativeMethods.SC_AUTOMATICFOLD_SHOW,
 
-    /// <summary>
-    /// Handle clicks in fold margin automatically. The <see cref="Scintilla.MarginClick" /> event is not raised for folding margins when this value is used.
-    /// </summary>
-    Click = NativeMethods.SC_AUTOMATICFOLD_CLICK,
+        /// <summary>
+        /// Handle clicks in fold margin automatically. The <see cref="Scintilla.MarginClick" /> event is not raised for folding margins when this value is used.
+        /// </summary>
+        Click = NativeMethods.SC_AUTOMATICFOLD_CLICK,
 
-    /// <summary>
-    /// Show lines as needed when the fold structure is changed.
-    /// </summary>
-    Change = NativeMethods.SC_AUTOMATICFOLD_CHANGE
+        /// <summary>
+        /// Show lines as needed when the fold structure is changed.
+        /// </summary>
+        Change = NativeMethods.SC_AUTOMATICFOLD_CHANGE
+    }
 }

--- a/Scintilla.NET/BeforeModificationEventArgs.cs
+++ b/Scintilla.NET/BeforeModificationEventArgs.cs
@@ -1,84 +1,85 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.BeforeInsert" /> and <see cref="Scintilla.BeforeDelete" /> events.
-/// </summary>
-public class BeforeModificationEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private readonly int byteLength;
-    private readonly IntPtr textPtr;
-
-    internal int? CachedPosition { get; set; }
-    internal string CachedText { get; set; }
-
     /// <summary>
-    /// Gets the zero-based document position where the modification will occur.
+    /// Provides data for the <see cref="Scintilla.BeforeInsert" /> and <see cref="Scintilla.BeforeDelete" /> events.
     /// </summary>
-    /// <returns>The zero-based character position within the document where text will be inserted or deleted.</returns>
-    public int Position
+    public class BeforeModificationEventArgs : EventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private readonly int byteLength;
+        private readonly IntPtr textPtr;
+
+        internal int? CachedPosition { get; set; }
+        internal string CachedText { get; set; }
+
+        /// <summary>
+        /// Gets the zero-based document position where the modification will occur.
+        /// </summary>
+        /// <returns>The zero-based character position within the document where text will be inserted or deleted.</returns>
+        public int Position
         {
-            CachedPosition ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
-
-            return (int)CachedPosition;
-        }
-    }
-
-    /// <summary>
-    /// Gets the source of the modification.
-    /// </summary>
-    /// <returns>One of the <see cref="ModificationSource" /> enum values.</returns>
-    public ModificationSource Source { get; private set; }
-
-    /// <summary>
-    /// Gets the text being inserted or deleted.
-    /// </summary>
-    /// <returns>
-    /// The text about to be inserted or deleted.
-    /// </returns>
-    public virtual unsafe string Text
-    {
-        get
-        {
-            if (CachedText == null)
+            get
             {
-                // For some reason the Scintilla overlords don't provide text in
-                // SC_MOD_BEFOREDELETE... but we can get it from the document.
-                if (this.textPtr == IntPtr.Zero)
-                {
-                    IntPtr ptr = this.scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, new IntPtr(this.bytePosition), new IntPtr(this.byteLength));
-                    CachedText = new string((sbyte*)ptr, 0, this.byteLength, this.scintilla.Encoding);
-                }
-                else
-                {
-                    CachedText = Helpers.GetString(this.textPtr, this.byteLength, this.scintilla.Encoding);
-                }
+                CachedPosition = CachedPosition ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+
+                return (int)CachedPosition;
             }
-
-            return CachedText;
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BeforeModificationEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="source">The source of the modification.</param>
-    /// <param name="bytePosition">The zero-based byte position within the document where text is being modified.</param>
-    /// <param name="byteLength">The length in bytes of the text being modified.</param>
-    /// <param name="text">A pointer to the text being inserted.</param>
-    public BeforeModificationEventArgs(Scintilla scintilla, ModificationSource source, int bytePosition, int byteLength, IntPtr text)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
-        this.byteLength = byteLength;
-        this.textPtr = text;
+        /// <summary>
+        /// Gets the source of the modification.
+        /// </summary>
+        /// <returns>One of the <see cref="ModificationSource" /> enum values.</returns>
+        public ModificationSource Source { get; private set; }
 
-        Source = source;
+        /// <summary>
+        /// Gets the text being inserted or deleted.
+        /// </summary>
+        /// <returns>
+        /// The text about to be inserted or deleted.
+        /// </returns>
+        public virtual unsafe string Text
+        {
+            get
+            {
+                if (CachedText == null)
+                {
+                    // For some reason the Scintilla overlords don't provide text in
+                    // SC_MOD_BEFOREDELETE... but we can get it from the document.
+                    if (this.textPtr == IntPtr.Zero)
+                    {
+                        IntPtr ptr = this.scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, new IntPtr(this.bytePosition), new IntPtr(this.byteLength));
+                        CachedText = new string((sbyte*)ptr, 0, this.byteLength, this.scintilla.Encoding);
+                    }
+                    else
+                    {
+                        CachedText = Helpers.GetString(this.textPtr, this.byteLength, this.scintilla.Encoding);
+                    }
+                }
+
+                return CachedText;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BeforeModificationEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="source">The source of the modification.</param>
+        /// <param name="bytePosition">The zero-based byte position within the document where text is being modified.</param>
+        /// <param name="byteLength">The length in bytes of the text being modified.</param>
+        /// <param name="text">A pointer to the text being inserted.</param>
+        public BeforeModificationEventArgs(Scintilla scintilla, ModificationSource source, int bytePosition, int byteLength, IntPtr text)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+            this.byteLength = byteLength;
+            this.textPtr = text;
+
+            Source = source;
+        }
     }
 }

--- a/Scintilla.NET/BiDirectionalDisplayType.cs
+++ b/Scintilla.NET/BiDirectionalDisplayType.cs
@@ -1,22 +1,23 @@
-namespace ScintillaNET;
-
-/// <summary>
-/// The display type for the <see cref="Scintilla.BiDirectionality"/> property.
-/// </summary>
-public enum BiDirectionalDisplayType
+namespace ScintillaNET
 {
     /// <summary>
-    /// The bi-directional display type is disabled.
+    /// The display type for the <see cref="Scintilla.BiDirectionality"/> property.
     /// </summary>
-    Disabled = NativeMethods.SC_BIDIRECTIONAL_DISABLED,
+    public enum BiDirectionalDisplayType
+    {
+        /// <summary>
+        /// The bi-directional display type is disabled.
+        /// </summary>
+        Disabled = NativeMethods.SC_BIDIRECTIONAL_DISABLED,
 
-    /// <summary>
-    /// The bi-directional display type is left-to-right.
-    /// </summary>
-    LeftToRight = NativeMethods.SC_BIDIRECTIONAL_L2R,
+        /// <summary>
+        /// The bi-directional display type is left-to-right.
+        /// </summary>
+        LeftToRight = NativeMethods.SC_BIDIRECTIONAL_L2R,
 
-    /// <summary>
-    /// The bi-directional display type is right-to-left.
-    /// </summary>
-    RightToLeft = NativeMethods.SC_BIDIRECTIONAL_R2L
+        /// <summary>
+        /// The bi-directional display type is right-to-left.
+        /// </summary>
+        RightToLeft = NativeMethods.SC_BIDIRECTIONAL_R2L
+    }
 }

--- a/Scintilla.NET/CallTipClickEventArgs.cs
+++ b/Scintilla.NET/CallTipClickEventArgs.cs
@@ -1,27 +1,28 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.CallTipClick" /> event.
-/// </summary>
-public class CallTipClickEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-
     /// <summary>
-    /// Gets the type of the call tip click.
+    /// Provides data for the <see cref="Scintilla.CallTipClick" /> event.
     /// </summary>
-    public CallTipClickType CallTipClickType { get; internal set; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DwellEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// /// <param name="callTipClickType">Type of the call tip click.</param>
-    public CallTipClickEventArgs(Scintilla scintilla, CallTipClickType callTipClickType)
+    public class CallTipClickEventArgs : EventArgs
     {
-        this.scintilla = scintilla;
-        CallTipClickType = callTipClickType;
+        private readonly Scintilla scintilla;
+
+        /// <summary>
+        /// Gets the type of the call tip click.
+        /// </summary>
+        public CallTipClickType CallTipClickType { get; internal set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DwellEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// /// <param name="callTipClickType">Type of the call tip click.</param>
+        public CallTipClickEventArgs(Scintilla scintilla, CallTipClickType callTipClickType)
+        {
+            this.scintilla = scintilla;
+            CallTipClickType = callTipClickType;
+        }
     }
 }

--- a/Scintilla.NET/CallTipClickType.cs
+++ b/Scintilla.NET/CallTipClickType.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The type of a call tip click.
-/// </summary>
-public enum CallTipClickType
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// The call tip was clicked elsewhere; not the up or down arrows.
+    /// The type of a call tip click.
     /// </summary>
-    Elsewhere = 0,
+    public enum CallTipClickType
+    {
+        /// <summary>
+        /// The call tip was clicked elsewhere; not the up or down arrows.
+        /// </summary>
+        Elsewhere = 0,
 
-    /// <summary>
-    /// The call tip up arrow was clicked.
-    /// </summary>
-    UpArrow = 1,
+        /// <summary>
+        /// The call tip up arrow was clicked.
+        /// </summary>
+        UpArrow = 1,
 
-    /// <summary>
-    /// The call tip down arrow was clicked.
-    /// </summary>
-    DownArrow = 2,
+        /// <summary>
+        /// The call tip down arrow was clicked.
+        /// </summary>
+        DownArrow = 2,
+    }
 }

--- a/Scintilla.NET/CaretStyle.cs
+++ b/Scintilla.NET/CaretStyle.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The caret visual style.
-/// </summary>
-public enum CaretStyle
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// The caret is not displayed.
+    /// The caret visual style.
     /// </summary>
-    Invisible = NativeMethods.CARETSTYLE_INVISIBLE,
+    public enum CaretStyle
+    {
+        /// <summary>
+        /// The caret is not displayed.
+        /// </summary>
+        Invisible = NativeMethods.CARETSTYLE_INVISIBLE,
 
-    /// <summary>
-    /// The caret is drawn as a vertical line.
-    /// </summary>
-    Line = NativeMethods.CARETSTYLE_LINE,
+        /// <summary>
+        /// The caret is drawn as a vertical line.
+        /// </summary>
+        Line = NativeMethods.CARETSTYLE_LINE,
 
-    /// <summary>
-    /// The caret is drawn as a block.
-    /// </summary>
-    Block = NativeMethods.CARETSTYLE_BLOCK
+        /// <summary>
+        /// The caret is drawn as a block.
+        /// </summary>
+        Block = NativeMethods.CARETSTYLE_BLOCK
+    }
 }

--- a/Scintilla.NET/ChangeAnnotationEventArgs.cs
+++ b/Scintilla.NET/ChangeAnnotationEventArgs.cs
@@ -1,24 +1,25 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.ChangeAnnotation" /> event.
-/// </summary>
-public class ChangeAnnotationEventArgs : EventArgs
+namespace ScintillaNET
 {
     /// <summary>
-    /// Gets the line index where the annotation changed.
+    /// Provides data for the <see cref="Scintilla.ChangeAnnotation" /> event.
     /// </summary>
-    /// <returns>The zero-based line index where the annotation change occurred.</returns>
-    public int Line { get; private set; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ChangeAnnotationEventArgs" /> class.
-    /// </summary>
-    /// <param name="line">The zero-based line index of the annotation that changed.</param>
-    public ChangeAnnotationEventArgs(int line)
+    public class ChangeAnnotationEventArgs : EventArgs
     {
-        Line = line;
+        /// <summary>
+        /// Gets the line index where the annotation changed.
+        /// </summary>
+        /// <returns>The zero-based line index where the annotation change occurred.</returns>
+        public int Line { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangeAnnotationEventArgs" /> class.
+        /// </summary>
+        /// <param name="line">The zero-based line index of the annotation that changed.</param>
+        public ChangeAnnotationEventArgs(int line)
+        {
+            Line = line;
+        }
     }
 }

--- a/Scintilla.NET/ChangeHistory.cs
+++ b/Scintilla.NET/ChangeHistory.cs
@@ -1,30 +1,31 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Bit-flags for whether Scintilla should keep track of document change history and in which ways it should display the difference.
-/// </summary>
-[Flags]
-public enum ChangeHistory : int
+namespace ScintillaNET
 {
     /// <summary>
-    /// The default: change history turned off.
+    /// Bit-flags for whether Scintilla should keep track of document change history and in which ways it should display the difference.
     /// </summary>
-    Disabled = NativeMethods.SC_CHANGE_HISTORY_DISABLED,
+    [Flags]
+    public enum ChangeHistory : int
+    {
+        /// <summary>
+        /// The default: change history turned off.
+        /// </summary>
+        Disabled = NativeMethods.SC_CHANGE_HISTORY_DISABLED,
 
-    /// <summary>
-    /// Track changes to the document.
-    /// </summary>
-    Enabled = NativeMethods.SC_CHANGE_HISTORY_ENABLED,
+        /// <summary>
+        /// Track changes to the document.
+        /// </summary>
+        Enabled = NativeMethods.SC_CHANGE_HISTORY_ENABLED,
 
-    /// <summary>
-    /// Display changes in the margin using the SC_MARKNUM_HISTORY markers.
-    /// </summary>
-    Markers = NativeMethods.SC_CHANGE_HISTORY_MARKERS,
+        /// <summary>
+        /// Display changes in the margin using the SC_MARKNUM_HISTORY markers.
+        /// </summary>
+        Markers = NativeMethods.SC_CHANGE_HISTORY_MARKERS,
 
-    /// <summary>
-    /// Display changes in the text using the INDICATOR_HISTORY indicators.
-    /// </summary>
-    Indicators = NativeMethods.SC_CHANGE_HISTORY_INDICATORS,
+        /// <summary>
+        /// Display changes in the text using the INDICATOR_HISTORY indicators.
+        /// </summary>
+        Indicators = NativeMethods.SC_CHANGE_HISTORY_INDICATORS,
+    }
 }

--- a/Scintilla.NET/CharAddedEventArgs.cs
+++ b/Scintilla.NET/CharAddedEventArgs.cs
@@ -1,24 +1,25 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.CharAdded" /> event.
-/// </summary>
-public class CharAddedEventArgs : EventArgs
+namespace ScintillaNET
 {
     /// <summary>
-    /// Gets the text character added to a <see cref="Scintilla" /> control.
+    /// Provides data for the <see cref="Scintilla.CharAdded" /> event.
     /// </summary>
-    /// <returns>The character added.</returns>
-    public int Char { get; private set; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CharAddedEventArgs" /> class.
-    /// </summary>
-    /// <param name="ch">The character added.</param>
-    public CharAddedEventArgs(int ch)
+    public class CharAddedEventArgs : EventArgs
     {
-        Char = ch;
+        /// <summary>
+        /// Gets the text character added to a <see cref="Scintilla" /> control.
+        /// </summary>
+        /// <returns>The character added.</returns>
+        public int Char { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CharAddedEventArgs" /> class.
+        /// </summary>
+        /// <param name="ch">The character added.</param>
+        public CharAddedEventArgs(int ch)
+        {
+            Char = ch;
+        }
     }
 }

--- a/Scintilla.NET/ColorSpace.cs
+++ b/Scintilla.NET/ColorSpace.cs
@@ -1,97 +1,112 @@
 ﻿using System;
 using System.Drawing;
 
-namespace ScintillaNET;
-
-internal class ColorSpace
+namespace ScintillaNET
 {
-    public static float SrgbToLinearSrgb(float x) =>
-        x >= 0.04045 ? (float)Math.Pow((x + 0.055f) / (1 + 0.055f), 2.4f) : x / 12.92f;
-
-    public static float LinearSrgbToSrgb(float x) =>
-        x >= 0.0031308 ? 1.055f * (float)Math.Pow(x, 1.0 / 2.4) - 0.055f : 12.92f * x;
-}
-
-/// <summary>
-/// OkLab color.
-/// </summary>
-/// <param name="L">Luminance (perceived lightness) in range [0.0, 1.0].</param>
-/// <param name="a">How green/red the color is in range [-0.233887, +0.276216].</param>
-/// <param name="b">How blue/yellow the color is in range [-0.311528, +0.198570].</param>
-internal struct OkLab(float L, float a, float b)
-{
-    public float L = L;
-    public float a = a;
-    public float b = b;
-
-    public readonly Srgb ToLinearSrgb()
+    internal class ColorSpace
     {
-        float l_ = this.L + 0.3963377774f * this.a + 0.2158037573f * this.b;
-        float m_ = this.L - 0.1055613458f * this.a - 0.0638541728f * this.b;
-        float s_ = this.L - 0.0894841775f * this.a - 1.2914855480f * this.b;
+        public static float SrgbToLinearSrgb(float x) =>
+            x >= 0.04045 ? (float)Math.Pow((x + 0.055f) / (1 + 0.055f), 2.4f) : x / 12.92f;
 
-        float l = l_ * l_ * l_;
-        float m = m_ * m_ * m_;
-        float s = s_ * s_ * s_;
-
-        return new Srgb(
-            Helpers.Clamp(+4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s, 0, 1),
-            Helpers.Clamp(-1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s, 0, 1),
-            Helpers.Clamp(-0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s, 0, 1)
-        );
+        public static float LinearSrgbToSrgb(float x) =>
+            x >= 0.0031308 ? 1.055f * (float)Math.Pow(x, 1.0 / 2.4) - 0.055f : 12.92f * x;
     }
 
-    public override readonly string ToString()
+    /// <summary>
+    /// OkLab color.
+    /// </summary>
+    internal struct OkLab
     {
-        return FormattableString.Invariant($"(L:{L}, a:{a}, b:{b})");
+        public float L;
+        public float a;
+        public float b;
+
+        /// <param name="L">Luminance (perceived lightness) in range [0.0, 1.0].</param>
+        /// <param name="a">How green/red the color is in range [-0.233887, +0.276216].</param>
+        /// <param name="b">How blue/yellow the color is in range [-0.311528, +0.198570].</param>
+        public OkLab(float L, float a, float b)
+        {
+            this.L = L;
+            this.a = a;
+            this.b = b;
+        }
+
+        public Srgb ToLinearSrgb()
+        {
+            float l_ = this.L + 0.3963377774f * this.a + 0.2158037573f * this.b;
+            float m_ = this.L - 0.1055613458f * this.a - 0.0638541728f * this.b;
+            float s_ = this.L - 0.0894841775f * this.a - 1.2914855480f * this.b;
+
+            float l = l_ * l_ * l_;
+            float m = m_ * m_ * m_;
+            float s = s_ * s_ * s_;
+
+            return new Srgb(
+                Helpers.Clamp(+4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s, 0, 1),
+                Helpers.Clamp(-1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s, 0, 1),
+                Helpers.Clamp(-0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s, 0, 1)
+            );
+        }
+
+        public override string ToString()
+        {
+            return FormattableString.Invariant($"(L:{this.L}, a:{this.a}, b:{this.b})");
+        }
     }
-}
 
-/// <summary>
-/// sRGB color.
-/// </summary>
-/// <param name="R">Red component.</param>
-/// <param name="G">Green component.</param>
-/// <param name="B">Blue component.</param>
-internal struct Srgb(float R, float G, float B)
-{
-    public float R = R;
-    public float G = G;
-    public float B = B;
-
-    public readonly OkLab ToOkLab()
+    /// <summary>
+    /// sRGB color.
+    /// </summary>
+    internal struct Srgb
     {
-        float l = 0.4122214708f * this.R + 0.5363325363f * this.G + 0.0514459929f * this.B;
-        float m = 0.2119034982f * this.R + 0.6806995451f * this.G + 0.1073969566f * this.B;
-        float s = 0.0883024619f * this.R + 0.2817188376f * this.G + 0.6299787005f * this.B;
+        public float R;
+        public float G;
+        public float B;
 
-        float l_ = (float)Math.Pow(l, 1.0 / 3.0);
-        float m_ = (float)Math.Pow(m, 1.0 / 3.0);
-        float s_ = (float)Math.Pow(s, 1.0 / 3.0);
+        /// <param name="R">Red component.</param>
+        /// <param name="G">Green component.</param>
+        /// <param name="B">Blue component.</param>
+        public Srgb(float R, float G, float B)
+        {
+            this.R = R;
+            this.G = G;
+            this.B = B;
+        }
 
-        return new OkLab(
-            0.2104542553f * l_ + 0.7936177850f * m_ - 0.0040720468f * s_,
-            1.9779984951f * l_ - 2.4285922050f * m_ + 0.4505937099f * s_,
-            0.0259040371f * l_ + 0.7827717662f * m_ - 0.8086757660f * s_
-        );
-    }
+        public OkLab ToOkLab()
+        {
+            float l = 0.4122214708f * this.R + 0.5363325363f * this.G + 0.0514459929f * this.B;
+            float m = 0.2119034982f * this.R + 0.6806995451f * this.G + 0.1073969566f * this.B;
+            float s = 0.0883024619f * this.R + 0.2817188376f * this.G + 0.6299787005f * this.B;
 
-    public static Srgb FromColor(Color c) => new(c.R / 255.0f, c.G / 255.0f, c.B / 255.0f);
+            float l_ = (float)Math.Pow(l, 1.0 / 3.0);
+            float m_ = (float)Math.Pow(m, 1.0 / 3.0);
+            float s_ = (float)Math.Pow(s, 1.0 / 3.0);
 
-    public readonly Color ToColor() => Color.FromArgb((byte)(this.R * 255), (byte)(this.G * 255), (byte)(this.B * 255));
+            return new OkLab(
+                0.2104542553f * l_ + 0.7936177850f * m_ - 0.0040720468f * s_,
+                1.9779984951f * l_ - 2.4285922050f * m_ + 0.4505937099f * s_,
+                0.0259040371f * l_ + 0.7827717662f * m_ - 0.8086757660f * s_
+            );
+        }
 
-    public readonly Srgb ToLinearSrgb() =>
-        new(Helpers.Clamp(ColorSpace.SrgbToLinearSrgb(R), 0f, 1f),
-            Helpers.Clamp(ColorSpace.SrgbToLinearSrgb(G), 0f, 1f),
-            Helpers.Clamp(ColorSpace.SrgbToLinearSrgb(B), 0f, 1f));
+        public static Srgb FromColor(Color c) => new Srgb(c.R / 255.0f, c.G / 255.0f, c.B / 255.0f);
 
-    public readonly Srgb ToSrgb() =>
-        new(Helpers.Clamp(ColorSpace.LinearSrgbToSrgb(R), 0f, 1f),
-            Helpers.Clamp(ColorSpace.LinearSrgbToSrgb(G), 0f, 1f),
-            Helpers.Clamp(ColorSpace.LinearSrgbToSrgb(B), 0f, 1f));
+        public Color ToColor() => Color.FromArgb((byte)(this.R * 255), (byte)(this.G * 255), (byte)(this.B * 255));
 
-    public override readonly string ToString()
-    {
-        return FormattableString.Invariant($"(R:{R}, G:{G}, B:{B})");
+        public Srgb ToLinearSrgb() =>
+            new Srgb(Helpers.Clamp(ColorSpace.SrgbToLinearSrgb(this.R), 0f, 1f),
+                Helpers.Clamp(ColorSpace.SrgbToLinearSrgb(this.G), 0f, 1f),
+                Helpers.Clamp(ColorSpace.SrgbToLinearSrgb(this.B), 0f, 1f));
+
+        public Srgb ToSrgb() =>
+            new Srgb(Helpers.Clamp(ColorSpace.LinearSrgbToSrgb(this.R), 0f, 1f),
+                Helpers.Clamp(ColorSpace.LinearSrgbToSrgb(this.G), 0f, 1f),
+                Helpers.Clamp(ColorSpace.LinearSrgbToSrgb(this.B), 0f, 1f));
+
+        public override string ToString()
+        {
+            return FormattableString.Invariant($"(R:{this.R}, G:{this.G}, B:{this.B})");
+        }
     }
 }

--- a/Scintilla.NET/Command.cs
+++ b/Scintilla.NET/Command.cs
@@ -1,580 +1,581 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Actions which can be performed by the application or bound to keys in a <see cref="Scintilla" /> control.
-/// </summary>
-public enum Command
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// When bound to keys performs the standard platform behavior.
-    /// </summary>
-    Default = 0,
-
-    /// <summary>
-    /// Performs no action and when bound to keys prevents them from propagating to the parent window.
-    /// </summary>
-    Null = NativeMethods.SCI_NULL,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret down one line.
-    /// </summary>
-    LineDown = NativeMethods.SCI_LINEDOWN,
-
-    /// <summary>
-    /// Extends the selection down one line.
-    /// </summary>
-    LineDownExtend = NativeMethods.SCI_LINEDOWNEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection down one line.
-    /// </summary>
-    LineDownRectExtend = NativeMethods.SCI_LINEDOWNRECTEXTEND,
-
-    /// <summary>
-    /// Scrolls down one line.
-    /// </summary>
-    LineScrollDown = NativeMethods.SCI_LINESCROLLDOWN,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret up one line.
-    /// </summary>
-    LineUp = NativeMethods.SCI_LINEUP,
-
-    /// <summary>
-    /// Extends the selection up one line.
-    /// </summary>
-    LineUpExtend = NativeMethods.SCI_LINEUPEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection up one line.
-    /// </summary>
-    LineUpRectExtend = NativeMethods.SCI_LINEUPRECTEXTEND,
-
-    /// <summary>
-    /// Scrolls up one line.
-    /// </summary>
-    LineScrollUp = NativeMethods.SCI_LINESCROLLUP,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret down one paragraph.
-    /// </summary>
-    ParaDown = NativeMethods.SCI_PARADOWN,
-
-    /// <summary>
-    /// Extends the selection down one paragraph.
-    /// </summary>
-    ParaDownExtend = NativeMethods.SCI_PARADOWNEXTEND,
-
-    /// <summary>
-    /// Moves the caret up one paragraph.
-    /// </summary>
-    ParaUp = NativeMethods.SCI_PARAUP,
-
-    /// <summary>
-    /// Extends the selection up one paragraph.
-    /// </summary>
-    ParaUpExtend = NativeMethods.SCI_PARAUPEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret left one character.
-    /// </summary>
-    CharLeft = NativeMethods.SCI_CHARLEFT,
-
-    /// <summary>
-    /// Extends the selection left one character.
-    /// </summary>
-    CharLeftExtend = NativeMethods.SCI_CHARLEFTEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection left one character.
-    /// </summary>
-    CharLeftRectExtend = NativeMethods.SCI_CHARLEFTRECTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret right one character.
-    /// </summary>
-    CharRight = NativeMethods.SCI_CHARRIGHT,
-
-    /// <summary>
-    /// Extends the selection right one character.
-    /// </summary>
-    CharRightExtend = NativeMethods.SCI_CHARRIGHTEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection right one character.
-    /// </summary>
-    CharRightRectExtend = NativeMethods.SCI_CHARRIGHTRECTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the start of the previous word.
-    /// </summary>
-    WordLeft = NativeMethods.SCI_WORDLEFT,
-
-    /// <summary>
-    /// Extends the selection to the start of the previous word.
-    /// </summary>
-    WordLeftExtend = NativeMethods.SCI_WORDLEFTEXTEND,
-
-    /// <summary>
-    /// Moves the caret to the start of the next word.
-    /// </summary>
-    WordRight = NativeMethods.SCI_WORDRIGHT,
-
-    /// <summary>
-    /// Extends the selection to the start of the next word.
-    /// </summary>
-    WordRightExtend = NativeMethods.SCI_WORDRIGHTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the end of the previous word.
-    /// </summary>
-    WordLeftEnd = NativeMethods.SCI_WORDLEFTEND,
-
-    /// <summary>
-    /// Extends the selection to the end of the previous word.
-    /// </summary>
-    WordLeftEndExtend = NativeMethods.SCI_WORDLEFTENDEXTEND,
-
-    /// <summary>
-    /// Moves the caret to the end of the next word.
-    /// </summary>
-    WordRightEnd = NativeMethods.SCI_WORDRIGHTEND,
-
-    /// <summary>
-    /// Extends the selection to the end of the next word.
-    /// </summary>
-    WordRightEndExtend = NativeMethods.SCI_WORDRIGHTENDEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the previous word segment (case change or underscore).
-    /// </summary>
-    WordPartLeft = NativeMethods.SCI_WORDPARTLEFT,
-
-    /// <summary>
-    /// Extends the selection to the previous word segment (case change or underscore).
-    /// </summary>
-    WordPartLeftExtend = NativeMethods.SCI_WORDPARTLEFTEXTEND,
-
-    /// <summary>
-    /// Moves the caret to the next word segment (case change or underscore).
-    /// </summary>
-    WordPartRight = NativeMethods.SCI_WORDPARTRIGHT,
-
-    /// <summary>
-    /// Extends the selection to the next word segment (case change or underscore).
-    /// </summary>
-    WordPartRightExtend = NativeMethods.SCI_WORDPARTRIGHTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the start of the line.
-    /// </summary>
-    Home = NativeMethods.SCI_HOME,
-
-    /// <summary>
-    /// Extends the selection to the start of the line.
-    /// </summary>
-    HomeExtend = NativeMethods.SCI_HOMEEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection to the start of the line.
-    /// </summary>
-    HomeRectExtend = NativeMethods.SCI_HOMERECTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the start of the display line.
-    /// </summary>
-    HomeDisplay = NativeMethods.SCI_HOMEDISPLAY,
-
-    /// <summary>
-    /// Extends the selection to the start of the display line.
-    /// </summary>
-    HomeDisplayExtend = NativeMethods.SCI_HOMEDISPLAYEXTEND,
-
-    /// <summary>
-    /// Moves the caret to the start of the display or document line.
-    /// </summary>
-    HomeWrap = NativeMethods.SCI_HOMEWRAP,
-
-    /// <summary>
-    /// Extends the selection to the start of the display or document line.
-    /// </summary>
-    HomeWrapExtend = NativeMethods.SCI_HOMEWRAPEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the first non-whitespace character of the line.
-    /// </summary>
-    VcHome = NativeMethods.SCI_VCHOME,
-
-    /// <summary>
-    /// Extends the selection to the first non-whitespace character of the line.
-    /// </summary>
-    VcHomeExtend = NativeMethods.SCI_VCHOMEEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection to the first non-whitespace character of the line.
-    /// </summary>
-    VcHomeRectExtend = NativeMethods.SCI_VCHOMERECTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the first non-whitespace character of the display or document line.
-    /// </summary>
-    VcHomeWrap = NativeMethods.SCI_VCHOMEWRAP,
-
-    /// <summary>
-    /// Extends the selection to the first non-whitespace character of the display or document line.
-    /// </summary>
-    VcHomeWrapExtend = NativeMethods.SCI_VCHOMEWRAPEXTEND,
-
-    /// <summary>
-    /// Moves the caret to the first non-whitespace character of the display line.
-    /// </summary>
-    VcHomeDisplay = NativeMethods.SCI_VCHOMEDISPLAY,
-
-    /// <summary>
-    /// Extends the selection to the first non-whitespace character of the display line.
-    /// </summary>
-    VcHomeDisplayExtend = NativeMethods.SCI_VCHOMEDISPLAYEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the end of the document line.
-    /// </summary>
-    LineEnd = NativeMethods.SCI_LINEEND,
-
-    /// <summary>
-    /// Extends the selection to the end of the document line.
-    /// </summary>
-    LineEndExtend = NativeMethods.SCI_LINEENDEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection to the end of the document line.
-    /// </summary>
-    LineEndRectExtend = NativeMethods.SCI_LINEENDRECTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the end of the display line.
-    /// </summary>
-    LineEndDisplay = NativeMethods.SCI_LINEENDDISPLAY,
-
-    /// <summary>
-    /// Extends the selection to the end of the display line.
-    /// </summary>
-    LineEndDisplayExtend = NativeMethods.SCI_LINEENDDISPLAYEXTEND,
-
-    /// <summary>
-    /// Moves the caret to the end of the display or document line.
-    /// </summary>
-    LineEndWrap = NativeMethods.SCI_LINEENDWRAP,
-
-    /// <summary>
-    /// Extends the selection to the end of the display or document line.
-    /// </summary>
-    LineEndWrapExtend = NativeMethods.SCI_LINEENDWRAPEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret to the start of the document.
-    /// </summary>
-    DocumentStart = NativeMethods.SCI_DOCUMENTSTART,
-
-    /// <summary>
-    /// Extends the selection to the start of the document.
-    /// </summary>
-    DocumentStartExtend = NativeMethods.SCI_DOCUMENTSTARTEXTEND,
-
-    /// <summary>
-    /// Moves the caret to the end of the document.
-    /// </summary>
-    DocumentEnd = NativeMethods.SCI_DOCUMENTEND,
-
-    /// <summary>
-    /// Extends the selection to the end of the document.
-    /// </summary>
-    DocumentEndExtend = NativeMethods.SCI_DOCUMENTENDEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret up one page.
-    /// </summary>
-    PageUp = NativeMethods.SCI_PAGEUP,
-
-    /// <summary>
-    /// Extends the selection up one page.
-    /// </summary>
-    PageUpExtend = NativeMethods.SCI_PAGEUPEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection up one page.
-    /// </summary>
-    PageUpRectExtend = NativeMethods.SCI_PAGEUPRECTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret down one page.
-    /// </summary>
-    PageDown = NativeMethods.SCI_PAGEDOWN,
-
-    /// <summary>
-    /// Extends the selection down one page.
-    /// </summary>
-    PageDownExtend = NativeMethods.SCI_PAGEDOWNEXTEND,
-
-    /// <summary>
-    /// Extends the rectangular selection down one page.
-    /// </summary>
-    PageDownRectExtend = NativeMethods.SCI_PAGEDOWNRECTEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret up one window or page.
-    /// </summary>
-    StutteredPageUp = NativeMethods.SCI_STUTTEREDPAGEUP,
-
-    /// <summary>
-    /// Extends the selection up one window or page.
-    /// </summary>
-    StutteredPageUpExtend = NativeMethods.SCI_STUTTEREDPAGEUPEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the caret down one window or page.
-    /// </summary>
-    StutteredPageDown = NativeMethods.SCI_STUTTEREDPAGEDOWN,
-
-    /// <summary>
-    /// Extends the selection down one window or page.
-    /// </summary>
-    StutteredPageDownExtend = NativeMethods.SCI_STUTTEREDPAGEDOWNEXTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Deletes the character left of the caret.
-    /// </summary>
-    DeleteBack = NativeMethods.SCI_DELETEBACK,
-
-    /// <summary>
-    /// Deletes the character (excluding line breaks) left of the caret.
-    /// </summary>
-    DeleteBackNotLine = NativeMethods.SCI_DELETEBACKNOTLINE,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Deletes from the caret to the start of the previous word.
-    /// </summary>
-    DelWordLeft = NativeMethods.SCI_DELWORDLEFT,
-
-    /// <summary>
-    /// Deletes from the caret to the start of the next word.
-    /// </summary>
-    DelWordRight = NativeMethods.SCI_DELWORDRIGHT,
-
-    /// <summary>
-    /// Deletes from the caret to the end of the next word.
-    /// </summary>
-    DelWordRightEnd = NativeMethods.SCI_DELWORDRIGHTEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Deletes the characters left of the caret to the start of the line.
-    /// </summary>
-    DelLineLeft = NativeMethods.SCI_DELLINELEFT,
-
-    /// <summary>
-    /// Deletes the characters right of the caret to the start of the line.
-    /// </summary>
-    DelLineRight = NativeMethods.SCI_DELLINERIGHT,
-
-    /// <summary>
-    /// Deletes the current line.
-    /// </summary>
-    LineDelete = NativeMethods.SCI_LINEDELETE,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Removes the current line and places it on the clipboard.
-    /// </summary>
-    LineCut = NativeMethods.SCI_LINECUT,
-
-    /// <summary>
-    /// Copies the current line and places it on the clipboard.
-    /// </summary>
-    LineCopy = NativeMethods.SCI_LINECOPY,
-
-    /// <summary>
-    /// Transposes the current and previous lines.
-    /// </summary>
-    LineTranspose = NativeMethods.SCI_LINETRANSPOSE,
-
-    /// <summary>
-    /// Reverses the current line.
-    /// </summary>
-    LineReverse = NativeMethods.SCI_LINEREVERSE,
-
-    /// <summary>
-    /// Duplicates the current line.
-    /// </summary>
-    LineDuplicate = NativeMethods.SCI_LINEDUPLICATE,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Converts the selection to lowercase.
-    /// </summary>
-    Lowercase = NativeMethods.SCI_LOWERCASE,
-
-    /// <summary>
-    /// Converts the selection to uppercase.
-    /// </summary>
-    Uppercase = NativeMethods.SCI_UPPERCASE,
-
-    /// <summary>
-    /// Cancels autocompletion, calltip display, and drops any additional selections.
-    /// </summary>
-    Cancel = NativeMethods.SCI_CANCEL,
-
-    /// <summary>
-    /// Toggles overtype. See <see cref="Scintilla.Overtype" />.
-    /// </summary>
-    EditToggleOvertype = NativeMethods.SCI_EDITTOGGLEOVERTYPE,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Inserts a newline character.
-    /// </summary>
-    NewLine = NativeMethods.SCI_NEWLINE,
-
-    /// <summary>
-    /// Inserts a form feed character.
-    /// </summary>
-    FormFeed = NativeMethods.SCI_FORMFEED,
-
-    /// <summary>
-    /// Adds a tab (indent) character.
-    /// </summary>
-    Tab = NativeMethods.SCI_TAB,
-
-    /// <summary>
-    /// Removes a tab (indent) character from the start of a line.
-    /// </summary>
-    BackTab = NativeMethods.SCI_BACKTAB,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Duplicates the current selection.
-    /// </summary>
-    SelectionDuplicate = NativeMethods.SCI_SELECTIONDUPLICATE,
-
-    /// <summary>
-    /// Moves the caret vertically to the center of the screen.
-    /// </summary>
-    VerticalCenterCaret = NativeMethods.SCI_VERTICALCENTRECARET,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Moves the selected lines up.
-    /// </summary>
-    MoveSelectedLinesUp = NativeMethods.SCI_MOVESELECTEDLINESUP,
-
-    /// <summary>
-    /// Moves the selected lines down.
-    /// </summary>
-    MoveSelectedLinesDown = NativeMethods.SCI_MOVESELECTEDLINESDOWN,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Scrolls to the start of the document without changing the selection.
-    /// </summary>
-    ScrollToStart = NativeMethods.SCI_SCROLLTOSTART,
-
-    /// <summary>
-    /// Scrolls to the end of the document without changing the selection.
-    /// </summary>
-    ScrollToEnd = NativeMethods.SCI_SCROLLTOEND,
-
-    // --------------------------------------------------------------------
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.ZoomIn" />.
-    /// </summary>
-    ZoomIn = NativeMethods.SCI_ZOOMIN,
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.ZoomOut" />.
-    /// </summary>
-    ZoomOut = NativeMethods.SCI_ZOOMOUT,
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.Undo" />.
-    /// </summary>
-    Undo = NativeMethods.SCI_UNDO,
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.Redo" />.
-    /// </summary>
-    Redo = NativeMethods.SCI_REDO,
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.SwapMainAnchorCaret" />
-    /// </summary>
-    SwapMainAnchorCaret = NativeMethods.SCI_SWAPMAINANCHORCARET,
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.RotateSelection" />
-    /// </summary>
-    RotateSelection = NativeMethods.SCI_ROTATESELECTION,
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.MultipleSelectAddNext" />
-    /// </summary>
-    MultipleSelectAddNext = NativeMethods.SCI_MULTIPLESELECTADDNEXT,
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.MultipleSelectAddEach" />
-    /// </summary>
-    MultipleSelectAddEach = NativeMethods.SCI_MULTIPLESELECTADDEACH,
-
-    /// <summary>
-    /// Command equivalent to <see cref="Scintilla.SelectAll" />
-    /// </summary>
-    SelectAll = NativeMethods.SCI_SELECTALL
+    /// Actions which can be performed by the application or bound to keys in a <see cref="Scintilla" /> control.
+    /// </summary>
+    public enum Command
+    {
+        /// <summary>
+        /// When bound to keys performs the standard platform behavior.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Performs no action and when bound to keys prevents them from propagating to the parent window.
+        /// </summary>
+        Null = NativeMethods.SCI_NULL,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret down one line.
+        /// </summary>
+        LineDown = NativeMethods.SCI_LINEDOWN,
+
+        /// <summary>
+        /// Extends the selection down one line.
+        /// </summary>
+        LineDownExtend = NativeMethods.SCI_LINEDOWNEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection down one line.
+        /// </summary>
+        LineDownRectExtend = NativeMethods.SCI_LINEDOWNRECTEXTEND,
+
+        /// <summary>
+        /// Scrolls down one line.
+        /// </summary>
+        LineScrollDown = NativeMethods.SCI_LINESCROLLDOWN,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret up one line.
+        /// </summary>
+        LineUp = NativeMethods.SCI_LINEUP,
+
+        /// <summary>
+        /// Extends the selection up one line.
+        /// </summary>
+        LineUpExtend = NativeMethods.SCI_LINEUPEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection up one line.
+        /// </summary>
+        LineUpRectExtend = NativeMethods.SCI_LINEUPRECTEXTEND,
+
+        /// <summary>
+        /// Scrolls up one line.
+        /// </summary>
+        LineScrollUp = NativeMethods.SCI_LINESCROLLUP,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret down one paragraph.
+        /// </summary>
+        ParaDown = NativeMethods.SCI_PARADOWN,
+
+        /// <summary>
+        /// Extends the selection down one paragraph.
+        /// </summary>
+        ParaDownExtend = NativeMethods.SCI_PARADOWNEXTEND,
+
+        /// <summary>
+        /// Moves the caret up one paragraph.
+        /// </summary>
+        ParaUp = NativeMethods.SCI_PARAUP,
+
+        /// <summary>
+        /// Extends the selection up one paragraph.
+        /// </summary>
+        ParaUpExtend = NativeMethods.SCI_PARAUPEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret left one character.
+        /// </summary>
+        CharLeft = NativeMethods.SCI_CHARLEFT,
+
+        /// <summary>
+        /// Extends the selection left one character.
+        /// </summary>
+        CharLeftExtend = NativeMethods.SCI_CHARLEFTEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection left one character.
+        /// </summary>
+        CharLeftRectExtend = NativeMethods.SCI_CHARLEFTRECTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret right one character.
+        /// </summary>
+        CharRight = NativeMethods.SCI_CHARRIGHT,
+
+        /// <summary>
+        /// Extends the selection right one character.
+        /// </summary>
+        CharRightExtend = NativeMethods.SCI_CHARRIGHTEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection right one character.
+        /// </summary>
+        CharRightRectExtend = NativeMethods.SCI_CHARRIGHTRECTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the start of the previous word.
+        /// </summary>
+        WordLeft = NativeMethods.SCI_WORDLEFT,
+
+        /// <summary>
+        /// Extends the selection to the start of the previous word.
+        /// </summary>
+        WordLeftExtend = NativeMethods.SCI_WORDLEFTEXTEND,
+
+        /// <summary>
+        /// Moves the caret to the start of the next word.
+        /// </summary>
+        WordRight = NativeMethods.SCI_WORDRIGHT,
+
+        /// <summary>
+        /// Extends the selection to the start of the next word.
+        /// </summary>
+        WordRightExtend = NativeMethods.SCI_WORDRIGHTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the end of the previous word.
+        /// </summary>
+        WordLeftEnd = NativeMethods.SCI_WORDLEFTEND,
+
+        /// <summary>
+        /// Extends the selection to the end of the previous word.
+        /// </summary>
+        WordLeftEndExtend = NativeMethods.SCI_WORDLEFTENDEXTEND,
+
+        /// <summary>
+        /// Moves the caret to the end of the next word.
+        /// </summary>
+        WordRightEnd = NativeMethods.SCI_WORDRIGHTEND,
+
+        /// <summary>
+        /// Extends the selection to the end of the next word.
+        /// </summary>
+        WordRightEndExtend = NativeMethods.SCI_WORDRIGHTENDEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the previous word segment (case change or underscore).
+        /// </summary>
+        WordPartLeft = NativeMethods.SCI_WORDPARTLEFT,
+
+        /// <summary>
+        /// Extends the selection to the previous word segment (case change or underscore).
+        /// </summary>
+        WordPartLeftExtend = NativeMethods.SCI_WORDPARTLEFTEXTEND,
+
+        /// <summary>
+        /// Moves the caret to the next word segment (case change or underscore).
+        /// </summary>
+        WordPartRight = NativeMethods.SCI_WORDPARTRIGHT,
+
+        /// <summary>
+        /// Extends the selection to the next word segment (case change or underscore).
+        /// </summary>
+        WordPartRightExtend = NativeMethods.SCI_WORDPARTRIGHTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the start of the line.
+        /// </summary>
+        Home = NativeMethods.SCI_HOME,
+
+        /// <summary>
+        /// Extends the selection to the start of the line.
+        /// </summary>
+        HomeExtend = NativeMethods.SCI_HOMEEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection to the start of the line.
+        /// </summary>
+        HomeRectExtend = NativeMethods.SCI_HOMERECTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the start of the display line.
+        /// </summary>
+        HomeDisplay = NativeMethods.SCI_HOMEDISPLAY,
+
+        /// <summary>
+        /// Extends the selection to the start of the display line.
+        /// </summary>
+        HomeDisplayExtend = NativeMethods.SCI_HOMEDISPLAYEXTEND,
+
+        /// <summary>
+        /// Moves the caret to the start of the display or document line.
+        /// </summary>
+        HomeWrap = NativeMethods.SCI_HOMEWRAP,
+
+        /// <summary>
+        /// Extends the selection to the start of the display or document line.
+        /// </summary>
+        HomeWrapExtend = NativeMethods.SCI_HOMEWRAPEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the first non-whitespace character of the line.
+        /// </summary>
+        VcHome = NativeMethods.SCI_VCHOME,
+
+        /// <summary>
+        /// Extends the selection to the first non-whitespace character of the line.
+        /// </summary>
+        VcHomeExtend = NativeMethods.SCI_VCHOMEEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection to the first non-whitespace character of the line.
+        /// </summary>
+        VcHomeRectExtend = NativeMethods.SCI_VCHOMERECTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the first non-whitespace character of the display or document line.
+        /// </summary>
+        VcHomeWrap = NativeMethods.SCI_VCHOMEWRAP,
+
+        /// <summary>
+        /// Extends the selection to the first non-whitespace character of the display or document line.
+        /// </summary>
+        VcHomeWrapExtend = NativeMethods.SCI_VCHOMEWRAPEXTEND,
+
+        /// <summary>
+        /// Moves the caret to the first non-whitespace character of the display line.
+        /// </summary>
+        VcHomeDisplay = NativeMethods.SCI_VCHOMEDISPLAY,
+
+        /// <summary>
+        /// Extends the selection to the first non-whitespace character of the display line.
+        /// </summary>
+        VcHomeDisplayExtend = NativeMethods.SCI_VCHOMEDISPLAYEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the end of the document line.
+        /// </summary>
+        LineEnd = NativeMethods.SCI_LINEEND,
+
+        /// <summary>
+        /// Extends the selection to the end of the document line.
+        /// </summary>
+        LineEndExtend = NativeMethods.SCI_LINEENDEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection to the end of the document line.
+        /// </summary>
+        LineEndRectExtend = NativeMethods.SCI_LINEENDRECTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the end of the display line.
+        /// </summary>
+        LineEndDisplay = NativeMethods.SCI_LINEENDDISPLAY,
+
+        /// <summary>
+        /// Extends the selection to the end of the display line.
+        /// </summary>
+        LineEndDisplayExtend = NativeMethods.SCI_LINEENDDISPLAYEXTEND,
+
+        /// <summary>
+        /// Moves the caret to the end of the display or document line.
+        /// </summary>
+        LineEndWrap = NativeMethods.SCI_LINEENDWRAP,
+
+        /// <summary>
+        /// Extends the selection to the end of the display or document line.
+        /// </summary>
+        LineEndWrapExtend = NativeMethods.SCI_LINEENDWRAPEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret to the start of the document.
+        /// </summary>
+        DocumentStart = NativeMethods.SCI_DOCUMENTSTART,
+
+        /// <summary>
+        /// Extends the selection to the start of the document.
+        /// </summary>
+        DocumentStartExtend = NativeMethods.SCI_DOCUMENTSTARTEXTEND,
+
+        /// <summary>
+        /// Moves the caret to the end of the document.
+        /// </summary>
+        DocumentEnd = NativeMethods.SCI_DOCUMENTEND,
+
+        /// <summary>
+        /// Extends the selection to the end of the document.
+        /// </summary>
+        DocumentEndExtend = NativeMethods.SCI_DOCUMENTENDEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret up one page.
+        /// </summary>
+        PageUp = NativeMethods.SCI_PAGEUP,
+
+        /// <summary>
+        /// Extends the selection up one page.
+        /// </summary>
+        PageUpExtend = NativeMethods.SCI_PAGEUPEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection up one page.
+        /// </summary>
+        PageUpRectExtend = NativeMethods.SCI_PAGEUPRECTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret down one page.
+        /// </summary>
+        PageDown = NativeMethods.SCI_PAGEDOWN,
+
+        /// <summary>
+        /// Extends the selection down one page.
+        /// </summary>
+        PageDownExtend = NativeMethods.SCI_PAGEDOWNEXTEND,
+
+        /// <summary>
+        /// Extends the rectangular selection down one page.
+        /// </summary>
+        PageDownRectExtend = NativeMethods.SCI_PAGEDOWNRECTEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret up one window or page.
+        /// </summary>
+        StutteredPageUp = NativeMethods.SCI_STUTTEREDPAGEUP,
+
+        /// <summary>
+        /// Extends the selection up one window or page.
+        /// </summary>
+        StutteredPageUpExtend = NativeMethods.SCI_STUTTEREDPAGEUPEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the caret down one window or page.
+        /// </summary>
+        StutteredPageDown = NativeMethods.SCI_STUTTEREDPAGEDOWN,
+
+        /// <summary>
+        /// Extends the selection down one window or page.
+        /// </summary>
+        StutteredPageDownExtend = NativeMethods.SCI_STUTTEREDPAGEDOWNEXTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Deletes the character left of the caret.
+        /// </summary>
+        DeleteBack = NativeMethods.SCI_DELETEBACK,
+
+        /// <summary>
+        /// Deletes the character (excluding line breaks) left of the caret.
+        /// </summary>
+        DeleteBackNotLine = NativeMethods.SCI_DELETEBACKNOTLINE,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Deletes from the caret to the start of the previous word.
+        /// </summary>
+        DelWordLeft = NativeMethods.SCI_DELWORDLEFT,
+
+        /// <summary>
+        /// Deletes from the caret to the start of the next word.
+        /// </summary>
+        DelWordRight = NativeMethods.SCI_DELWORDRIGHT,
+
+        /// <summary>
+        /// Deletes from the caret to the end of the next word.
+        /// </summary>
+        DelWordRightEnd = NativeMethods.SCI_DELWORDRIGHTEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Deletes the characters left of the caret to the start of the line.
+        /// </summary>
+        DelLineLeft = NativeMethods.SCI_DELLINELEFT,
+
+        /// <summary>
+        /// Deletes the characters right of the caret to the start of the line.
+        /// </summary>
+        DelLineRight = NativeMethods.SCI_DELLINERIGHT,
+
+        /// <summary>
+        /// Deletes the current line.
+        /// </summary>
+        LineDelete = NativeMethods.SCI_LINEDELETE,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Removes the current line and places it on the clipboard.
+        /// </summary>
+        LineCut = NativeMethods.SCI_LINECUT,
+
+        /// <summary>
+        /// Copies the current line and places it on the clipboard.
+        /// </summary>
+        LineCopy = NativeMethods.SCI_LINECOPY,
+
+        /// <summary>
+        /// Transposes the current and previous lines.
+        /// </summary>
+        LineTranspose = NativeMethods.SCI_LINETRANSPOSE,
+
+        /// <summary>
+        /// Reverses the current line.
+        /// </summary>
+        LineReverse = NativeMethods.SCI_LINEREVERSE,
+
+        /// <summary>
+        /// Duplicates the current line.
+        /// </summary>
+        LineDuplicate = NativeMethods.SCI_LINEDUPLICATE,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Converts the selection to lowercase.
+        /// </summary>
+        Lowercase = NativeMethods.SCI_LOWERCASE,
+
+        /// <summary>
+        /// Converts the selection to uppercase.
+        /// </summary>
+        Uppercase = NativeMethods.SCI_UPPERCASE,
+
+        /// <summary>
+        /// Cancels autocompletion, calltip display, and drops any additional selections.
+        /// </summary>
+        Cancel = NativeMethods.SCI_CANCEL,
+
+        /// <summary>
+        /// Toggles overtype. See <see cref="Scintilla.Overtype" />.
+        /// </summary>
+        EditToggleOvertype = NativeMethods.SCI_EDITTOGGLEOVERTYPE,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Inserts a newline character.
+        /// </summary>
+        NewLine = NativeMethods.SCI_NEWLINE,
+
+        /// <summary>
+        /// Inserts a form feed character.
+        /// </summary>
+        FormFeed = NativeMethods.SCI_FORMFEED,
+
+        /// <summary>
+        /// Adds a tab (indent) character.
+        /// </summary>
+        Tab = NativeMethods.SCI_TAB,
+
+        /// <summary>
+        /// Removes a tab (indent) character from the start of a line.
+        /// </summary>
+        BackTab = NativeMethods.SCI_BACKTAB,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Duplicates the current selection.
+        /// </summary>
+        SelectionDuplicate = NativeMethods.SCI_SELECTIONDUPLICATE,
+
+        /// <summary>
+        /// Moves the caret vertically to the center of the screen.
+        /// </summary>
+        VerticalCenterCaret = NativeMethods.SCI_VERTICALCENTRECARET,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Moves the selected lines up.
+        /// </summary>
+        MoveSelectedLinesUp = NativeMethods.SCI_MOVESELECTEDLINESUP,
+
+        /// <summary>
+        /// Moves the selected lines down.
+        /// </summary>
+        MoveSelectedLinesDown = NativeMethods.SCI_MOVESELECTEDLINESDOWN,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Scrolls to the start of the document without changing the selection.
+        /// </summary>
+        ScrollToStart = NativeMethods.SCI_SCROLLTOSTART,
+
+        /// <summary>
+        /// Scrolls to the end of the document without changing the selection.
+        /// </summary>
+        ScrollToEnd = NativeMethods.SCI_SCROLLTOEND,
+
+        // --------------------------------------------------------------------
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.ZoomIn" />.
+        /// </summary>
+        ZoomIn = NativeMethods.SCI_ZOOMIN,
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.ZoomOut" />.
+        /// </summary>
+        ZoomOut = NativeMethods.SCI_ZOOMOUT,
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.Undo" />.
+        /// </summary>
+        Undo = NativeMethods.SCI_UNDO,
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.Redo" />.
+        /// </summary>
+        Redo = NativeMethods.SCI_REDO,
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.SwapMainAnchorCaret" />
+        /// </summary>
+        SwapMainAnchorCaret = NativeMethods.SCI_SWAPMAINANCHORCARET,
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.RotateSelection" />
+        /// </summary>
+        RotateSelection = NativeMethods.SCI_ROTATESELECTION,
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.MultipleSelectAddNext" />
+        /// </summary>
+        MultipleSelectAddNext = NativeMethods.SCI_MULTIPLESELECTADDNEXT,
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.MultipleSelectAddEach" />
+        /// </summary>
+        MultipleSelectAddEach = NativeMethods.SCI_MULTIPLESELECTADDEACH,
+
+        /// <summary>
+        /// Command equivalent to <see cref="Scintilla.SelectAll" />
+        /// </summary>
+        SelectAll = NativeMethods.SCI_SELECTALL
+    }
 }

--- a/Scintilla.NET/CopyFormat.cs
+++ b/Scintilla.NET/CopyFormat.cs
@@ -1,25 +1,26 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Specifies the clipboard formats to copy.
-/// </summary>
-[Flags]
-public enum CopyFormat
+namespace ScintillaNET
 {
     /// <summary>
-    /// Copies text to the clipboard in Unicode format.
+    /// Specifies the clipboard formats to copy.
     /// </summary>
-    Text = 1 << 0,
+    [Flags]
+    public enum CopyFormat
+    {
+        /// <summary>
+        /// Copies text to the clipboard in Unicode format.
+        /// </summary>
+        Text = 1 << 0,
 
-    /// <summary>
-    /// Copies text to the clipboard in Rich Text Format (RTF).
-    /// </summary>
-    Rtf = 1 << 1,
+        /// <summary>
+        /// Copies text to the clipboard in Rich Text Format (RTF).
+        /// </summary>
+        Rtf = 1 << 1,
 
-    /// <summary>
-    /// Copies text to the clipboard in HyperText Markup Language (HTML) format.
-    /// </summary>
-    Html = 1 << 2
+        /// <summary>
+        /// Copies text to the clipboard in HyperText Markup Language (HTML) format.
+        /// </summary>
+        Html = 1 << 2
+    }
 }

--- a/Scintilla.NET/Document.cs
+++ b/Scintilla.NET/Document.cs
@@ -1,61 +1,62 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// A <see cref="Scintilla" /> document.
-/// </summary>
-/// <remarks>
-/// This is an opaque type, meaning it can be used by a <see cref="Scintilla" /> control but
-/// otherwise has no public members of its own.
-/// </remarks>
-public struct Document
+namespace ScintillaNET
 {
-    internal IntPtr Value;
-
     /// <summary>
-    /// A read-only field that represents an uninitialized document.
+    /// A <see cref="Scintilla" /> document.
     /// </summary>
-    public static readonly Document Empty;
-
-    /// <summary>
-    /// Returns a value indicating whether this instance is equal to a specified object.
-    /// </summary>
-    /// <param name="obj">An object to compare with this instance or null.</param>
-    /// <returns>true if <paramref name="obj" /> is an instance of <see cref="Document" /> and equals the value of this instance; otherwise, false.</returns>
-    public override bool Equals(object obj)
+    /// <remarks>
+    /// This is an opaque type, meaning it can be used by a <see cref="Scintilla" /> control but
+    /// otherwise has no public members of its own.
+    /// </remarks>
+    public struct Document
     {
-        return obj is IntPtr && this.Value == ((Document)obj).Value;
-    }
+        internal IntPtr Value;
 
-    /// <summary>
-    /// Returns the hash code for this instance.
-    /// </summary>
-    /// <returns>A 32-bit signed integer hash code.</returns>
-    public override int GetHashCode()
-    {
-        return this.Value.GetHashCode();
-    }
+        /// <summary>
+        /// A read-only field that represents an uninitialized document.
+        /// </summary>
+        public static readonly Document Empty;
 
-    /// <summary>
-    /// Determines whether two specified instances of <see cref="Document" /> are equal.
-    /// </summary>
-    /// <param name="a">The first document to compare.</param>
-    /// <param name="b">The second document to compare.</param>
-    /// <returns>true if <paramref name="a" /> equals <paramref name="b" />; otherwise, false.</returns>
-    public static bool operator ==(Document a, Document b)
-    {
-        return a.Value == b.Value;
-    }
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this instance or null.</param>
+        /// <returns>true if <paramref name="obj" /> is an instance of <see cref="Document" /> and equals the value of this instance; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return obj is IntPtr && this.Value == ((Document)obj).Value;
+        }
 
-    /// <summary>
-    /// Determines whether two specified instances of <see cref="Document" /> are not equal.
-    /// </summary>
-    /// <param name="a">The first document to compare.</param>
-    /// <param name="b">The second document to compare.</param>
-    /// <returns>true if <paramref name="a" /> does not equal <paramref name="b" />; otherwise, false.</returns>
-    public static bool operator !=(Document a, Document b)
-    {
-        return a.Value != b.Value;
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return this.Value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="Document" /> are equal.
+        /// </summary>
+        /// <param name="a">The first document to compare.</param>
+        /// <param name="b">The second document to compare.</param>
+        /// <returns>true if <paramref name="a" /> equals <paramref name="b" />; otherwise, false.</returns>
+        public static bool operator ==(Document a, Document b)
+        {
+            return a.Value == b.Value;
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="Document" /> are not equal.
+        /// </summary>
+        /// <param name="a">The first document to compare.</param>
+        /// <param name="b">The second document to compare.</param>
+        /// <returns>true if <paramref name="a" /> does not equal <paramref name="b" />; otherwise, false.</returns>
+        public static bool operator !=(Document a, Document b)
+        {
+            return a.Value != b.Value;
+        }
     }
 }

--- a/Scintilla.NET/DoubleClickEventArgs.cs
+++ b/Scintilla.NET/DoubleClickEventArgs.cs
@@ -1,61 +1,62 @@
 ﻿using System;
 using System.Windows.Forms;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.DoubleClick" /> event.
-/// </summary>
-public class DoubleClickEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private int? position;
-
     /// <summary>
-    /// Gets the line double clicked.
+    /// Provides data for the <see cref="Scintilla.DoubleClick" /> event.
     /// </summary>
-    /// <returns>The zero-based index of the double clicked line.</returns>
-    public int Line { get; private set; }
-
-    /// <summary>
-    /// Gets the modifier keys (SHIFT, CTRL, ALT) held down when double clicked.
-    /// </summary>
-    /// <returns>A bitwise combination of the Keys enumeration indicating the modifier keys.</returns>
-    public Keys Modifiers { get; private set; }
-
-    /// <summary>
-    /// Gets the zero-based document position of the text double clicked.
-    /// </summary>
-    /// <returns>
-    /// The zero-based character position within the document of the double clicked text;
-    /// otherwise, -1 if not a document position.
-    /// </returns>
-    public int Position
+    public class DoubleClickEventArgs : EventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private int? position;
+
+        /// <summary>
+        /// Gets the line double clicked.
+        /// </summary>
+        /// <returns>The zero-based index of the double clicked line.</returns>
+        public int Line { get; private set; }
+
+        /// <summary>
+        /// Gets the modifier keys (SHIFT, CTRL, ALT) held down when double clicked.
+        /// </summary>
+        /// <returns>A bitwise combination of the Keys enumeration indicating the modifier keys.</returns>
+        public Keys Modifiers { get; private set; }
+
+        /// <summary>
+        /// Gets the zero-based document position of the text double clicked.
+        /// </summary>
+        /// <returns>
+        /// The zero-based character position within the document of the double clicked text;
+        /// otherwise, -1 if not a document position.
+        /// </returns>
+        public int Position
         {
-            this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+            get
+            {
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
-            return (int)this.position;
+                return (int)this.position;
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DoubleClickEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="modifiers">The modifier keys that where held down at the time of the double click.</param>
-    /// <param name="bytePosition">The zero-based byte position of the double clicked text.</param>
-    /// <param name="line">The zero-based line index of the double clicked text.</param>
-    public DoubleClickEventArgs(Scintilla scintilla, Keys modifiers, int bytePosition, int line)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
-        Modifiers = modifiers;
-        Line = line;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DoubleClickEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="modifiers">The modifier keys that where held down at the time of the double click.</param>
+        /// <param name="bytePosition">The zero-based byte position of the double clicked text.</param>
+        /// <param name="line">The zero-based line index of the double clicked text.</param>
+        public DoubleClickEventArgs(Scintilla scintilla, Keys modifiers, int bytePosition, int line)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+            Modifiers = modifiers;
+            Line = line;
 
-        if (bytePosition == -1)
-            this.position = -1;
+            if (bytePosition == -1)
+                this.position = -1;
+        }
     }
 }

--- a/Scintilla.NET/DwellEventArgs.cs
+++ b/Scintilla.NET/DwellEventArgs.cs
@@ -1,58 +1,59 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.DwellStart" /> and <see cref="Scintilla.DwellEnd" /> events.
-/// </summary>
-public class DwellEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private int? position;
-
     /// <summary>
-    /// Gets the zero-based document position where the mouse pointer was lingering.
+    /// Provides data for the <see cref="Scintilla.DwellStart" /> and <see cref="Scintilla.DwellEnd" /> events.
     /// </summary>
-    /// <returns>The nearest zero-based document position to where the mouse pointer was lingering.</returns>
-    public int Position
+    public class DwellEventArgs : EventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private int? position;
+
+        /// <summary>
+        /// Gets the zero-based document position where the mouse pointer was lingering.
+        /// </summary>
+        /// <returns>The nearest zero-based document position to where the mouse pointer was lingering.</returns>
+        public int Position
         {
-            this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+            get
+            {
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
-            return (int)this.position;
+                return (int)this.position;
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets the x-coordinate of the mouse pointer.
-    /// </summary>
-    /// <returns>The x-coordinate of the mouse pointer relative to the <see cref="Scintilla" /> control.</returns>
-    public int X { get; private set; }
+        /// <summary>
+        /// Gets the x-coordinate of the mouse pointer.
+        /// </summary>
+        /// <returns>The x-coordinate of the mouse pointer relative to the <see cref="Scintilla" /> control.</returns>
+        public int X { get; private set; }
 
-    /// <summary>
-    /// Gets the y-coordinate of the mouse pointer.
-    /// </summary>
-    /// <returns>The y-coordinate of the mouse pointer relative to the <see cref="Scintilla" /> control.</returns>
-    public int Y { get; private set; }
+        /// <summary>
+        /// Gets the y-coordinate of the mouse pointer.
+        /// </summary>
+        /// <returns>The y-coordinate of the mouse pointer relative to the <see cref="Scintilla" /> control.</returns>
+        public int Y { get; private set; }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DwellEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="bytePosition">The zero-based byte position within the document where the mouse pointer was lingering.</param>
-    /// <param name="x">The x-coordinate of the mouse pointer relative to the <see cref="Scintilla" /> control.</param>
-    /// <param name="y">The y-coordinate of the mouse pointer relative to the <see cref="Scintilla" /> control.</param>
-    public DwellEventArgs(Scintilla scintilla, int bytePosition, int x, int y)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
-        X = x;
-        Y = y;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DwellEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="bytePosition">The zero-based byte position within the document where the mouse pointer was lingering.</param>
+        /// <param name="x">The x-coordinate of the mouse pointer relative to the <see cref="Scintilla" /> control.</param>
+        /// <param name="y">The y-coordinate of the mouse pointer relative to the <see cref="Scintilla" /> control.</param>
+        public DwellEventArgs(Scintilla scintilla, int bytePosition, int x, int y)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+            X = x;
+            Y = y;
 
-        // The position is not over text
-        if (bytePosition < 0)
-            this.position = bytePosition;
+            // The position is not over text
+            if (bytePosition < 0)
+                this.position = bytePosition;
+        }
     }
 }

--- a/Scintilla.NET/EdgeMode.cs
+++ b/Scintilla.NET/EdgeMode.cs
@@ -1,28 +1,29 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The long line edge display mode.
-/// </summary>
-public enum EdgeMode
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Long lines are not indicated. This is the default.
+    /// The long line edge display mode.
     /// </summary>
-    None = NativeMethods.EDGE_NONE,
+    public enum EdgeMode
+    {
+        /// <summary>
+        /// Long lines are not indicated. This is the default.
+        /// </summary>
+        None = NativeMethods.EDGE_NONE,
 
-    /// <summary>
-    /// Long lines are indicated with a vertical line.
-    /// </summary>
-    Line = NativeMethods.EDGE_LINE,
+        /// <summary>
+        /// Long lines are indicated with a vertical line.
+        /// </summary>
+        Line = NativeMethods.EDGE_LINE,
 
-    /// <summary>
-    /// Long lines are indicated with a background color.
-    /// </summary>
-    Background = NativeMethods.EDGE_BACKGROUND,
+        /// <summary>
+        /// Long lines are indicated with a background color.
+        /// </summary>
+        Background = NativeMethods.EDGE_BACKGROUND,
 
-    /// <summary>
-    /// Similar to <see cref="Line" /> except allows for multiple vertical lines to be visible using the <see cref="Scintilla.MultiEdgeAddLine" /> method.
-    /// </summary>
-    /// <remarks><see cref="Line" /> and <see cref="Scintilla.EdgeColumn" /> are completely independant of this mode.</remarks>
-    MultiLine = NativeMethods.EDGE_MULTILINE
+        /// <summary>
+        /// Similar to <see cref="Line" /> except allows for multiple vertical lines to be visible using the <see cref="Scintilla.MultiEdgeAddLine" /> method.
+        /// </summary>
+        /// <remarks><see cref="Line" /> and <see cref="Scintilla.EdgeColumn" /> are completely independant of this mode.</remarks>
+        MultiLine = NativeMethods.EDGE_MULTILINE
+    }
 }

--- a/Scintilla.NET/Eol.cs
+++ b/Scintilla.NET/Eol.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// End-of-line format.
-/// </summary>
-public enum Eol
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Carriage Return, Line Feed pair "\r\n" (0x0D0A).
+    /// End-of-line format.
     /// </summary>
-    CrLf = NativeMethods.SC_EOL_CRLF,
+    public enum Eol
+    {
+        /// <summary>
+        /// Carriage Return, Line Feed pair "\r\n" (0x0D0A).
+        /// </summary>
+        CrLf = NativeMethods.SC_EOL_CRLF,
 
-    /// <summary>
-    /// Carriage Return '\r' (0x0D).
-    /// </summary>
-    Cr = NativeMethods.SC_EOL_CR,
+        /// <summary>
+        /// Carriage Return '\r' (0x0D).
+        /// </summary>
+        Cr = NativeMethods.SC_EOL_CR,
 
-    /// <summary>
-    /// Line Feed '\n' (0x0A).
-    /// </summary>
-    Lf = NativeMethods.SC_EOL_LF
+        /// <summary>
+        /// Line Feed '\n' (0x0A).
+        /// </summary>
+        Lf = NativeMethods.SC_EOL_LF
+    }
 }

--- a/Scintilla.NET/FlagsConverter.cs
+++ b/Scintilla.NET/FlagsConverter.cs
@@ -4,81 +4,82 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 
-namespace ScintillaNET;
-
-internal class FlagsConverter : TypeConverter
+namespace ScintillaNET
 {
-    public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+    internal class FlagsConverter : TypeConverter
     {
-        return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
-    }
-
-    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-    {
-        return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
-    }
-
-    public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-    {
-        if (value is Enum valueEnum && destinationType == typeof(string))
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            Type enumType = valueEnum.GetType();
-            ulong valueBits = Convert.ToUInt64(valueEnum);
-            if (valueBits == 0)
+            return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (value is Enum valueEnum && destinationType == typeof(string))
             {
-                return Enum.ToObject(enumType, 0).ToString();
-            }
-
-            ulong bits = 0;
-            List<Enum> enums = [];
-            var items = Enum.GetValues(enumType).Cast<Enum>()
-                .Select(e => new { @enum = e, bits = Convert.ToUInt64(e), bitCount = Helpers.PopCount(Convert.ToUInt64(e))})
-                .Where(e => e.bits != 0 && e.bitCount > 0)
-                .ToList();
-            int maxIterations = items.Count;
-            for (int i = 0; i < maxIterations && bits != valueBits && items.Count > 0; i++)
-            {
-                int maxIndex = items
-                    .Select(e => new { contrib = Helpers.PopCount(e.bits & valueBits & ~bits), item = e})
-                    .MaxIndex(
-                        (x, y) =>                                                                    // Select one that:
-                        (x.contrib != y.contrib) ? (x.contrib - y.contrib) :                         // Contributes most bits
-                        (x.item.bitCount != y.item.bitCount) ? (y.item.bitCount - x.item.bitCount) : // Has least amount of bits set
-                        (x.item.bits < y.item.bits) ? -1 : (x.item.bits > y.item.bits ? 1 : 0)       // With the highest integer value
-                    );
-
-                var item = items[maxIndex];
-
-                if ((valueBits & item.bits) == item.bits && (bits & item.bits) != item.bits)
+                Type enumType = valueEnum.GetType();
+                ulong valueBits = Convert.ToUInt64(valueEnum);
+                if (valueBits == 0)
                 {
-                    bits |= item.bits;
-                    items.RemoveAt(maxIndex);
-                    enums.Add(item.@enum);
+                    return Enum.ToObject(enumType, 0).ToString();
                 }
+
+                ulong bits = 0;
+                var enums = new List<Enum>();
+                var items = Enum.GetValues(enumType).Cast<Enum>()
+                    .Select(e => new { @enum = e, bits = Convert.ToUInt64(e), bitCount = Helpers.PopCount(Convert.ToUInt64(e)) })
+                    .Where(e => e.bits != 0 && e.bitCount > 0)
+                    .ToList();
+                int maxIterations = items.Count;
+                for (int i = 0; i < maxIterations && bits != valueBits && items.Count > 0; i++)
+                {
+                    int maxIndex = items
+                        .Select(e => new { contrib = Helpers.PopCount(e.bits & valueBits & ~bits), item = e })
+                        .MaxIndex(
+                            (x, y) =>                                                                    // Select one that:
+                            (x.contrib != y.contrib) ? (x.contrib - y.contrib) :                         // Contributes most bits
+                            (x.item.bitCount != y.item.bitCount) ? (y.item.bitCount - x.item.bitCount) : // Has least amount of bits set
+                            (x.item.bits < y.item.bits) ? -1 : (x.item.bits > y.item.bits ? 1 : 0)       // With the highest integer value
+                        );
+
+                    var item = items[maxIndex];
+
+                    if ((valueBits & item.bits) == item.bits && (bits & item.bits) != item.bits)
+                    {
+                        bits |= item.bits;
+                        items.RemoveAt(maxIndex);
+                        enums.Add(item.@enum);
+                    }
+                }
+
+                enums.Sort();
+                return string.Join(" | ", enums);
             }
 
-            enums.Sort();
-            return string.Join(" | ", enums);
+            return base.ConvertTo(context, culture, value, destinationType);
         }
 
-        return base.ConvertTo(context, culture, value, destinationType);
-    }
-
-    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-    {
-        if (value is string str)
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            Type t = context.PropertyDescriptor.PropertyType;
-            ulong bits = 0;
-            IEnumerable<string> nameList = str.Split('|').Select(x => x.Trim());
-            foreach (string name in nameList)
+            if (value is string str)
             {
-                bits |= Convert.ToUInt64(Enum.Parse(t, name));
+                Type t = context.PropertyDescriptor.PropertyType;
+                ulong bits = 0;
+                IEnumerable<string> nameList = str.Split('|').Select(x => x.Trim());
+                foreach (string name in nameList)
+                {
+                    bits |= Convert.ToUInt64(Enum.Parse(t, name));
+                }
+
+                return Enum.ToObject(t, bits);
             }
 
-            return Enum.ToObject(t, bits);
+            return base.ConvertFrom(context, culture, value);
         }
-
-        return base.ConvertFrom(context, culture, value);
     }
 }

--- a/Scintilla.NET/FlagsEditor.cs
+++ b/Scintilla.NET/FlagsEditor.cs
@@ -4,27 +4,28 @@ using System.Drawing.Design;
 using System.Linq;
 using System.Windows.Forms.Design;
 
-namespace ScintillaNET;
-
-internal class FlagsEditor : UITypeEditor
+namespace ScintillaNET
 {
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => UITypeEditorEditStyle.DropDown;
-
-    public override bool IsDropDownResizable => true;
-
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    internal class FlagsEditor : UITypeEditor
     {
-        if (value is Enum e && context.PropertyDescriptor.Attributes.OfType<FlagsAttribute>().Any())
-        {
-            var svc = (IWindowsFormsEditorService)provider.GetService(typeof(IWindowsFormsEditorService));
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => UITypeEditorEditStyle.DropDown;
 
-            var control = new FlagsEditorControl(svc, e);
-            svc.DropDownControl(control);
-            return control.Value;
-        }
-        else
+        public override bool IsDropDownResizable => true;
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
         {
-            return base.EditValue(context, provider, value);
+            if (value is Enum e && context.PropertyDescriptor.Attributes.OfType<FlagsAttribute>().Any())
+            {
+                var svc = (IWindowsFormsEditorService)provider.GetService(typeof(IWindowsFormsEditorService));
+
+                var control = new FlagsEditorControl(svc, e);
+                svc.DropDownControl(control);
+                return control.Value;
+            }
+            else
+            {
+                return base.EditValue(context, provider, value);
+            }
         }
     }
 }

--- a/Scintilla.NET/FlagsEditorControl.Designer.cs
+++ b/Scintilla.NET/FlagsEditorControl.Designer.cs
@@ -1,126 +1,127 @@
-﻿namespace ScintillaNET;
-
-partial class FlagsEditorControl
+﻿namespace ScintillaNET
 {
-    /// <summary> 
-    /// Required designer variable.
-    /// </summary>
-    private System.ComponentModel.IContainer components = null;
-
-    /// <summary> 
-    /// Clean up any resources being used.
-    /// </summary>
-    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-    protected override void Dispose(bool disposing)
+    partial class FlagsEditorControl
     {
-        if (disposing && (components != null))
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
         {
-            components.Dispose();
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
         }
-        base.Dispose(disposing);
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+                this.flowLayoutPanel_CheckBoxList = new System.Windows.Forms.FlowLayoutPanel();
+                this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+                this.button_Ok = new System.Windows.Forms.Button();
+                this.button_Cancel = new System.Windows.Forms.Button();
+                this.tableLayoutPanel.SuspendLayout();
+                this.SuspendLayout();
+                // 
+                // flowLayoutPanel_CheckBoxList
+                // 
+                this.flowLayoutPanel_CheckBoxList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+                | System.Windows.Forms.AnchorStyles.Left) 
+                | System.Windows.Forms.AnchorStyles.Right)));
+                this.flowLayoutPanel_CheckBoxList.AutoScroll = true;
+                this.flowLayoutPanel_CheckBoxList.AutoSize = true;
+                this.flowLayoutPanel_CheckBoxList.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+                this.tableLayoutPanel.SetColumnSpan(this.flowLayoutPanel_CheckBoxList, 2);
+                this.flowLayoutPanel_CheckBoxList.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+                this.flowLayoutPanel_CheckBoxList.Location = new System.Drawing.Point(0, 0);
+                this.flowLayoutPanel_CheckBoxList.Margin = new System.Windows.Forms.Padding(0);
+                this.flowLayoutPanel_CheckBoxList.Name = "flowLayoutPanel_CheckBoxList";
+                this.flowLayoutPanel_CheckBoxList.Size = new System.Drawing.Size(150, 124);
+                this.flowLayoutPanel_CheckBoxList.TabIndex = 0;
+                this.flowLayoutPanel_CheckBoxList.WrapContents = false;
+                // 
+                // tableLayoutPanel
+                // 
+                this.tableLayoutPanel.AutoSize = true;
+                this.tableLayoutPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+                this.tableLayoutPanel.ColumnCount = 2;
+                this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+                this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+                this.tableLayoutPanel.Controls.Add(this.flowLayoutPanel_CheckBoxList, 0, 0);
+                this.tableLayoutPanel.Controls.Add(this.button_Ok, 0, 1);
+                this.tableLayoutPanel.Controls.Add(this.button_Cancel, 1, 1);
+                this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+                this.tableLayoutPanel.Location = new System.Drawing.Point(0, 0);
+                this.tableLayoutPanel.Name = "tableLayoutPanel";
+                this.tableLayoutPanel.RowCount = 2;
+                this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+                this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+                this.tableLayoutPanel.Size = new System.Drawing.Size(150, 150);
+                this.tableLayoutPanel.TabIndex = 0;
+                // 
+                // button_Ok
+                // 
+                this.button_Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+                | System.Windows.Forms.AnchorStyles.Left) 
+                | System.Windows.Forms.AnchorStyles.Right)));
+                this.button_Ok.AutoSize = true;
+                this.button_Ok.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+                this.button_Ok.Location = new System.Drawing.Point(0, 124);
+                this.button_Ok.Margin = new System.Windows.Forms.Padding(0);
+                this.button_Ok.Name = "button_Ok";
+                this.button_Ok.Size = new System.Drawing.Size(75, 26);
+                this.button_Ok.TabIndex = 1;
+                this.button_Ok.Text = "OK";
+                this.button_Ok.UseVisualStyleBackColor = false;
+                this.button_Ok.Click += new System.EventHandler(this.button_Ok_Click);
+                // 
+                // button_Cancel
+                // 
+                this.button_Cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+                | System.Windows.Forms.AnchorStyles.Left) 
+                | System.Windows.Forms.AnchorStyles.Right)));
+                this.button_Cancel.AutoSize = true;
+                this.button_Cancel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+                this.button_Cancel.Location = new System.Drawing.Point(75, 124);
+                this.button_Cancel.Margin = new System.Windows.Forms.Padding(0);
+                this.button_Cancel.Name = "button_Cancel";
+                this.button_Cancel.Size = new System.Drawing.Size(75, 26);
+                this.button_Cancel.TabIndex = 1;
+                this.button_Cancel.Text = "Cancel";
+                this.button_Cancel.UseVisualStyleBackColor = false;
+                this.button_Cancel.Click += new System.EventHandler(this.button_Cancel_Click);
+                // 
+                // FlagsEditorControl
+                // 
+                this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+                this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+                this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+                this.Controls.Add(this.tableLayoutPanel);
+                this.Name = "FlagsEditorControl";
+                this.tableLayoutPanel.ResumeLayout(false);
+                this.tableLayoutPanel.PerformLayout();
+                this.ResumeLayout(false);
+                this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel_CheckBoxList;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel;
+        private System.Windows.Forms.Button button_Ok;
+        private System.Windows.Forms.Button button_Cancel;
     }
-
-    #region Component Designer generated code
-
-    /// <summary> 
-    /// Required method for Designer support - do not modify 
-    /// the contents of this method with the code editor.
-    /// </summary>
-    private void InitializeComponent()
-    {
-			this.flowLayoutPanel_CheckBoxList = new System.Windows.Forms.FlowLayoutPanel();
-			this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
-			this.button_Ok = new System.Windows.Forms.Button();
-			this.button_Cancel = new System.Windows.Forms.Button();
-			this.tableLayoutPanel.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// flowLayoutPanel_CheckBoxList
-			// 
-			this.flowLayoutPanel_CheckBoxList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.flowLayoutPanel_CheckBoxList.AutoScroll = true;
-			this.flowLayoutPanel_CheckBoxList.AutoSize = true;
-			this.flowLayoutPanel_CheckBoxList.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.tableLayoutPanel.SetColumnSpan(this.flowLayoutPanel_CheckBoxList, 2);
-			this.flowLayoutPanel_CheckBoxList.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-			this.flowLayoutPanel_CheckBoxList.Location = new System.Drawing.Point(0, 0);
-			this.flowLayoutPanel_CheckBoxList.Margin = new System.Windows.Forms.Padding(0);
-			this.flowLayoutPanel_CheckBoxList.Name = "flowLayoutPanel_CheckBoxList";
-			this.flowLayoutPanel_CheckBoxList.Size = new System.Drawing.Size(150, 124);
-			this.flowLayoutPanel_CheckBoxList.TabIndex = 0;
-			this.flowLayoutPanel_CheckBoxList.WrapContents = false;
-			// 
-			// tableLayoutPanel
-			// 
-			this.tableLayoutPanel.AutoSize = true;
-			this.tableLayoutPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.tableLayoutPanel.ColumnCount = 2;
-			this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.tableLayoutPanel.Controls.Add(this.flowLayoutPanel_CheckBoxList, 0, 0);
-			this.tableLayoutPanel.Controls.Add(this.button_Ok, 0, 1);
-			this.tableLayoutPanel.Controls.Add(this.button_Cancel, 1, 1);
-			this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel.Location = new System.Drawing.Point(0, 0);
-			this.tableLayoutPanel.Name = "tableLayoutPanel";
-			this.tableLayoutPanel.RowCount = 2;
-			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel.Size = new System.Drawing.Size(150, 150);
-			this.tableLayoutPanel.TabIndex = 0;
-			// 
-			// button_Ok
-			// 
-			this.button_Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.button_Ok.AutoSize = true;
-			this.button_Ok.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.button_Ok.Location = new System.Drawing.Point(0, 124);
-			this.button_Ok.Margin = new System.Windows.Forms.Padding(0);
-			this.button_Ok.Name = "button_Ok";
-			this.button_Ok.Size = new System.Drawing.Size(75, 26);
-			this.button_Ok.TabIndex = 1;
-			this.button_Ok.Text = "OK";
-			this.button_Ok.UseVisualStyleBackColor = false;
-			this.button_Ok.Click += new System.EventHandler(this.button_Ok_Click);
-			// 
-			// button_Cancel
-			// 
-			this.button_Cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.button_Cancel.AutoSize = true;
-			this.button_Cancel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.button_Cancel.Location = new System.Drawing.Point(75, 124);
-			this.button_Cancel.Margin = new System.Windows.Forms.Padding(0);
-			this.button_Cancel.Name = "button_Cancel";
-			this.button_Cancel.Size = new System.Drawing.Size(75, 26);
-			this.button_Cancel.TabIndex = 1;
-			this.button_Cancel.Text = "Cancel";
-			this.button_Cancel.UseVisualStyleBackColor = false;
-			this.button_Cancel.Click += new System.EventHandler(this.button_Cancel_Click);
-			// 
-			// FlagsEditorControl
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-			this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.Controls.Add(this.tableLayoutPanel);
-			this.Name = "FlagsEditorControl";
-			this.tableLayoutPanel.ResumeLayout(false);
-			this.tableLayoutPanel.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
-
-    }
-
-    #endregion
-
-    private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel_CheckBoxList;
-    private System.Windows.Forms.TableLayoutPanel tableLayoutPanel;
-    private System.Windows.Forms.Button button_Ok;
-    private System.Windows.Forms.Button button_Cancel;
 }

--- a/Scintilla.NET/FlagsEditorControl.cs
+++ b/Scintilla.NET/FlagsEditorControl.cs
@@ -5,173 +5,174 @@ using System.Linq;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
 
-namespace ScintillaNET;
-
-internal partial class FlagsEditorControl : UserControl
+namespace ScintillaNET
 {
-    public FlagsEditorControl()
+    internal partial class FlagsEditorControl : UserControl
     {
-        InitializeComponent();
-        this.button_Ok.Text = NativeMethods.GetMessageBoxString(0);
-        this.button_Cancel.Text = NativeMethods.GetMessageBoxString(1);
-    }
-
-    private readonly Type enumType;
-    private readonly Enum initialValue;
-    public Enum Value { get; protected set; }
-
-    private readonly IWindowsFormsEditorService editorService;
-
-    private int inCheck;
-
-    public FlagsEditorControl(IWindowsFormsEditorService editorService, Enum value) : this()
-    {
-        this.editorService = editorService;
-
-        this.enumType = value.GetType();
-        Value = this.initialValue = value;
-
-        this.inCheck++;
-        try
+        public FlagsEditorControl()
         {
-            ulong allBits = CalculateEnumAllValue(this.enumType);
-            bool hasAll = false;
-            ulong valueBits = Convert.ToUInt64(Value);
-            foreach (string itemName in Enum.GetNames(this.enumType))
+            InitializeComponent();
+            this.button_Ok.Text = NativeMethods.GetMessageBoxString(0);
+            this.button_Cancel.Text = NativeMethods.GetMessageBoxString(1);
+        }
+
+        private readonly Type enumType;
+        private readonly Enum initialValue;
+        public Enum Value { get; protected set; }
+
+        private readonly IWindowsFormsEditorService editorService;
+
+        private int inCheck;
+
+        public FlagsEditorControl(IWindowsFormsEditorService editorService, Enum value) : this()
+        {
+            this.editorService = editorService;
+
+            this.enumType = value.GetType();
+            Value = this.initialValue = value;
+
+            this.inCheck++;
+            try
             {
-                var item = (Enum)Enum.Parse(this.enumType, itemName);
-                ulong itemBits = Convert.ToUInt64(item);
-                if (itemBits == allBits)
-                    hasAll = true;
-                if (itemBits != 0)
+                ulong allBits = CalculateEnumAllValue(this.enumType);
+                bool hasAll = false;
+                ulong valueBits = Convert.ToUInt64(Value);
+                foreach (string itemName in Enum.GetNames(this.enumType))
+                {
+                    var item = (Enum)Enum.Parse(this.enumType, itemName);
+                    ulong itemBits = Convert.ToUInt64(item);
+                    if (itemBits == allBits)
+                        hasAll = true;
+                    if (itemBits != 0)
+                    {
+                        var checkBox = new CheckBox() {
+                            Text = itemName,
+                            CheckState = CheckStateFromBits(itemBits, valueBits),
+                            AutoSize = true,
+                            Tag = item,
+                            Margin = new Padding(3, 0, 3, 0),
+                            Padding = Padding.Empty,
+                        };
+                        checkBox.CheckStateChanged += checkBox_CheckStateChanged;
+                        this.flowLayoutPanel_CheckBoxList.Controls.Add(checkBox);
+                    }
+                }
+
+                if (!hasAll)
                 {
                     var checkBox = new CheckBox() {
-                        Text = itemName,
-                        CheckState = CheckStateFromBits(itemBits, valueBits),
+                        Text = "All",
+                        CheckState = CheckStateFromBits(allBits, valueBits),
                         AutoSize = true,
-                        Tag = item,
+                        Tag = (Enum)Enum.ToObject(this.enumType, allBits),
                         Margin = new Padding(3, 0, 3, 0),
                         Padding = Padding.Empty,
                     };
                     checkBox.CheckStateChanged += checkBox_CheckStateChanged;
                     this.flowLayoutPanel_CheckBoxList.Controls.Add(checkBox);
                 }
-            }
 
-            if (!hasAll)
+                AutoSize = true;
+            }
+            finally
             {
-                var checkBox = new CheckBox() {
-                    Text = "All",
-                    CheckState = CheckStateFromBits(allBits, valueBits),
-                    AutoSize = true,
-                    Tag = (Enum)Enum.ToObject(this.enumType, allBits),
-                    Margin = new Padding(3, 0, 3, 0),
-                    Padding = Padding.Empty,
-                };
-                checkBox.CheckStateChanged += checkBox_CheckStateChanged;
-                this.flowLayoutPanel_CheckBoxList.Controls.Add(checkBox);
+                this.inCheck--;
             }
-
-            AutoSize = true;
-        }
-        finally
-        {
-            this.inCheck--;
-        }
-    }
-
-    protected override void OnBackColorChanged(EventArgs e)
-    {
-        base.OnBackColorChanged(e);
-        Helpers.ApplyToControlTree(this, c => {
-            OkLab backColor = Srgb.FromColor(c.BackColor).ToLinearSrgb().ToOkLab();
-            if (backColor.L < 0.5f)
-                c.ForeColor = Color.White;
-            else
-                c.ForeColor = Color.Black;
-        });
-    }
-
-    private static ulong CalculateEnumAllValue(Type enumType)
-    {
-        ulong all = 0;
-        foreach (Enum bits in Enum.GetValues(enumType))
-        {
-            all |= Convert.ToUInt64(bits);
         }
 
-        return all;
-    }
-
-    private static ulong CombineEnumBits(IEnumerable<CheckBox> checkBoxList)
-    {
-        ulong bits = 0;
-        foreach (CheckBox checkBox in checkBoxList.Where(c => c.CheckState == CheckState.Checked))
+        protected override void OnBackColorChanged(EventArgs e)
         {
-            bits |= Convert.ToUInt64(checkBox.Tag);
+            base.OnBackColorChanged(e);
+            Helpers.ApplyToControlTree(this, c => {
+                var backColor = Srgb.FromColor(c.BackColor).ToLinearSrgb().ToOkLab();
+                if (backColor.L < 0.5f)
+                    c.ForeColor = Color.White;
+                else
+                    c.ForeColor = Color.Black;
+            });
         }
 
-        return bits;
-    }
-
-    private void checkBox_CheckStateChanged(object sender, EventArgs e)
-    {
-        if (this.inCheck > 0)
-            return;
-        this.inCheck++;
-        try
+        private static ulong CalculateEnumAllValue(Type enumType)
         {
-            var checkTarget = (CheckBox)sender;
-            IEnumerable<CheckBox> checkBoxList = this.flowLayoutPanel_CheckBoxList.Controls.OfType<CheckBox>();
-            ulong valueBits = CombineEnumBits(checkBoxList);
-            ulong changedBits = Convert.ToUInt64(checkTarget.Tag);
-            if (checkTarget.CheckState == CheckState.Checked)
-                valueBits |= changedBits;
-            else if (checkTarget.CheckState == CheckState.Unchecked)
-                valueBits &= ~changedBits;
-            Value = (Enum)Enum.ToObject(this.enumType, valueBits);
-            foreach (CheckBox checkBox in checkBoxList)
+            ulong all = 0;
+            foreach (Enum bits in Enum.GetValues(enumType))
             {
-                ulong itemBits = Convert.ToUInt64(checkBox.Tag);
-                checkBox.CheckState = CheckStateFromBits(itemBits, valueBits);
+                all |= Convert.ToUInt64(bits);
+            }
+
+            return all;
+        }
+
+        private static ulong CombineEnumBits(IEnumerable<CheckBox> checkBoxList)
+        {
+            ulong bits = 0;
+            foreach (CheckBox checkBox in checkBoxList.Where(c => c.CheckState == CheckState.Checked))
+            {
+                bits |= Convert.ToUInt64(checkBox.Tag);
+            }
+
+            return bits;
+        }
+
+        private void checkBox_CheckStateChanged(object sender, EventArgs e)
+        {
+            if (this.inCheck > 0)
+                return;
+            this.inCheck++;
+            try
+            {
+                var checkTarget = (CheckBox)sender;
+                IEnumerable<CheckBox> checkBoxList = this.flowLayoutPanel_CheckBoxList.Controls.OfType<CheckBox>();
+                ulong valueBits = CombineEnumBits(checkBoxList);
+                ulong changedBits = Convert.ToUInt64(checkTarget.Tag);
+                if (checkTarget.CheckState == CheckState.Checked)
+                    valueBits |= changedBits;
+                else if (checkTarget.CheckState == CheckState.Unchecked)
+                    valueBits &= ~changedBits;
+                Value = (Enum)Enum.ToObject(this.enumType, valueBits);
+                foreach (CheckBox checkBox in checkBoxList)
+                {
+                    ulong itemBits = Convert.ToUInt64(checkBox.Tag);
+                    checkBox.CheckState = CheckStateFromBits(itemBits, valueBits);
+                }
+            }
+            finally
+            {
+                this.inCheck--;
             }
         }
-        finally
-        {
-            this.inCheck--;
-        }
-    }
 
-    private static CheckState CheckStateFromBits(ulong itemBits, ulong valueBits)
-    {
-        return (itemBits & valueBits) == itemBits ? CheckState.Checked : (itemBits & valueBits) == 0 ? CheckState.Unchecked : CheckState.Indeterminate;
-    }
-
-    protected override bool ProcessDialogKey(Keys keyData)
-    {
-        if (keyData == Keys.Return)
+        private static CheckState CheckStateFromBits(ulong itemBits, ulong valueBits)
         {
-            button_Ok_Click(this.button_Ok, EventArgs.Empty);
-            return true;
+            return (itemBits & valueBits) == itemBits ? CheckState.Checked : (itemBits & valueBits) == 0 ? CheckState.Unchecked : CheckState.Indeterminate;
         }
 
-        if (keyData == Keys.Escape)
+        protected override bool ProcessDialogKey(Keys keyData)
         {
-            button_Cancel_Click(this.button_Cancel, EventArgs.Empty);
-            return true;
+            if (keyData == Keys.Return)
+            {
+                button_Ok_Click(this.button_Ok, EventArgs.Empty);
+                return true;
+            }
+
+            if (keyData == Keys.Escape)
+            {
+                button_Cancel_Click(this.button_Cancel, EventArgs.Empty);
+                return true;
+            }
+
+            return base.ProcessDialogKey(keyData);
         }
 
-        return base.ProcessDialogKey(keyData);
-    }
+        private void button_Ok_Click(object sender, EventArgs e)
+        {
+            this.editorService.CloseDropDown();
+        }
 
-    private void button_Ok_Click(object sender, EventArgs e)
-    {
-        this.editorService.CloseDropDown();
-    }
-
-    private void button_Cancel_Click(object sender, EventArgs e)
-    {
-        Value = this.initialValue;
-        this.editorService.CloseDropDown();
+        private void button_Cancel_Click(object sender, EventArgs e)
+        {
+            Value = this.initialValue;
+            this.editorService.CloseDropDown();
+        }
     }
 }

--- a/Scintilla.NET/FlagsEnumConverter.cs
+++ b/Scintilla.NET/FlagsEnumConverter.cs
@@ -5,188 +5,189 @@ using System;
 using System.ComponentModel;
 using System.Reflection;
 
-namespace FlagsEnumTypeConverter;
-
-/// <summary>
-/// Flags enumeration type converter.
-/// </summary>
-internal class FlagsEnumConverter : EnumConverter
+namespace FlagsEnumTypeConverter
 {
     /// <summary>
-    /// This class represents an enumeration field in the property grid.
+    /// Flags enumeration type converter.
     /// </summary>
-    protected class EnumFieldDescriptor : SimplePropertyDescriptor
+    internal class FlagsEnumConverter : EnumConverter
     {
-        #region Fields
         /// <summary>
-        /// Stores the context which the enumeration field descriptor was created in.
+        /// This class represents an enumeration field in the property grid.
         /// </summary>
-        private readonly ITypeDescriptorContext fContext;
-        #endregion
+        protected class EnumFieldDescriptor : SimplePropertyDescriptor
+        {
+            #region Fields
+            /// <summary>
+            /// Stores the context which the enumeration field descriptor was created in.
+            /// </summary>
+            private readonly ITypeDescriptorContext fContext;
+            #endregion
+
+            #region Methods
+            /// <summary>
+            /// Creates an instance of the enumeration field descriptor class.
+            /// </summary>
+            /// <param name="componentType">The type of the enumeration.</param>
+            /// <param name="name">The name of the enumeration field.</param>
+            /// <param name="context">The current context.</param>
+            public EnumFieldDescriptor(Type componentType, string name, ITypeDescriptorContext context) : base(componentType, name, typeof(bool))
+            {
+                this.fContext = context;
+            }
+
+            /// <summary>
+            /// Retrieves the value of the enumeration field.
+            /// </summary>
+            /// <param name="component">
+            /// The instance of the enumeration type which to retrieve the field value for.
+            /// </param>
+            /// <returns>
+            /// True if the enumeration field is included to the enumeration; 
+            /// otherwise, False.
+            /// </returns>
+            public override object GetValue(object component)
+            {
+                ulong bits = Convert.ToUInt64(Enum.Parse(ComponentType, Name));
+                return (Convert.ToUInt64(component) & bits) == bits;
+            }
+
+            /// <summary>
+            /// Sets the value of the enumeration field.
+            /// </summary>
+            /// <param name="component">
+            /// The instance of the enumeration type which to set the field value to.
+            /// </param>
+            /// <param name="value">
+            /// True if the enumeration field should included to the enumeration; 
+            /// otherwise, False.
+            /// </param>
+            public override void SetValue(object component, object value)
+            {
+                bool myValue = (bool)value;
+                ulong myNewValue;
+                if (myValue)
+                    myNewValue = Convert.ToUInt64(component) | Convert.ToUInt64(Enum.Parse(ComponentType, Name));
+                else
+                    myNewValue = Convert.ToUInt64(component) & ~Convert.ToUInt64(Enum.Parse(ComponentType, Name));
+
+                FieldInfo myField = component.GetType().GetField("value__", BindingFlags.Instance | BindingFlags.Public);
+                myField.SetValue(component, Convert.ChangeType(myNewValue, Enum.GetUnderlyingType(ComponentType)));
+                this.fContext.PropertyDescriptor.SetValue(this.fContext.Instance, component);
+            }
+
+            /// <summary>
+            /// Retrieves a value indicating whether the enumeration 
+            /// field is set to a non-default value.
+            /// </summary>
+            public override bool ShouldSerializeValue(object component)
+            {
+                return (bool)GetValue(component) != GetDefaultValue();
+            }
+
+            /// <summary>
+            /// Resets the enumeration field to its default value.
+            /// </summary>
+            public override void ResetValue(object component)
+            {
+                SetValue(component, GetDefaultValue());
+            }
+
+            /// <summary>
+            /// Retrieves a value indicating whether the enumeration 
+            /// field can be reset to the default value.
+            /// </summary>
+            public override bool CanResetValue(object component)
+            {
+                return ShouldSerializeValue(component);
+            }
+
+            /// <summary>
+            /// Retrieves the enumerations field�s default value.
+            /// </summary>
+            private bool GetDefaultValue()
+            {
+                object myDefaultValue = null;
+                string myPropertyName = this.fContext.PropertyDescriptor.Name;
+                Type myComponentType = this.fContext.PropertyDescriptor.ComponentType;
+
+                // Get DefaultValueAttribute
+                var myDefaultValueAttribute = (DefaultValueAttribute)Attribute.GetCustomAttribute(
+                    myComponentType.GetProperty(myPropertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+                    typeof(DefaultValueAttribute));
+                if (myDefaultValueAttribute != null)
+                    myDefaultValue = myDefaultValueAttribute.Value;
+
+                if (myDefaultValue != null)
+                    return (Convert.ToUInt64(myDefaultValue) & Convert.ToUInt64(Enum.Parse(ComponentType, Name))) != 0;
+                return false;
+            }
+            #endregion
+
+            #region Properties
+            public override AttributeCollection Attributes
+            {
+                get
+                {
+                    return new AttributeCollection(new Attribute[] { RefreshPropertiesAttribute.Repaint });
+                }
+            }
+            #endregion
+        }
 
         #region Methods
         /// <summary>
-        /// Creates an instance of the enumeration field descriptor class.
+        /// Creates an instance of the FlagsEnumConverter class.
         /// </summary>
-        /// <param name="componentType">The type of the enumeration.</param>
-        /// <param name="name">The name of the enumeration field.</param>
+        /// <param name="type">The type of the enumeration.</param>
+        public FlagsEnumConverter(Type type) : base(type) { }
+
+        /// <summary>
+        /// Retrieves the property descriptors for the enumeration fields. 
+        /// These property descriptors will be used by the property grid 
+        /// to show separate enumeration fields.
+        /// </summary>
         /// <param name="context">The current context.</param>
-        public EnumFieldDescriptor(Type componentType, string name, ITypeDescriptorContext context) : base(componentType, name, typeof(bool))
+        /// <param name="value">A value of an enumeration type.</param>
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
         {
-            this.fContext = context;
+            if (context != null)
+            {
+                Type myType = value.GetType();
+                string[] myNames = Enum.GetNames(myType);
+                Array myValues = Enum.GetValues(myType);
+                if (myNames != null)
+                {
+                    var myCollection = new PropertyDescriptorCollection(null);
+                    for (int i = 0; i < myNames.Length; i++)
+                    {
+                        if (Convert.ToUInt64(myValues.GetValue(i)) != 0)
+                            myCollection.Add(new EnumFieldDescriptor(myType, myNames[i], context));
+                    }
+
+                    return myCollection;
+                }
+            }
+
+            return base.GetProperties(context, value, attributes);
         }
 
-        /// <summary>
-        /// Retrieves the value of the enumeration field.
-        /// </summary>
-        /// <param name="component">
-        /// The instance of the enumeration type which to retrieve the field value for.
-        /// </param>
-        /// <returns>
-        /// True if the enumeration field is included to the enumeration; 
-        /// otherwise, False.
-        /// </returns>
-        public override object GetValue(object component)
+        public override bool GetPropertiesSupported(ITypeDescriptorContext context)
         {
-            ulong bits = Convert.ToUInt64(Enum.Parse(ComponentType, Name));
-            return (Convert.ToUInt64(component) & bits) == bits;
+            if (context != null)
+            {
+                return true;
+            }
+
+            return base.GetPropertiesSupported(context);
         }
 
-        /// <summary>
-        /// Sets the value of the enumeration field.
-        /// </summary>
-        /// <param name="component">
-        /// The instance of the enumeration type which to set the field value to.
-        /// </param>
-        /// <param name="value">
-        /// True if the enumeration field should included to the enumeration; 
-        /// otherwise, False.
-        /// </param>
-        public override void SetValue(object component, object value)
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
         {
-            bool myValue = (bool)value;
-            ulong myNewValue;
-            if (myValue)
-                myNewValue = Convert.ToUInt64(component) | Convert.ToUInt64(Enum.Parse(ComponentType, Name));
-            else
-                myNewValue = Convert.ToUInt64(component) & ~Convert.ToUInt64(Enum.Parse(ComponentType, Name));
-
-            FieldInfo myField = component.GetType().GetField("value__", BindingFlags.Instance | BindingFlags.Public);
-            myField.SetValue(component, Convert.ChangeType(myNewValue, Enum.GetUnderlyingType(ComponentType)));
-            this.fContext.PropertyDescriptor.SetValue(this.fContext.Instance, component);
-        }
-
-        /// <summary>
-        /// Retrieves a value indicating whether the enumeration 
-        /// field is set to a non-default value.
-        /// </summary>
-        public override bool ShouldSerializeValue(object component)
-        {
-            return (bool)GetValue(component) != GetDefaultValue();
-        }
-
-        /// <summary>
-        /// Resets the enumeration field to its default value.
-        /// </summary>
-        public override void ResetValue(object component)
-        {
-            SetValue(component, GetDefaultValue());
-        }
-
-        /// <summary>
-        /// Retrieves a value indicating whether the enumeration 
-        /// field can be reset to the default value.
-        /// </summary>
-        public override bool CanResetValue(object component)
-        {
-            return ShouldSerializeValue(component);
-        }
-
-        /// <summary>
-        /// Retrieves the enumerations field�s default value.
-        /// </summary>
-        private bool GetDefaultValue()
-        {
-            object myDefaultValue = null;
-            string myPropertyName = this.fContext.PropertyDescriptor.Name;
-            Type myComponentType = this.fContext.PropertyDescriptor.ComponentType;
-
-            // Get DefaultValueAttribute
-            var myDefaultValueAttribute = (DefaultValueAttribute)Attribute.GetCustomAttribute(
-                myComponentType.GetProperty(myPropertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
-                typeof(DefaultValueAttribute));
-            if (myDefaultValueAttribute != null)
-                myDefaultValue = myDefaultValueAttribute.Value;
-
-            if (myDefaultValue != null)
-                return (Convert.ToUInt64(myDefaultValue) & Convert.ToUInt64(Enum.Parse(ComponentType, Name))) != 0;
             return false;
         }
         #endregion
-
-        #region Properties
-        public override AttributeCollection Attributes
-        {
-            get
-            {
-                return new AttributeCollection(new Attribute[] { RefreshPropertiesAttribute.Repaint });
-            }
-        }
-        #endregion
     }
-
-    #region Methods
-    /// <summary>
-    /// Creates an instance of the FlagsEnumConverter class.
-    /// </summary>
-    /// <param name="type">The type of the enumeration.</param>
-    public FlagsEnumConverter(Type type) : base(type) { }
-
-    /// <summary>
-    /// Retrieves the property descriptors for the enumeration fields. 
-    /// These property descriptors will be used by the property grid 
-    /// to show separate enumeration fields.
-    /// </summary>
-    /// <param name="context">The current context.</param>
-    /// <param name="value">A value of an enumeration type.</param>
-    public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
-    {
-        if (context != null)
-        {
-            Type myType = value.GetType();
-            string[] myNames = Enum.GetNames(myType);
-            Array myValues = Enum.GetValues(myType);
-            if (myNames != null)
-            {
-                var myCollection = new PropertyDescriptorCollection(null);
-                for (int i = 0; i < myNames.Length; i++)
-                {
-                    if (Convert.ToUInt64(myValues.GetValue(i)) != 0)
-                        myCollection.Add(new EnumFieldDescriptor(myType, myNames[i], context));
-                }
-
-                return myCollection;
-            }
-        }
-
-        return base.GetProperties(context, value, attributes);
-    }
-
-    public override bool GetPropertiesSupported(ITypeDescriptorContext context)
-    {
-        if (context != null)
-        {
-            return true;
-        }
-
-        return base.GetPropertiesSupported(context);
-    }
-
-    public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
-    {
-        return false;
-    }
-    #endregion
-}
 
 #pragma warning restore 1573
+}

--- a/Scintilla.NET/FoldAction.cs
+++ b/Scintilla.NET/FoldAction.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Fold actions.
-/// </summary>
-public enum FoldAction
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Contract the fold.
+    /// Fold actions.
     /// </summary>
-    Contract = NativeMethods.SC_FOLDACTION_CONTRACT,
+    public enum FoldAction
+    {
+        /// <summary>
+        /// Contract the fold.
+        /// </summary>
+        Contract = NativeMethods.SC_FOLDACTION_CONTRACT,
 
-    /// <summary>
-    /// Expand the fold.
-    /// </summary>
-    Expand = NativeMethods.SC_FOLDACTION_EXPAND,
+        /// <summary>
+        /// Expand the fold.
+        /// </summary>
+        Expand = NativeMethods.SC_FOLDACTION_EXPAND,
 
-    /// <summary>
-    /// Toggle between contracted and expanded.
-    /// </summary>
-    Toggle = NativeMethods.SC_FOLDACTION_TOGGLE
+        /// <summary>
+        /// Toggle between contracted and expanded.
+        /// </summary>
+        Toggle = NativeMethods.SC_FOLDACTION_TOGGLE
+    }
 }

--- a/Scintilla.NET/FoldDisplayText.cs
+++ b/Scintilla.NET/FoldDisplayText.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Display options for fold text tags.
-/// </summary>
-public enum FoldDisplayText
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Do not display the text tags. This is the default.
+    /// Display options for fold text tags.
     /// </summary>
-    Hidden = NativeMethods.SC_FOLDDISPLAYTEXT_HIDDEN,
+    public enum FoldDisplayText
+    {
+        /// <summary>
+        /// Do not display the text tags. This is the default.
+        /// </summary>
+        Hidden = NativeMethods.SC_FOLDDISPLAYTEXT_HIDDEN,
 
-    /// <summary>
-    /// Display the text tags.
-    /// </summary>
-    Standard = NativeMethods.SC_FOLDDISPLAYTEXT_STANDARD,
+        /// <summary>
+        /// Display the text tags.
+        /// </summary>
+        Standard = NativeMethods.SC_FOLDDISPLAYTEXT_STANDARD,
 
-    /// <summary>
-    /// Display the text tags with a box drawn around them.
-    /// </summary>
-    Boxed = NativeMethods.SC_FOLDDISPLAYTEXT_BOXED
+        /// <summary>
+        /// Display the text tags with a box drawn around them.
+        /// </summary>
+        Boxed = NativeMethods.SC_FOLDDISPLAYTEXT_BOXED
+    }
 }

--- a/Scintilla.NET/FoldFlags.cs
+++ b/Scintilla.NET/FoldFlags.cs
@@ -1,42 +1,43 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Additional display options for folds.
-/// </summary>
-[Flags]
-public enum FoldFlags
+namespace ScintillaNET
 {
     /// <summary>
-    /// A line is drawn above if expanded.
+    /// Additional display options for folds.
     /// </summary>
-    LineBeforeExpanded = NativeMethods.SC_FOLDFLAG_LINEBEFORE_EXPANDED,
+    [Flags]
+    public enum FoldFlags
+    {
+        /// <summary>
+        /// A line is drawn above if expanded.
+        /// </summary>
+        LineBeforeExpanded = NativeMethods.SC_FOLDFLAG_LINEBEFORE_EXPANDED,
 
-    /// <summary>
-    /// A line is drawn above if not expanded.
-    /// </summary>
-    LineBeforeContracted = NativeMethods.SC_FOLDFLAG_LINEBEFORE_CONTRACTED,
+        /// <summary>
+        /// A line is drawn above if not expanded.
+        /// </summary>
+        LineBeforeContracted = NativeMethods.SC_FOLDFLAG_LINEBEFORE_CONTRACTED,
 
-    /// <summary>
-    /// A line is drawn below if expanded.
-    /// </summary>
-    LineAfterExpanded = NativeMethods.SC_FOLDFLAG_LINEAFTER_EXPANDED,
+        /// <summary>
+        /// A line is drawn below if expanded.
+        /// </summary>
+        LineAfterExpanded = NativeMethods.SC_FOLDFLAG_LINEAFTER_EXPANDED,
 
-    /// <summary>
-    /// A line is drawn below if not expanded.
-    /// </summary>
-    LineAfterContracted = NativeMethods.SC_FOLDFLAG_LINEAFTER_CONTRACTED,
+        /// <summary>
+        /// A line is drawn below if not expanded.
+        /// </summary>
+        LineAfterContracted = NativeMethods.SC_FOLDFLAG_LINEAFTER_CONTRACTED,
 
-    /// <summary>
-    /// Displays the hexadecimal fold levels in the margin to aid with debugging.
-    /// This feature may change in the future.
-    /// </summary>
-    LevelNumbers = NativeMethods.SC_FOLDFLAG_LEVELNUMBERS,
+        /// <summary>
+        /// Displays the hexadecimal fold levels in the margin to aid with debugging.
+        /// This feature may change in the future.
+        /// </summary>
+        LevelNumbers = NativeMethods.SC_FOLDFLAG_LEVELNUMBERS,
 
-    /// <summary>
-    /// Displays the hexadecimal line state in the margin to aid with debugging. This flag
-    /// cannot be used at the same time as the <see cref="LevelNumbers" /> flag.
-    /// </summary>
-    LineState = NativeMethods.SC_FOLDFLAG_LINESTATE
+        /// <summary>
+        /// Displays the hexadecimal line state in the margin to aid with debugging. This flag
+        /// cannot be used at the same time as the <see cref="LevelNumbers" /> flag.
+        /// </summary>
+        LineState = NativeMethods.SC_FOLDFLAG_LINESTATE
+    }
 }

--- a/Scintilla.NET/FoldLevelFlags.cs
+++ b/Scintilla.NET/FoldLevelFlags.cs
@@ -1,21 +1,22 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Flags for additional line fold level behavior.
-/// </summary>
-[Flags]
-public enum FoldLevelFlags
+namespace ScintillaNET
 {
     /// <summary>
-    /// Indicates that the line is blank and should be treated slightly different than its level may indicate;
-    /// otherwise, blank lines should generally not be fold points.
+    /// Flags for additional line fold level behavior.
     /// </summary>
-    White = NativeMethods.SC_FOLDLEVELWHITEFLAG,
+    [Flags]
+    public enum FoldLevelFlags
+    {
+        /// <summary>
+        /// Indicates that the line is blank and should be treated slightly different than its level may indicate;
+        /// otherwise, blank lines should generally not be fold points.
+        /// </summary>
+        White = NativeMethods.SC_FOLDLEVELWHITEFLAG,
 
-    /// <summary>
-    /// Indicates that the line is a header (fold point).
-    /// </summary>
-    Header = NativeMethods.SC_FOLDLEVELHEADERFLAG
+        /// <summary>
+        /// Indicates that the line is a header (fold point).
+        /// </summary>
+        Header = NativeMethods.SC_FOLDLEVELHEADERFLAG
+    }
 }

--- a/Scintilla.NET/FontQuality.cs
+++ b/Scintilla.NET/FontQuality.cs
@@ -1,28 +1,29 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The font quality (antialiasing method) used to render text.
-/// </summary>
-public enum FontQuality
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Specifies that the character quality of the font does not matter; so the lowest quality can be used.
-    /// This is the default.
+    /// The font quality (antialiasing method) used to render text.
     /// </summary>
-    Default = NativeMethods.SC_EFF_QUALITY_DEFAULT,
+    public enum FontQuality
+    {
+        /// <summary>
+        /// Specifies that the character quality of the font does not matter; so the lowest quality can be used.
+        /// This is the default.
+        /// </summary>
+        Default = NativeMethods.SC_EFF_QUALITY_DEFAULT,
 
-    /// <summary>
-    /// Specifies that anti-aliasing should not be used when rendering text.
-    /// </summary>
-    NonAntiAliased = NativeMethods.SC_EFF_QUALITY_NON_ANTIALIASED,
+        /// <summary>
+        /// Specifies that anti-aliasing should not be used when rendering text.
+        /// </summary>
+        NonAntiAliased = NativeMethods.SC_EFF_QUALITY_NON_ANTIALIASED,
 
-    /// <summary>
-    /// Specifies that anti-aliasing should be used when rendering text, if the font supports it.
-    /// </summary>
-    AntiAliased = NativeMethods.SC_EFF_QUALITY_ANTIALIASED,
+        /// <summary>
+        /// Specifies that anti-aliasing should be used when rendering text, if the font supports it.
+        /// </summary>
+        AntiAliased = NativeMethods.SC_EFF_QUALITY_ANTIALIASED,
 
-    /// <summary>
-    /// Specifies that ClearType anti-aliasing should be used when rendering text, if the font supports it.
-    /// </summary>
-    LcdOptimized = NativeMethods.SC_EFF_QUALITY_LCD_OPTIMIZED
+        /// <summary>
+        /// Specifies that ClearType anti-aliasing should be used when rendering text, if the font supports it.
+        /// </summary>
+        LcdOptimized = NativeMethods.SC_EFF_QUALITY_LCD_OPTIMIZED
+    }
 }

--- a/Scintilla.NET/GapBuffer.cs
+++ b/Scintilla.NET/GapBuffer.cs
@@ -3,179 +3,180 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace ScintillaNET;
-
-// Do error checking higher up
-// http://www.codeproject.com/Articles/20910/Generic-Gap-Buffer
-[DebuggerDisplay("Count = {Count}")]
-internal sealed class GapBuffer<T> : IEnumerable<T>
+namespace ScintillaNET
 {
-    private T[] buffer;
-    private int gapStart;
-    private int gapEnd;
-
-    public void Add(T item)
+    // Do error checking higher up
+    // http://www.codeproject.com/Articles/20910/Generic-Gap-Buffer
+    [DebuggerDisplay("Count = {Count}")]
+    internal sealed class GapBuffer<T> : IEnumerable<T>
     {
-        Insert(Count, item);
-    }
+        private T[] buffer;
+        private int gapStart;
+        private int gapEnd;
 
-    public void AddRange(ICollection<T> collection)
-    {
-        InsertRange(Count, collection);
-    }
-
-    private void EnsureGapCapacity(int length)
-    {
-        if (length > this.gapEnd - this.gapStart)
+        public void Add(T item)
         {
-            // How much to grow the buffer is a tricky question.
-            // Our current algo will double the capacity unless that's not enough.
-            int minCapacity = Count + length;
-            int newCapacity = this.buffer.Length * 2;
-            if (newCapacity < minCapacity)
-            {
-                newCapacity = minCapacity;
-            }
-
-            var newBuffer = new T[newCapacity];
-            int newGapEnd = newBuffer.Length - (this.buffer.Length - this.gapEnd);
-
-            Array.Copy(this.buffer, 0, newBuffer, 0, this.gapStart);
-            Array.Copy(this.buffer, this.gapEnd, newBuffer, newGapEnd, newBuffer.Length - newGapEnd);
-            this.buffer = newBuffer;
-            this.gapEnd = newGapEnd;
+            Insert(Count, item);
         }
-    }
 
-    public IEnumerator<T> GetEnumerator()
-    {
-        int count = Count;
-        for (int i = 0; i < count; i++)
-            yield return this[i];
+        public void AddRange(ICollection<T> collection)
+        {
+            InsertRange(Count, collection);
+        }
 
-        yield break;
-    }
+        private void EnsureGapCapacity(int length)
+        {
+            if (length > this.gapEnd - this.gapStart)
+            {
+                // How much to grow the buffer is a tricky question.
+                // Our current algo will double the capacity unless that's not enough.
+                int minCapacity = Count + length;
+                int newCapacity = this.buffer.Length * 2;
+                if (newCapacity < minCapacity)
+                {
+                    newCapacity = minCapacity;
+                }
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+                var newBuffer = new T[newCapacity];
+                int newGapEnd = newBuffer.Length - (this.buffer.Length - this.gapEnd);
 
-    public void Insert(int index, T item)
-    {
-        PlaceGapStart(index);
-        EnsureGapCapacity(1);
+                Array.Copy(this.buffer, 0, newBuffer, 0, this.gapStart);
+                Array.Copy(this.buffer, this.gapEnd, newBuffer, newGapEnd, newBuffer.Length - newGapEnd);
+                this.buffer = newBuffer;
+                this.gapEnd = newGapEnd;
+            }
+        }
 
-        this.buffer[index] = item;
-        this.gapStart++;
-    }
+        public IEnumerator<T> GetEnumerator()
+        {
+            int count = Count;
+            for (int i = 0; i < count; i++)
+                yield return this[i];
 
-    public void InsertRange(int index, ICollection<T> collection)
-    {
-        int count = collection.Count;
-        if (count > 0)
+            yield break;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Insert(int index, T item)
         {
             PlaceGapStart(index);
-            EnsureGapCapacity(count);
+            EnsureGapCapacity(1);
 
-            collection.CopyTo(this.buffer, this.gapStart);
-            this.gapStart += count;
+            this.buffer[index] = item;
+            this.gapStart++;
         }
-    }
 
-    private void PlaceGapStart(int index)
-    {
-        if (index != this.gapStart)
+        public void InsertRange(int index, ICollection<T> collection)
         {
-            if (this.gapEnd - this.gapStart == 0)
+            int count = collection.Count;
+            if (count > 0)
             {
-                // There is no gap
-                this.gapStart = index;
-                this.gapEnd = index;
-            }
-            else if (index < this.gapStart)
-            {
-                // Move gap left (copy contents right)
-                int length = this.gapStart - index;
-                int deltaLength = this.gapEnd - this.gapStart < length ? this.gapEnd - this.gapStart : length;
-                Array.Copy(this.buffer, index, this.buffer, this.gapEnd - length, length);
-                this.gapStart -= length;
-                this.gapEnd -= length;
+                PlaceGapStart(index);
+                EnsureGapCapacity(count);
 
-                Array.Clear(this.buffer, index, deltaLength);
-            }
-            else
-            {
-                // Move gap right (copy contents left)
-                int length = index - this.gapStart;
-                int deltaIndex = index > this.gapEnd ? index : this.gapEnd;
-                Array.Copy(this.buffer, this.gapEnd, this.buffer, this.gapStart, length);
-                this.gapStart += length;
-                this.gapEnd += length;
-
-                Array.Clear(this.buffer, deltaIndex, this.gapEnd - deltaIndex);
+                collection.CopyTo(this.buffer, this.gapStart);
+                this.gapStart += count;
             }
         }
-    }
 
-    public void RemoveAt(int index)
-    {
-        PlaceGapStart(index);
-        this.buffer[this.gapEnd] = default;
-        this.gapEnd++;
-    }
+        private void PlaceGapStart(int index)
+        {
+            if (index != this.gapStart)
+            {
+                if (this.gapEnd - this.gapStart == 0)
+                {
+                    // There is no gap
+                    this.gapStart = index;
+                    this.gapEnd = index;
+                }
+                else if (index < this.gapStart)
+                {
+                    // Move gap left (copy contents right)
+                    int length = this.gapStart - index;
+                    int deltaLength = this.gapEnd - this.gapStart < length ? this.gapEnd - this.gapStart : length;
+                    Array.Copy(this.buffer, index, this.buffer, this.gapEnd - length, length);
+                    this.gapStart -= length;
+                    this.gapEnd -= length;
 
-    public void RemoveRange(int index, int count)
-    {
-        if (count > 0)
+                    Array.Clear(this.buffer, index, deltaLength);
+                }
+                else
+                {
+                    // Move gap right (copy contents left)
+                    int length = index - this.gapStart;
+                    int deltaIndex = index > this.gapEnd ? index : this.gapEnd;
+                    Array.Copy(this.buffer, this.gapEnd, this.buffer, this.gapStart, length);
+                    this.gapStart += length;
+                    this.gapEnd += length;
+
+                    Array.Clear(this.buffer, deltaIndex, this.gapEnd - deltaIndex);
+                }
+            }
+        }
+
+        public void RemoveAt(int index)
         {
             PlaceGapStart(index);
-            Array.Clear(this.buffer, this.gapEnd, count);
-            this.gapEnd += count;
+            this.buffer[this.gapEnd] = default;
+            this.gapEnd++;
         }
-    }
 
-    public int Count
-    {
-        get
+        public void RemoveRange(int index, int count)
         {
-            return this.buffer.Length - (this.gapEnd - this.gapStart);
+            if (count > 0)
+            {
+                PlaceGapStart(index);
+                Array.Clear(this.buffer, this.gapEnd, count);
+                this.gapEnd += count;
+            }
         }
-    }
+
+        public int Count
+        {
+            get
+            {
+                return this.buffer.Length - (this.gapEnd - this.gapStart);
+            }
+        }
 
 #if DEBUG
-    // Poor man's DebuggerTypeProxy because I can't seem to get that working
-    private List<T> Debug
-    {
-        get
+        // Poor man's DebuggerTypeProxy because I can't seem to get that working
+        private List<T> Debug
         {
-            var list = new List<T>(this);
-            return list;
+            get
+            {
+                var list = new List<T>(this);
+                return list;
+            }
         }
-    }
 #endif
 
-    public T this[int index]
-    {
-        get
+        public T this[int index]
         {
-            if (index < this.gapStart)
-                return this.buffer[index];
+            get
+            {
+                if (index < this.gapStart)
+                    return this.buffer[index];
 
-            return this.buffer[index + (this.gapEnd - this.gapStart)];
+                return this.buffer[index + (this.gapEnd - this.gapStart)];
+            }
+            set
+            {
+                if (index >= this.gapStart)
+                    index += this.gapEnd - this.gapStart;
+
+                this.buffer[index] = value;
+            }
         }
-        set
+
+        public GapBuffer(int capacity = 0)
         {
-            if (index >= this.gapStart)
-                index += this.gapEnd - this.gapStart;
-
-            this.buffer[index] = value;
+            this.buffer = new T[capacity];
+            this.gapEnd = this.buffer.Length;
         }
-    }
-
-    public GapBuffer(int capacity = 0)
-    {
-        this.buffer = new T[capacity];
-        this.gapEnd = this.buffer.Length;
     }
 }

--- a/Scintilla.NET/HelperMethods.cs
+++ b/Scintilla.NET/HelperMethods.cs
@@ -3,110 +3,111 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Helper methods for the <see cref="Scintilla"/> control.
-/// </summary>
-public static class HelperMethods
+namespace ScintillaNET
 {
-    private static readonly Dictionary<int, Color> knownColorMap = [];
-
-    static HelperMethods()
+    /// <summary>
+    /// Helper methods for the <see cref="Scintilla"/> control.
+    /// </summary>
+    public static class HelperMethods
     {
-        foreach (KnownColor knownColor in Enum.GetValues(typeof(KnownColor)).Cast<KnownColor>().Where(k => k is >= KnownColor.Transparent and < KnownColor.ButtonFace))
+        private static readonly Dictionary<int, Color> knownColorMap = new Dictionary<int, Color>();
+
+        static HelperMethods()
         {
-            var color = Color.FromKnownColor(knownColor);
-            knownColorMap[ToWin32Color(color)] = color;
-        }
-    }
-
-    /// <summary>
-    /// Converts an ABGR WinAPI color to <see cref="Color"/>.
-    /// </summary>
-    /// <param name="color">The color value to convert.</param>
-    /// <returns>A <see cref="Color"/> equivalent of the ABGR WinAPI color.</returns>
-    public static Color FromWin32Color(int color)
-    {
-        if ((color & 0xFF_00_00_00) == 0)
-            return Color.Transparent;
-
-        if (knownColorMap.TryGetValue(color, out Color result))
-            // We do all this nonsense because Visual Studio designer does not
-            // mark raw colors as default if there exists a known color
-            // with the same value.
-            return result;
-
-        return Color.FromArgb((color >> 24) & 0xFF, (color >> 0) & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF);
-    }
-
-    /// <summary>
-    /// Converts a <see cref="Color"/> to ABGR WinAPI color.
-    /// </summary>
-    /// <param name="color">The <see cref="Color"/> instance to convert.</param>
-    /// <returns>ABGR WinAPI color value of the <see cref="Color"/> instance.</returns>
-    public static int ToWin32Color(Color color)
-    {
-        return (color.A << 24) | (color.R << 0) | (color.G << 8) | (color.B << 16);
-    }
-
-    /// <summary>
-    /// Converts an ABGR WinAPI color to <see cref="Color"/> while ignoring the alpha channel.
-    /// </summary>
-    /// <param name="color">The color value to convert.</param>
-    /// <returns>A <see cref="Color"/> equivalent of the ABGR WinAPI color with alpha channel value set to max (opaque).</returns>
-    public static Color FromWin32ColorOpaque(int color)
-    {
-        color |= unchecked((int)0xFF_00_00_00);
-
-        if (knownColorMap.TryGetValue(color, out Color result))
-            // We do all this nonsense because Visual Studio designer does not
-            // mark raw colors as default if there exists a known color
-            // with the same value.
-            return result;
-
-        return Color.FromArgb((color >> 0) & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF);
-    }
-
-    /// <summary>
-    /// Converts a <see cref="Color"/> to ABGR WinAPI color while ignoring the alpha channel.
-    /// </summary>
-    /// <param name="color">The <see cref="Color"/> instance to convert.</param>
-    /// <returns>ABGR WinAPI color value of the <see cref="Color"/> instance with alpha channel value set to max (opaque).</returns>
-    public static int ToWin32ColorOpaque(Color color)
-    {
-        return (0xFF << 24) | (color.R << 0) | (color.G << 8) | (color.B << 16);
-    }
-
-    /// <summary>
-    /// Gets the folding state of the control as a delimited string containing line indexes.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla"/> control instance.</param>
-    /// <param name="separator">The string to use as a separator.</param>
-    /// <returns>The folding state of the control.</returns>
-    public static string GetFoldingState(this Scintilla scintilla, string separator = ";")
-    {
-        return string.Join(separator,
-            scintilla.Lines.Where(f => !f.Expanded).Select(f => f.Index).OrderBy(f => f).ToArray());
-    }
-
-    /// <summary>
-    /// Sets the folding state of the state of the control with specified index string.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla"/> control instance.</param>
-    /// <param name="foldingState">A string containing the folded line indexes separated with the <paramref name="separator"/> to restore the folding.</param>
-    /// <param name="separator">The string to use as a separator.</param>
-    public static void SetFoldingState(this Scintilla scintilla, string foldingState, string separator = ";")
-    {
-        scintilla.FoldAll(FoldAction.Expand);
-        foreach (int index in foldingState.Split(new[] { separator }, System.StringSplitOptions.None).Select(int.Parse))
-        {
-            if (index < 0 || index >= scintilla.Lines.Count)
+            foreach (KnownColor knownColor in Enum.GetValues(typeof(KnownColor)).Cast<KnownColor>().Where(k => k >= KnownColor.Transparent && k < KnownColor.ButtonFace))
             {
-                continue;
+                var color = Color.FromKnownColor(knownColor);
+                knownColorMap[ToWin32Color(color)] = color;
             }
+        }
 
-            scintilla.Lines[index].ToggleFold();
+        /// <summary>
+        /// Converts an ABGR WinAPI color to <see cref="Color"/>.
+        /// </summary>
+        /// <param name="color">The color value to convert.</param>
+        /// <returns>A <see cref="Color"/> equivalent of the ABGR WinAPI color.</returns>
+        public static Color FromWin32Color(int color)
+        {
+            if ((color & 0xFF_00_00_00) == 0)
+                return Color.Transparent;
+
+            if (knownColorMap.TryGetValue(color, out Color result))
+                // We do all this nonsense because Visual Studio designer does not
+                // mark raw colors as default if there exists a known color
+                // with the same value.
+                return result;
+
+            return Color.FromArgb((color >> 24) & 0xFF, (color >> 0) & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Color"/> to ABGR WinAPI color.
+        /// </summary>
+        /// <param name="color">The <see cref="Color"/> instance to convert.</param>
+        /// <returns>ABGR WinAPI color value of the <see cref="Color"/> instance.</returns>
+        public static int ToWin32Color(Color color)
+        {
+            return (color.A << 24) | (color.R << 0) | (color.G << 8) | (color.B << 16);
+        }
+
+        /// <summary>
+        /// Converts an ABGR WinAPI color to <see cref="Color"/> while ignoring the alpha channel.
+        /// </summary>
+        /// <param name="color">The color value to convert.</param>
+        /// <returns>A <see cref="Color"/> equivalent of the ABGR WinAPI color with alpha channel value set to max (opaque).</returns>
+        public static Color FromWin32ColorOpaque(int color)
+        {
+            color |= unchecked((int)0xFF_00_00_00);
+
+            if (knownColorMap.TryGetValue(color, out Color result))
+                // We do all this nonsense because Visual Studio designer does not
+                // mark raw colors as default if there exists a known color
+                // with the same value.
+                return result;
+
+            return Color.FromArgb((color >> 0) & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Color"/> to ABGR WinAPI color while ignoring the alpha channel.
+        /// </summary>
+        /// <param name="color">The <see cref="Color"/> instance to convert.</param>
+        /// <returns>ABGR WinAPI color value of the <see cref="Color"/> instance with alpha channel value set to max (opaque).</returns>
+        public static int ToWin32ColorOpaque(Color color)
+        {
+            return (0xFF << 24) | (color.R << 0) | (color.G << 8) | (color.B << 16);
+        }
+
+        /// <summary>
+        /// Gets the folding state of the control as a delimited string containing line indexes.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla"/> control instance.</param>
+        /// <param name="separator">The string to use as a separator.</param>
+        /// <returns>The folding state of the control.</returns>
+        public static string GetFoldingState(this Scintilla scintilla, string separator = ";")
+        {
+            return string.Join(separator,
+                scintilla.Lines.Where(f => !f.Expanded).Select(f => f.Index).OrderBy(f => f).ToArray());
+        }
+
+        /// <summary>
+        /// Sets the folding state of the state of the control with specified index string.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla"/> control instance.</param>
+        /// <param name="foldingState">A string containing the folded line indexes separated with the <paramref name="separator"/> to restore the folding.</param>
+        /// <param name="separator">The string to use as a separator.</param>
+        public static void SetFoldingState(this Scintilla scintilla, string foldingState, string separator = ";")
+        {
+            scintilla.FoldAll(FoldAction.Expand);
+            foreach (int index in foldingState.Split(new[] { separator }, System.StringSplitOptions.None).Select(int.Parse))
+            {
+                if (index < 0 || index >= scintilla.Lines.Count)
+                {
+                    continue;
+                }
+
+                scintilla.Lines[index].ToggleFold();
+            }
         }
     }
 }

--- a/Scintilla.NET/Helpers.cs
+++ b/Scintilla.NET/Helpers.cs
@@ -7,1239 +7,1227 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 
-namespace ScintillaNET;
-
-internal static class Helpers
+namespace ScintillaNET
 {
-    #region Fields
-
-    private static bool registeredFormats;
-    private static uint CF_HTML;
-    private static uint CF_RTF;
-    private static uint CF_LINESELECT;
-    private static uint CF_VSLINETAG;
-
-    #endregion Fields
-
-    #region Methods
-
-    public static long CopyTo(this Stream source, Stream destination)
+    internal static class Helpers
     {
-        byte[] buffer = new byte[2048];
-        int bytesRead;
-        long totalBytes = 0;
-        while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+        #region Fields
+
+        private static bool registeredFormats;
+        private static uint CF_HTML;
+        private static uint CF_RTF;
+        private static uint CF_LINESELECT;
+        private static uint CF_VSLINETAG;
+
+        #endregion Fields
+
+        #region Methods
+
+        public static long CopyTo(this Stream source, Stream destination)
         {
-            destination.Write(buffer, 0, bytesRead);
-            totalBytes += bytesRead;
-        }
-
-        return totalBytes;
-    }
-
-    public static unsafe byte[] BitmapToArgb(Bitmap image)
-    {
-        // This code originally used Image.LockBits and some fast byte copying, however, the endianness
-        // of the image formats was making my brain hurt. For now I'm going to use the slow but simple
-        // GetPixel approach.
-
-        byte[] bytes = new byte[4 * image.Width * image.Height];
-
-        int i = 0;
-        for (int y = 0; y < image.Height; y++)
-        {
-            for (int x = 0; x < image.Width; x++)
+            byte[] buffer = new byte[2048];
+            int bytesRead;
+            long totalBytes = 0;
+            while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
             {
-                Color color = image.GetPixel(x, y);
-                bytes[i++] = color.R;
-                bytes[i++] = color.G;
-                bytes[i++] = color.B;
-                bytes[i++] = color.A;
-            }
-        }
-
-        return bytes;
-    }
-
-    public static unsafe byte[] ByteToCharStyles(byte* styles, byte* text, int length, Encoding encoding)
-    {
-        // This is used by annotations and margins to get all the styles in one call.
-        // It converts an array of styles where each element corresponds to a BYTE
-        // to an array of styles where each element corresponds to a CHARACTER.
-
-        int bytePos = 0; // Position within text BYTES and style BYTES (should be the same)
-        int charPos = 0; // Position within style CHARACTERS
-        Decoder decoder = encoding.GetDecoder();
-        byte[] result = new byte[encoding.GetCharCount(text, length)];
-
-        while (bytePos < length)
-        {
-            if (decoder.GetCharCount(text + bytePos, 1, false) > 0)
-                result[charPos++] = *(styles + bytePos); // New char
-
-            bytePos++;
-        }
-
-        return result;
-    }
-
-    public static unsafe byte[] CharToByteStyles(byte[] styles, byte* text, int length, Encoding encoding)
-    {
-        // This is used by annotations and margins to style all the text in one call.
-        // It converts an array of styles where each element corresponds to a CHARACTER
-        // to an array of styles where each element corresponds to a BYTE.
-
-        int bytePos = 0; // Position within text BYTES and style BYTES (should be the same)
-        int charPos = 0; // Position within style CHARACTERS
-        Decoder decoder = encoding.GetDecoder();
-        byte[] result = new byte[length];
-
-        while (bytePos < length && charPos < styles.Length)
-        {
-            result[bytePos] = styles[charPos];
-            if (decoder.GetCharCount(text + bytePos, 1, false) > 0)
-                charPos++; // Move a char
-
-            bytePos++;
-        }
-
-        return result;
-    }
-
-    public static float Clamp(float f, float min, float max)
-    {
-        return f < min ? min : f > max ? max : f;
-    }
-
-    public static int Clamp(int value, int min, int max)
-    {
-        if (value < min)
-            return min;
-
-        if (value > max)
-            return max;
-
-        return value;
-    }
-
-    public static int ClampMin(int value, int min)
-    {
-        if (value < min)
-            return min;
-
-        return value;
-    }
-
-    public static void Copy(Scintilla scintilla, CopyFormat format, bool useSelection, bool allowLine, int startBytePos, int endBytePos)
-    {
-        // Plain text
-        if ((format & CopyFormat.Text) > 0)
-        {
-            if (useSelection)
-            {
-                if (allowLine)
-                    scintilla.DirectMessage(NativeMethods.SCI_COPYALLOWLINE);
-                else
-                    scintilla.DirectMessage(NativeMethods.SCI_COPY);
-            }
-            else
-            {
-                scintilla.DirectMessage(NativeMethods.SCI_COPYRANGE, new IntPtr(startBytePos), new IntPtr(endBytePos));
-            }
-        }
-
-        // RTF and/or HTML
-        if ((format & (CopyFormat.Rtf | CopyFormat.Html)) > 0)
-        {
-            // If we ever allow more than UTF-8, this will have to be revisited
-            Debug.Assert(scintilla.DirectMessage(NativeMethods.SCI_GETCODEPAGE).ToInt32() == NativeMethods.SC_CP_UTF8);
-
-            if (!registeredFormats)
-            {
-                // Register non-standard clipboard formats.
-                // Scintilla -> ScintillaWin.cxx
-                // NppExport -> HTMLExporter.h
-                // NppExport -> RTFExporter.h
-
-                CF_LINESELECT = NativeMethods.RegisterClipboardFormat("MSDEVLineSelect");
-                CF_VSLINETAG = NativeMethods.RegisterClipboardFormat("VisualStudioEditorOperationsLineCutCopyClipboardTag");
-                CF_HTML = NativeMethods.RegisterClipboardFormat("HTML Format");
-                CF_RTF = NativeMethods.RegisterClipboardFormat("Rich Text Format");
-                registeredFormats = true;
+                destination.Write(buffer, 0, bytesRead);
+                totalBytes += bytesRead;
             }
 
-            bool lineCopy = false;
-            StyleData[] styles = null;
-            List<ArraySegment<byte>> styledSegments = null;
+            return totalBytes;
+        }
 
-            if (useSelection)
+        public static unsafe byte[] BitmapToArgb(Bitmap image)
+        {
+            // This code originally used Image.LockBits and some fast byte copying, however, the endianness
+            // of the image formats was making my brain hurt. For now I'm going to use the slow but simple
+            // GetPixel approach.
+
+            byte[] bytes = new byte[4 * image.Width * image.Height];
+
+            int i = 0;
+            for (int y = 0; y < image.Height; y++)
             {
-                bool selIsEmpty = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONEMPTY) != IntPtr.Zero;
-                if (selIsEmpty)
+                for (int x = 0; x < image.Width; x++)
+                {
+                    Color color = image.GetPixel(x, y);
+                    bytes[i++] = color.R;
+                    bytes[i++] = color.G;
+                    bytes[i++] = color.B;
+                    bytes[i++] = color.A;
+                }
+            }
+
+            return bytes;
+        }
+
+        public static unsafe byte[] ByteToCharStyles(byte* styles, byte* text, int length, Encoding encoding)
+        {
+            // This is used by annotations and margins to get all the styles in one call.
+            // It converts an array of styles where each element corresponds to a BYTE
+            // to an array of styles where each element corresponds to a CHARACTER.
+
+            int bytePos = 0; // Position within text BYTES and style BYTES (should be the same)
+            int charPos = 0; // Position within style CHARACTERS
+            Decoder decoder = encoding.GetDecoder();
+            byte[] result = new byte[encoding.GetCharCount(text, length)];
+
+            while (bytePos < length)
+            {
+                if (decoder.GetCharCount(text + bytePos, 1, false) > 0)
+                    result[charPos++] = *(styles + bytePos); // New char
+
+                bytePos++;
+            }
+
+            return result;
+        }
+
+        public static unsafe byte[] CharToByteStyles(byte[] styles, byte* text, int length, Encoding encoding)
+        {
+            // This is used by annotations and margins to style all the text in one call.
+            // It converts an array of styles where each element corresponds to a CHARACTER
+            // to an array of styles where each element corresponds to a BYTE.
+
+            int bytePos = 0; // Position within text BYTES and style BYTES (should be the same)
+            int charPos = 0; // Position within style CHARACTERS
+            Decoder decoder = encoding.GetDecoder();
+            byte[] result = new byte[length];
+
+            while (bytePos < length && charPos < styles.Length)
+            {
+                result[bytePos] = styles[charPos];
+                if (decoder.GetCharCount(text + bytePos, 1, false) > 0)
+                    charPos++; // Move a char
+
+                bytePos++;
+            }
+
+            return result;
+        }
+
+        public static float Clamp(float f, float min, float max)
+        {
+            return f < min ? min : f > max ? max : f;
+        }
+
+        public static int Clamp(int value, int min, int max)
+        {
+            if (value < min)
+                return min;
+
+            if (value > max)
+                return max;
+
+            return value;
+        }
+
+        public static int ClampMin(int value, int min)
+        {
+            if (value < min)
+                return min;
+
+            return value;
+        }
+
+        public static void Copy(Scintilla scintilla, CopyFormat format, bool useSelection, bool allowLine, int startBytePos, int endBytePos)
+        {
+            // Plain text
+            if ((format & CopyFormat.Text) > 0)
+            {
+                if (useSelection)
                 {
                     if (allowLine)
-                    {
-                        // Get the current line
-                        styledSegments = GetStyledSegments(scintilla, false, true, 0, 0, out styles);
-                        lineCopy = true;
-                    }
+                        scintilla.DirectMessage(NativeMethods.SCI_COPYALLOWLINE);
+                    else
+                        scintilla.DirectMessage(NativeMethods.SCI_COPY);
                 }
                 else
                 {
-                    // Get every selection
-                    styledSegments = GetStyledSegments(scintilla, true, false, 0, 0, out styles);
+                    scintilla.DirectMessage(NativeMethods.SCI_COPYRANGE, new IntPtr(startBytePos), new IntPtr(endBytePos));
                 }
             }
-            else if (startBytePos != endBytePos)
-            {
-                // User-specified range
-                styledSegments = GetStyledSegments(scintilla, false, false, startBytePos, endBytePos, out styles);
-            }
 
-            // If we have segments and can open the clipboard
-            if (styledSegments != null && styledSegments.Count > 0 && NativeMethods.OpenClipboard(scintilla.Handle))
+            // RTF and/or HTML
+            if ((format & (CopyFormat.Rtf | CopyFormat.Html)) > 0)
             {
-                if ((format & CopyFormat.Text) == 0)
+                // If we ever allow more than UTF-8, this will have to be revisited
+                Debug.Assert(scintilla.DirectMessage(NativeMethods.SCI_GETCODEPAGE).ToInt32() == NativeMethods.SC_CP_UTF8);
+
+                if (!registeredFormats)
                 {
-                    // Do the things default (plain text) processing would normally give us
-                    NativeMethods.EmptyClipboard();
+                    // Register non-standard clipboard formats.
+                    // Scintilla -> ScintillaWin.cxx
+                    // NppExport -> HTMLExporter.h
+                    // NppExport -> RTFExporter.h
 
-                    if (lineCopy)
+                    CF_LINESELECT = NativeMethods.RegisterClipboardFormat("MSDEVLineSelect");
+                    CF_VSLINETAG = NativeMethods.RegisterClipboardFormat("VisualStudioEditorOperationsLineCutCopyClipboardTag");
+                    CF_HTML = NativeMethods.RegisterClipboardFormat("HTML Format");
+                    CF_RTF = NativeMethods.RegisterClipboardFormat("Rich Text Format");
+                    registeredFormats = true;
+                }
+
+                bool lineCopy = false;
+                StyleData[] styles = null;
+                List<ArraySegment<byte>> styledSegments = null;
+
+                if (useSelection)
+                {
+                    bool selIsEmpty = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONEMPTY) != IntPtr.Zero;
+                    if (selIsEmpty)
                     {
-                        // Clipboard tags
-                        NativeMethods.SetClipboardData(CF_LINESELECT, IntPtr.Zero);
-                        NativeMethods.SetClipboardData(CF_VSLINETAG, IntPtr.Zero);
-                    }
-                }
-
-                // RTF
-                if ((format & CopyFormat.Rtf) > 0)
-                    CopyRtf(scintilla, styles, styledSegments);
-
-                // HTML
-                if ((format & CopyFormat.Html) > 0)
-                    CopyHtml(scintilla, styles, styledSegments);
-
-                NativeMethods.CloseClipboard();
-            }
-        }
-    }
-
-    private static unsafe void CopyHtml(Scintilla scintilla, StyleData[] styles, List<ArraySegment<byte>> styledSegments)
-    {
-        // NppExport -> NppExport.cpp
-        // NppExport -> HTMLExporter.cpp
-        // http://blogs.msdn.com/b/jmstall/archive/2007/01/21/html-clipboard.aspx
-        // http://blogs.msdn.com/b/jmstall/archive/2007/01/21/sample-code-html-clipboard.aspx
-        // https://msdn.microsoft.com/en-us/library/windows/desktop/ms649015.aspx
-
-        try
-        {
-            long pos = 0;
-            byte[] bytes;
-
-            // Write HTML
-            using var ms = new NativeMemoryStream(styledSegments.Sum(s => s.Count));
-            using var tw = new StreamWriter(ms, new UTF8Encoding(false));
-            const int INDEX_START_HTML = 23;
-            const int INDEX_START_FRAGMENT = 65;
-            const int INDEX_END_FRAGMENT = 87;
-            const int INDEX_END_HTML = 41;
-
-            tw.WriteLine("Version:0.9");
-            tw.WriteLine("StartHTML:00000000");
-            tw.WriteLine("EndHTML:00000000");
-            tw.WriteLine("StartFragment:00000000");
-            tw.WriteLine("EndFragment:00000000");
-            tw.Flush();
-
-            // Patch header
-            pos = ms.Position;
-            ms.Seek(INDEX_START_HTML, SeekOrigin.Begin);
-            ms.Write(bytes = Encoding.ASCII.GetBytes(ms.Length.ToString("D8")), 0, bytes.Length);
-            ms.Seek(pos, SeekOrigin.Begin);
-
-            tw.WriteLine("<html>");
-            tw.WriteLine("<head>");
-            tw.WriteLine(@"<meta charset=""utf-8"" />");
-            tw.WriteLine(@"<title>ScintillaNET v{0}</title>", scintilla.GetType().Assembly.GetName().Version.ToString(3));
-            tw.WriteLine("</head>");
-            tw.WriteLine("<body>");
-            tw.Flush();
-
-            // Patch header
-            pos = ms.Position;
-            ms.Seek(INDEX_START_FRAGMENT, SeekOrigin.Begin);
-            ms.Write(bytes = Encoding.ASCII.GetBytes(ms.Length.ToString("D8")), 0, bytes.Length);
-            ms.Seek(pos, SeekOrigin.Begin);
-            tw.WriteLine("<!--StartFragment -->");
-
-            // Write the styles.
-            // We're doing the style tag in the body to include it in the "fragment".
-            tw.WriteLine(@"<style type=""text/css"" scoped="""">");
-            tw.Write("div#segments {");
-            tw.Write(" float: left;");
-            tw.Write(" white-space: pre;");
-            tw.Write(" line-height: {0}px;", scintilla.DirectMessage(NativeMethods.SCI_TEXTHEIGHT, new IntPtr(0)).ToInt32());
-            tw.Write(" background-color: #{0:X2}{1:X2}{2:X2};", (styles[Style.Default].BackColor >> 0) & 0xFF, (styles[Style.Default].BackColor >> 8) & 0xFF, (styles[Style.Default].BackColor >> 16) & 0xFF);
-            tw.WriteLine(" }");
-
-            for (int i = 0; i < styles.Length; i++)
-            {
-                if (!styles[i].Used)
-                    continue;
-
-                tw.Write("span.s{0} {{", i);
-                tw.Write(@" font-family: ""{0}"";", styles[i].FontName);
-                tw.Write(" font-size: {0}pt;", styles[i].SizeF);
-                tw.Write(" font-weight: {0};", styles[i].Weight);
-                if (styles[i].Italic != 0)
-                    tw.Write(" font-style: italic;");
-                if (styles[i].Underline != 0)
-                    tw.Write(" text-decoration: underline;");
-                tw.Write(" background-color: #{0:X2}{1:X2}{2:X2};", (styles[i].BackColor >> 0) & 0xFF, (styles[i].BackColor >> 8) & 0xFF, (styles[i].BackColor >> 16) & 0xFF);
-                tw.Write(" color: #{0:X2}{1:X2}{2:X2};", (styles[i].ForeColor >> 0) & 0xFF, (styles[i].ForeColor >> 8) & 0xFF, (styles[i].ForeColor >> 16) & 0xFF);
-                switch ((StyleCase)styles[i].Case)
-                {
-                    case StyleCase.Upper:
-                        tw.Write(" text-transform: uppercase;");
-                        break;
-                    case StyleCase.Lower:
-                        tw.Write(" text-transform: lowercase;");
-                        break;
-                }
-
-                if (styles[i].Visible == 0)
-                    tw.Write(" visibility: hidden;");
-                tw.WriteLine(" }");
-            }
-
-            tw.WriteLine("</style>");
-            tw.Write(@"<div id=""segments""><span class=""s{0}"">", Style.Default);
-            tw.Flush();
-
-            int tabSize = scintilla.DirectMessage(NativeMethods.SCI_GETTABWIDTH).ToInt32();
-            string tab = new(' ', tabSize);
-
-            tw.AutoFlush = true;
-            int lastStyle = Style.Default;
-            bool unicodeLineEndings = (scintilla.DirectMessage(NativeMethods.SCI_GETLINEENDTYPESACTIVE).ToInt32() & NativeMethods.SC_LINE_END_TYPE_UNICODE) > 0;
-            foreach (ArraySegment<byte> seg in styledSegments)
-            {
-                int endOffset = seg.Offset + seg.Count;
-                for (int i = seg.Offset; i < endOffset; i += 2)
-                {
-                    byte ch = seg.Array[i];
-                    byte style = seg.Array[i + 1];
-
-                    if (lastStyle != style)
-                    {
-                        tw.Write(@"</span><span class=""s{0}"">", style);
-                        lastStyle = style;
-                    }
-
-                    switch (ch)
-                    {
-                        case (byte)'<':
-                            tw.Write("&lt;");
-                            break;
-
-                        case (byte)'>':
-                            tw.Write("&gt;");
-                            break;
-
-                        case (byte)'&':
-                            tw.Write("&amp;");
-                            break;
-
-                        case (byte)'\t':
-                            tw.Write(tab);
-                            break;
-
-                        case (byte)'\r':
-                            if (i + 2 < endOffset)
-                            {
-                                if (seg.Array[i + 2] == (byte)'\n')
-                                    i += 2;
-                            }
-
-                            // Either way, this is a line break
-                            goto case (byte)'\n';
-
-                        case 0xC2:
-                            if (unicodeLineEndings && i + 2 < endOffset)
-                            {
-                                if (seg.Array[i + 2] == 0x85) // NEL \u0085
-                                {
-                                    i += 2;
-                                    goto case (byte)'\n';
-                                }
-                            }
-
-                            // Not a Unicode line break
-                            goto default;
-
-                        case 0xE2:
-                            if (unicodeLineEndings && i + 4 < endOffset)
-                            {
-                                if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA8) // LS \u2028
-                                {
-                                    i += 4;
-                                    goto case (byte)'\n';
-                                }
-                                else if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA9) // PS \u2029
-                                {
-                                    i += 4;
-                                    goto case (byte)'\n';
-                                }
-                            }
-
-                            // Not a Unicode line break
-                            goto default;
-
-                        case (byte)'\n':
-                            // All your line breaks are belong to us
-                            tw.Write("\r\n");
-                            break;
-
-                        default:
-
-                            if (ch == 0)
-                            {
-                                // Scintilla behavior is to allow control characters except for
-                                // NULL which will cause the Clipboard to truncate the string.
-                                tw.Write(" "); // Replace with space
-                                break;
-                            }
-
-                            ms.WriteByte(ch);
-                            break;
-                    }
-                }
-            }
-
-            tw.AutoFlush = false;
-            tw.WriteLine("</span></div>");
-            tw.Flush();
-
-            // Patch header
-            pos = ms.Position;
-            ms.Seek(INDEX_END_FRAGMENT, SeekOrigin.Begin);
-            ms.Write(bytes = Encoding.ASCII.GetBytes(ms.Length.ToString("D8")), 0, bytes.Length);
-            ms.Seek(pos, SeekOrigin.Begin);
-            tw.WriteLine("<!--EndFragment-->");
-
-            tw.WriteLine("</body>");
-            tw.WriteLine("</html>");
-            tw.Flush();
-
-            // Patch header
-            pos = ms.Position;
-            ms.Seek(INDEX_END_HTML, SeekOrigin.Begin);
-            ms.Write(bytes = Encoding.ASCII.GetBytes(ms.Length.ToString("D8")), 0, bytes.Length);
-            ms.Seek(pos, SeekOrigin.Begin);
-
-            // Terminator
-            ms.WriteByte(0);
-
-            string str = GetString(ms.Pointer, (int)ms.Length, Encoding.UTF8);
-            if (NativeMethods.SetClipboardData(CF_HTML, ms.Pointer) != IntPtr.Zero)
-                ms.FreeOnDispose = false; // Clipboard will free memory
-        }
-        catch (Exception ex)
-        {
-            // Yes, we swallow any exceptions. That may seem like code smell but this matches
-            // the behavior of the Clipboard class, Windows Forms controls, and native Scintilla.
-            Debug.Fail(ex.Message, ex.ToString());
-        }
-    }
-
-    private static unsafe void CopyRtf(Scintilla scintilla, StyleData[] styles, List<ArraySegment<byte>> styledSegments)
-    {
-        // NppExport -> NppExport.cpp
-        // NppExport -> RTFExporter.cpp
-        // http://en.wikipedia.org/wiki/Rich_Text_Format
-        // https://msdn.microsoft.com/en-us/library/windows/desktop/ms649013.aspx
-        // http://forums.codeguru.com/showthread.php?242982-Converting-pixels-to-twips
-        // http://en.wikipedia.org/wiki/UTF-8
-
-        try
-        {
-            // Calculate twips per space
-            int twips;
-            FontStyle fontStyle = FontStyle.Regular;
-            if (styles[Style.Default].Weight >= 700)
-                fontStyle |= FontStyle.Bold;
-            if (styles[Style.Default].Italic != 0)
-                fontStyle |= FontStyle.Italic;
-            if (styles[Style.Default].Underline != 0)
-                fontStyle |= FontStyle.Underline;
-
-            using (Graphics graphics = scintilla.CreateGraphics())
-            using (var font = new Font(styles[Style.Default].FontName, styles[Style.Default].SizeF, fontStyle))
-            {
-                float width = graphics.MeasureString(" ", font).Width;
-                twips = (int)(width / graphics.DpiX * 1440);
-                // TODO The twips value calculated seems too small on my computer
-            }
-
-            // Write RTF
-            using var ms = new NativeMemoryStream(styledSegments.Sum(s => s.Count));
-            using var tw = new StreamWriter(ms, Encoding.ASCII);
-            int tabWidth = scintilla.DirectMessage(NativeMethods.SCI_GETTABWIDTH).ToInt32();
-            int deftab = tabWidth * twips;
-
-            tw.WriteLine(@"{{\rtf1\ansi\deff0\deftab{0}", deftab);
-            tw.Flush();
-
-            // Build the font table
-            tw.Write(@"{\fonttbl");
-            tw.Write(@"{{\f0 {0};}}", styles[Style.Default].FontName);
-            int fontIndex = 1;
-            for (int i = 0; i < styles.Length; i++)
-            {
-                if (!styles[i].Used)
-                    continue;
-
-                if (i == Style.Default)
-                    continue;
-
-                // Not a completely unique list, but close enough
-                if (styles[i].FontName != styles[Style.Default].FontName)
-                {
-                    styles[i].FontIndex = fontIndex++;
-                    tw.Write(@"{{\f{0} {1};}}", styles[i].FontIndex, styles[i].FontName);
-                }
-            }
-
-            tw.WriteLine("}"); // fonttbl
-            tw.Flush();
-
-            // Build the color table
-            tw.Write(@"{\colortbl");
-            tw.Write(@"\red{0}\green{1}\blue{2};", (styles[Style.Default].ForeColor >> 0) & 0xFF, (styles[Style.Default].ForeColor >> 8) & 0xFF, (styles[Style.Default].ForeColor >> 16) & 0xFF);
-            tw.Write(@"\red{0}\green{1}\blue{2};", (styles[Style.Default].BackColor >> 0) & 0xFF, (styles[Style.Default].BackColor >> 8) & 0xFF, (styles[Style.Default].BackColor >> 16) & 0xFF);
-            styles[Style.Default].ForeColorIndex = 0;
-            styles[Style.Default].BackColorIndex = 1;
-            int colorIndex = 2;
-            for (int i = 0; i < styles.Length; i++)
-            {
-                if (!styles[i].Used)
-                    continue;
-
-                if (i == Style.Default)
-                    continue;
-
-                // Not a completely unique list, but close enough
-                if (styles[i].ForeColor != styles[Style.Default].ForeColor)
-                {
-                    styles[i].ForeColorIndex = colorIndex++;
-                    tw.Write(@"\red{0}\green{1}\blue{2};", (styles[i].ForeColor >> 0) & 0xFF, (styles[i].ForeColor >> 8) & 0xFF, (styles[i].ForeColor >> 16) & 0xFF);
-                }
-                else
-                {
-                    styles[i].ForeColorIndex = styles[Style.Default].ForeColorIndex;
-                }
-
-                if (styles[i].BackColor != styles[Style.Default].BackColor)
-                {
-                    styles[i].BackColorIndex = colorIndex++;
-                    tw.Write(@"\red{0}\green{1}\blue{2};", (styles[i].BackColor >> 0) & 0xFF, (styles[i].BackColor >> 8) & 0xFF, (styles[i].BackColor >> 16) & 0xFF);
-                }
-                else
-                {
-                    styles[i].BackColorIndex = styles[Style.Default].BackColorIndex;
-                }
-            }
-
-            tw.WriteLine("}"); // colortbl
-            tw.Flush();
-
-            // Start with the default style
-            tw.Write(@"\f{0}\fs{1}\cf{2}\chshdng0\chcbpat{3}\cb{3} ", styles[Style.Default].FontIndex, (int)(styles[Style.Default].SizeF * 2), styles[Style.Default].ForeColorIndex, styles[Style.Default].BackColorIndex);
-            if (styles[Style.Default].Italic != 0)
-                tw.Write(@"\i");
-            if (styles[Style.Default].Underline != 0)
-                tw.Write(@"\ul");
-            if (styles[Style.Default].Weight >= 700)
-                tw.Write(@"\b");
-
-            tw.AutoFlush = true;
-            int lastStyle = Style.Default;
-            bool unicodeLineEndings = (scintilla.DirectMessage(NativeMethods.SCI_GETLINEENDTYPESACTIVE).ToInt32() & NativeMethods.SC_LINE_END_TYPE_UNICODE) > 0;
-            foreach (ArraySegment<byte> seg in styledSegments)
-            {
-                int endOffset = seg.Offset + seg.Count;
-                for (int i = seg.Offset; i < endOffset; i += 2)
-                {
-                    byte ch = seg.Array[i];
-                    byte style = seg.Array[i + 1];
-
-                    if (lastStyle != style)
-                    {
-                        // Change the style
-                        if (styles[lastStyle].FontIndex != styles[style].FontIndex)
-                            tw.Write(@"\f{0}", styles[style].FontIndex);
-                        if (styles[lastStyle].SizeF != styles[style].SizeF)
-                            tw.Write(@"\fs{0}", (int)(styles[style].SizeF * 2));
-                        if (styles[lastStyle].ForeColorIndex != styles[style].ForeColorIndex)
-                            tw.Write(@"\cf{0}", styles[style].ForeColorIndex);
-                        if (styles[lastStyle].BackColorIndex != styles[style].BackColorIndex)
-                            tw.Write(@"\chshdng0\chcbpat{0}\cb{0}", styles[style].BackColorIndex);
-                        if (styles[lastStyle].Italic != styles[style].Italic)
-                            tw.Write(@"\i{0}", styles[style].Italic != 0 ? "" : "0");
-                        if (styles[lastStyle].Underline != styles[style].Underline)
-                            tw.Write(@"\ul{0}", styles[style].Underline != 0 ? "" : "0");
-                        if (styles[lastStyle].Weight != styles[style].Weight)
+                        if (allowLine)
                         {
-                            if (styles[style].Weight >= 700 && styles[lastStyle].Weight < 700)
-                                tw.Write(@"\b");
-                            else if (styles[style].Weight < 700 && styles[lastStyle].Weight >= 700)
-                                tw.Write(@"\b0");
+                            // Get the current line
+                            styledSegments = GetStyledSegments(scintilla, false, true, 0, 0, out styles);
+                            lineCopy = true;
+                        }
+                    }
+                    else
+                    {
+                        // Get every selection
+                        styledSegments = GetStyledSegments(scintilla, true, false, 0, 0, out styles);
+                    }
+                }
+                else if (startBytePos != endBytePos)
+                {
+                    // User-specified range
+                    styledSegments = GetStyledSegments(scintilla, false, false, startBytePos, endBytePos, out styles);
+                }
+
+                // If we have segments and can open the clipboard
+                if (styledSegments != null && styledSegments.Count > 0 && NativeMethods.OpenClipboard(scintilla.Handle))
+                {
+                    if ((format & CopyFormat.Text) == 0)
+                    {
+                        // Do the things default (plain text) processing would normally give us
+                        NativeMethods.EmptyClipboard();
+
+                        if (lineCopy)
+                        {
+                            // Clipboard tags
+                            NativeMethods.SetClipboardData(CF_LINESELECT, IntPtr.Zero);
+                            NativeMethods.SetClipboardData(CF_VSLINETAG, IntPtr.Zero);
+                        }
+                    }
+
+                    // RTF
+                    if ((format & CopyFormat.Rtf) > 0)
+                        CopyRtf(scintilla, styles, styledSegments);
+
+                    // HTML
+                    if ((format & CopyFormat.Html) > 0)
+                        CopyHtml(scintilla, styles, styledSegments);
+
+                    NativeMethods.CloseClipboard();
+                }
+            }
+        }
+
+        private static unsafe void CopyHtml(Scintilla scintilla, StyleData[] styles, List<ArraySegment<byte>> styledSegments)
+        {
+            // NppExport -> NppExport.cpp
+            // NppExport -> HTMLExporter.cpp
+            // http://blogs.msdn.com/b/jmstall/archive/2007/01/21/html-clipboard.aspx
+            // http://blogs.msdn.com/b/jmstall/archive/2007/01/21/sample-code-html-clipboard.aspx
+            // https://msdn.microsoft.com/en-us/library/windows/desktop/ms649015.aspx
+
+            try
+            {
+                long pos = 0;
+                byte[] bytes;
+
+                // Write HTML
+                const int INDEX_START_HTML = 23;
+                const int INDEX_START_FRAGMENT = 65;
+                const int INDEX_END_FRAGMENT = 87;
+                const int INDEX_END_HTML = 41;
+
+                using (var ms = new NativeMemoryStream(styledSegments.Sum(s => s.Count)))
+                {
+                    using (var tw = new StreamWriter(ms, new UTF8Encoding(false)))
+                    {
+                        tw.WriteLine("Version:0.9");
+                        tw.WriteLine("StartHTML:00000000");
+                        tw.WriteLine("EndHTML:00000000");
+                        tw.WriteLine("StartFragment:00000000");
+                        tw.WriteLine("EndFragment:00000000");
+                        tw.Flush();
+
+                        // Patch header
+                        pos = ms.Position;
+                        ms.Seek(INDEX_START_HTML, SeekOrigin.Begin);
+                        ms.Write(bytes = Encoding.ASCII.GetBytes(ms.Length.ToString("D8")), 0, bytes.Length);
+                        ms.Seek(pos, SeekOrigin.Begin);
+
+                        tw.WriteLine("<html>");
+                        tw.WriteLine("<head>");
+                        tw.WriteLine(@"<meta charset=""utf-8"" />");
+                        tw.WriteLine(@"<title>ScintillaNET v{0}</title>", scintilla.GetType().Assembly.GetName().Version.ToString(3));
+                        tw.WriteLine("</head>");
+                        tw.WriteLine("<body>");
+                        tw.Flush();
+
+                        // Patch header
+                        pos = ms.Position;
+                        ms.Seek(INDEX_START_FRAGMENT, SeekOrigin.Begin);
+                        ms.Write(bytes = Encoding.ASCII.GetBytes(ms.Length.ToString("D8")), 0, bytes.Length);
+                        ms.Seek(pos, SeekOrigin.Begin);
+                        tw.WriteLine("<!--StartFragment -->");
+
+                        // Write the styles.
+                        // We're doing the style tag in the body to include it in the "fragment".
+                        tw.WriteLine(@"<style type=""text/css"" scoped="""">");
+                        tw.Write("div#segments {");
+                        tw.Write(" float: left;");
+                        tw.Write(" white-space: pre;");
+                        tw.Write(" line-height: {0}px;", scintilla.DirectMessage(NativeMethods.SCI_TEXTHEIGHT, new IntPtr(0)).ToInt32());
+                        tw.Write(" background-color: #{0:X2}{1:X2}{2:X2};", (styles[Style.Default].BackColor >> 0) & 0xFF, (styles[Style.Default].BackColor >> 8) & 0xFF, (styles[Style.Default].BackColor >> 16) & 0xFF);
+                        tw.WriteLine(" }");
+
+                        for (int i = 0; i < styles.Length; i++)
+                        {
+                            if (!styles[i].Used)
+                                continue;
+
+                            tw.Write("span.s{0} {{", i);
+                            tw.Write(@" font-family: ""{0}"";", styles[i].FontName);
+                            tw.Write(" font-size: {0}pt;", styles[i].SizeF);
+                            tw.Write(" font-weight: {0};", styles[i].Weight);
+                            if (styles[i].Italic != 0)
+                                tw.Write(" font-style: italic;");
+                            if (styles[i].Underline != 0)
+                                tw.Write(" text-decoration: underline;");
+                            tw.Write(" background-color: #{0:X2}{1:X2}{2:X2};", (styles[i].BackColor >> 0) & 0xFF, (styles[i].BackColor >> 8) & 0xFF, (styles[i].BackColor >> 16) & 0xFF);
+                            tw.Write(" color: #{0:X2}{1:X2}{2:X2};", (styles[i].ForeColor >> 0) & 0xFF, (styles[i].ForeColor >> 8) & 0xFF, (styles[i].ForeColor >> 16) & 0xFF);
+                            switch ((StyleCase)styles[i].Case)
+                            {
+                                case StyleCase.Upper:
+                                    tw.Write(" text-transform: uppercase;");
+                                    break;
+                                case StyleCase.Lower:
+                                    tw.Write(" text-transform: lowercase;");
+                                    break;
+                            }
+
+                            if (styles[i].Visible == 0)
+                                tw.Write(" visibility: hidden;");
+                            tw.WriteLine(" }");
                         }
 
-                        // NOTE: We don't support StyleData.Visible and StyleData.Case in RTF
+                        tw.WriteLine("</style>");
+                        tw.Write(@"<div id=""segments""><span class=""s{0}"">", Style.Default);
+                        tw.Flush();
 
-                        lastStyle = style;
-                        tw.Write("\n"); // Delimiter
-                    }
+                        int tabSize = scintilla.DirectMessage(NativeMethods.SCI_GETTABWIDTH).ToInt32();
+                        string tab = new string(' ', tabSize);
 
-                    switch (ch)
-                    {
-                        case (byte)'{':
-                            tw.Write(@"\{");
-                            break;
-
-                        case (byte)'}':
-                            tw.Write(@"\}");
-                            break;
-
-                        case (byte)'\\':
-                            tw.Write(@"\\");
-                            break;
-
-                        case (byte)'\t':
-                            tw.Write(@"\tab ");
-                            break;
-
-                        case (byte)'\r':
-                            if (i + 2 < endOffset)
+                        tw.AutoFlush = true;
+                        int lastStyle = Style.Default;
+                        bool unicodeLineEndings = (scintilla.DirectMessage(NativeMethods.SCI_GETLINEENDTYPESACTIVE).ToInt32() & NativeMethods.SC_LINE_END_TYPE_UNICODE) > 0;
+                        foreach (ArraySegment<byte> seg in styledSegments)
+                        {
+                            int endOffset = seg.Offset + seg.Count;
+                            for (int i = seg.Offset; i < endOffset; i += 2)
                             {
-                                if (seg.Array[i + 2] == (byte)'\n')
-                                    i += 2;
-                            }
+                                byte ch = seg.Array[i];
+                                byte style = seg.Array[i + 1];
 
-                            // Either way, this is a line break
-                            goto case (byte)'\n';
-
-                        case 0xC2:
-                            if (unicodeLineEndings && i + 2 < endOffset)
-                            {
-                                if (seg.Array[i + 2] == 0x85) // NEL \u0085
+                                if (lastStyle != style)
                                 {
-                                    i += 2;
-                                    goto case (byte)'\n';
+                                    tw.Write(@"</span><span class=""s{0}"">", style);
+                                    lastStyle = style;
                                 }
-                            }
 
-                            // Not a Unicode line break
-                            goto default;
-
-                        case 0xE2:
-                            if (unicodeLineEndings && i + 4 < endOffset)
-                            {
-                                if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA8) // LS \u2028
+                                switch (ch)
                                 {
-                                    i += 4;
-                                    goto case (byte)'\n';
-                                }
-                                else if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA9) // PS \u2029
-                                {
-                                    i += 4;
-                                    goto case (byte)'\n';
-                                }
-                            }
+                                    case (byte)'<':
+                                        tw.Write("&lt;");
+                                        break;
 
-                            // Not a Unicode line break
-                            goto default;
+                                    case (byte)'>':
+                                        tw.Write("&gt;");
+                                        break;
 
-                        case (byte)'\n':
-                            // All your line breaks are belong to us
-                            tw.WriteLine(@"\par");
-                            break;
+                                    case (byte)'&':
+                                        tw.Write("&amp;");
+                                        break;
 
-                        default:
+                                    case (byte)'\t':
+                                        tw.Write(tab);
+                                        break;
 
-                            if (ch == 0)
-                            {
-                                // Scintilla behavior is to allow control characters except for
-                                // NULL which will cause the Clipboard to truncate the string.
-                                tw.Write(" "); // Replace with space
-                                break;
-                            }
+                                    case (byte)'\r':
+                                        if (i + 2 < endOffset)
+                                        {
+                                            if (seg.Array[i + 2] == (byte)'\n')
+                                                i += 2;
+                                        }
 
-                            if (ch > 0x7F)
-                            {
-                                // Treat as UTF-8 code point
-                                int unicode = 0;
-                                if (ch < 0xE0 && i + 2 < endOffset)
-                                {
-                                    unicode |= (0x1F & ch) << 6;
-                                    unicode |= 0x3F & seg.Array[i + 2];
-                                    tw.Write(@"\u{0}?", unicode);
-                                    i += 2;
-                                    break;
-                                }
-                                else if (ch < 0xF0 && i + 4 < endOffset)
-                                {
-                                    unicode |= (0xF & ch) << 12;
-                                    unicode |= (0x3F & seg.Array[i + 2]) << 6;
-                                    unicode |= 0x3F & seg.Array[i + 4];
-                                    tw.Write(@"\u{0}?", unicode);
-                                    i += 4;
-                                    break;
-                                }
-                                else if (ch < 0xF8 && i + 6 < endOffset)
-                                {
-                                    unicode |= (0x7 & ch) << 18;
-                                    unicode |= (0x3F & seg.Array[i + 2]) << 12;
-                                    unicode |= (0x3F & seg.Array[i + 4]) << 6;
-                                    unicode |= 0x3F & seg.Array[i + 6];
-                                    tw.Write(@"\u{0}?", unicode);
-                                    i += 6;
-                                    break;
+                                        // Either way, this is a line break
+                                        goto case (byte)'\n';
+
+                                    case 0xC2:
+                                        if (unicodeLineEndings && i + 2 < endOffset)
+                                        {
+                                            if (seg.Array[i + 2] == 0x85) // NEL \u0085
+                                            {
+                                                i += 2;
+                                                goto case (byte)'\n';
+                                            }
+                                        }
+
+                                        // Not a Unicode line break
+                                        goto default;
+
+                                    case 0xE2:
+                                        if (unicodeLineEndings && i + 4 < endOffset)
+                                        {
+                                            if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA8) // LS \u2028
+                                            {
+                                                i += 4;
+                                                goto case (byte)'\n';
+                                            }
+                                            else if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA9) // PS \u2029
+                                            {
+                                                i += 4;
+                                                goto case (byte)'\n';
+                                            }
+                                        }
+
+                                        // Not a Unicode line break
+                                        goto default;
+
+                                    case (byte)'\n':
+                                        // All your line breaks are belong to us
+                                        tw.Write("\r\n");
+                                        break;
+
+                                    default:
+
+                                        if (ch == 0)
+                                        {
+                                            // Scintilla behavior is to allow control characters except for
+                                            // NULL which will cause the Clipboard to truncate the string.
+                                            tw.Write(" "); // Replace with space
+                                            break;
+                                        }
+
+                                        ms.WriteByte(ch);
+                                        break;
                                 }
                             }
+                        }
 
-                            // Regular ANSI char
-                            ms.WriteByte(ch);
-                            break;
+                        tw.AutoFlush = false;
+                        tw.WriteLine("</span></div>");
+                        tw.Flush();
+
+                        // Patch header
+                        pos = ms.Position;
+                        ms.Seek(INDEX_END_FRAGMENT, SeekOrigin.Begin);
+                        ms.Write(bytes = Encoding.ASCII.GetBytes(ms.Length.ToString("D8")), 0, bytes.Length);
+                        ms.Seek(pos, SeekOrigin.Begin);
+                        tw.WriteLine("<!--EndFragment-->");
+
+                        tw.WriteLine("</body>");
+                        tw.WriteLine("</html>");
+                        tw.Flush();
+
+                        // Patch header
+                        pos = ms.Position;
+                        ms.Seek(INDEX_END_HTML, SeekOrigin.Begin);
+                        ms.Write(bytes = Encoding.ASCII.GetBytes(ms.Length.ToString("D8")), 0, bytes.Length);
+                        ms.Seek(pos, SeekOrigin.Begin);
+
+                        // Terminator
+                        ms.WriteByte(0);
+
+                        string str = GetString(ms.Pointer, (int)ms.Length, Encoding.UTF8);
+                        if (NativeMethods.SetClipboardData(CF_HTML, ms.Pointer) != IntPtr.Zero)
+                            ms.FreeOnDispose = false; // Clipboard will free memory
                     }
                 }
             }
-
-            tw.AutoFlush = false;
-            tw.WriteLine("}"); // rtf1
-            tw.Flush();
-
-            // Terminator
-            ms.WriteByte(0);
-
-            // var str = GetString(ms.Pointer, (int)ms.Length, Encoding.ASCII);
-            if (NativeMethods.SetClipboardData(CF_RTF, ms.Pointer) != IntPtr.Zero)
-                ms.FreeOnDispose = false; // Clipboard will free memory
-        }
-        catch (Exception ex)
-        {
-            // Yes, we swallow any exceptions. That may seem like code smell but this matches
-            // the behavior of the Clipboard class, Windows Forms controls, and native Scintilla.
-            Debug.Fail(ex.Message, ex.ToString());
-        }
-    }
-
-    public static unsafe byte[] GetBytes(string text, Encoding encoding, bool zeroTerminated)
-    {
-        if (string.IsNullOrEmpty(text))
-            return zeroTerminated ? new byte[] { 0 } : new byte[0];
-
-        int count = encoding.GetByteCount(text);
-        byte[] buffer = new byte[count + (zeroTerminated ? 1 : 0)];
-
-        fixed (byte* bp = buffer)
-        fixed (char* ch = text)
-        {
-            encoding.GetBytes(ch, text.Length, bp, count);
+            catch (Exception ex)
+            {
+                // Yes, we swallow any exceptions. That may seem like code smell but this matches
+                // the behavior of the Clipboard class, Windows Forms controls, and native Scintilla.
+                Debug.Fail(ex.Message, ex.ToString());
+            }
         }
 
-        if (zeroTerminated)
-            buffer[buffer.Length - 1] = 0;
-
-        return buffer;
-    }
-
-    public static unsafe byte[] GetBytes(char[] text, int length, Encoding encoding, bool zeroTerminated)
-    {
-        fixed (char* cp = text)
+        private static unsafe void CopyRtf(Scintilla scintilla, StyleData[] styles, List<ArraySegment<byte>> styledSegments)
         {
-            int count = encoding.GetByteCount(cp, length);
+            // NppExport -> NppExport.cpp
+            // NppExport -> RTFExporter.cpp
+            // http://en.wikipedia.org/wiki/Rich_Text_Format
+            // https://msdn.microsoft.com/en-us/library/windows/desktop/ms649013.aspx
+            // http://forums.codeguru.com/showthread.php?242982-Converting-pixels-to-twips
+            // http://en.wikipedia.org/wiki/UTF-8
+
+            try
+            {
+                // Calculate twips per space
+                int twips;
+                FontStyle fontStyle = FontStyle.Regular;
+                if (styles[Style.Default].Weight >= 700)
+                    fontStyle |= FontStyle.Bold;
+                if (styles[Style.Default].Italic != 0)
+                    fontStyle |= FontStyle.Italic;
+                if (styles[Style.Default].Underline != 0)
+                    fontStyle |= FontStyle.Underline;
+
+                using (Graphics graphics = scintilla.CreateGraphics())
+                using (var font = new Font(styles[Style.Default].FontName, styles[Style.Default].SizeF, fontStyle))
+                {
+                    float width = graphics.MeasureString(" ", font).Width;
+                    twips = (int)(width / graphics.DpiX * 1440);
+                    // TODO The twips value calculated seems too small on my computer
+                }
+
+                // Write RTF
+                using (var ms = new NativeMemoryStream(styledSegments.Sum(s => s.Count)))
+                {
+                    using (var tw = new StreamWriter(ms, Encoding.ASCII))
+                    {
+                        int tabWidth = scintilla.DirectMessage(NativeMethods.SCI_GETTABWIDTH).ToInt32();
+                        int deftab = tabWidth * twips;
+
+                        tw.WriteLine(@"{{\rtf1\ansi\deff0\deftab{0}", deftab);
+                        tw.Flush();
+
+                        // Build the font table
+                        tw.Write(@"{\fonttbl");
+                        tw.Write(@"{{\f0 {0};}}", styles[Style.Default].FontName);
+                        int fontIndex = 1;
+                        for (int i = 0; i < styles.Length; i++)
+                        {
+                            if (!styles[i].Used)
+                                continue;
+
+                            if (i == Style.Default)
+                                continue;
+
+                            // Not a completely unique list, but close enough
+                            if (styles[i].FontName != styles[Style.Default].FontName)
+                            {
+                                styles[i].FontIndex = fontIndex++;
+                                tw.Write(@"{{\f{0} {1};}}", styles[i].FontIndex, styles[i].FontName);
+                            }
+                        }
+
+                        tw.WriteLine("}"); // fonttbl
+                        tw.Flush();
+
+                        // Build the color table
+                        tw.Write(@"{\colortbl");
+                        tw.Write(@"\red{0}\green{1}\blue{2};", (styles[Style.Default].ForeColor >> 0) & 0xFF, (styles[Style.Default].ForeColor >> 8) & 0xFF, (styles[Style.Default].ForeColor >> 16) & 0xFF);
+                        tw.Write(@"\red{0}\green{1}\blue{2};", (styles[Style.Default].BackColor >> 0) & 0xFF, (styles[Style.Default].BackColor >> 8) & 0xFF, (styles[Style.Default].BackColor >> 16) & 0xFF);
+                        styles[Style.Default].ForeColorIndex = 0;
+                        styles[Style.Default].BackColorIndex = 1;
+                        int colorIndex = 2;
+                        for (int i = 0; i < styles.Length; i++)
+                        {
+                            if (!styles[i].Used)
+                                continue;
+
+                            if (i == Style.Default)
+                                continue;
+
+                            // Not a completely unique list, but close enough
+                            if (styles[i].ForeColor != styles[Style.Default].ForeColor)
+                            {
+                                styles[i].ForeColorIndex = colorIndex++;
+                                tw.Write(@"\red{0}\green{1}\blue{2};", (styles[i].ForeColor >> 0) & 0xFF, (styles[i].ForeColor >> 8) & 0xFF, (styles[i].ForeColor >> 16) & 0xFF);
+                            }
+                            else
+                            {
+                                styles[i].ForeColorIndex = styles[Style.Default].ForeColorIndex;
+                            }
+
+                            if (styles[i].BackColor != styles[Style.Default].BackColor)
+                            {
+                                styles[i].BackColorIndex = colorIndex++;
+                                tw.Write(@"\red{0}\green{1}\blue{2};", (styles[i].BackColor >> 0) & 0xFF, (styles[i].BackColor >> 8) & 0xFF, (styles[i].BackColor >> 16) & 0xFF);
+                            }
+                            else
+                            {
+                                styles[i].BackColorIndex = styles[Style.Default].BackColorIndex;
+                            }
+                        }
+
+                        tw.WriteLine("}"); // colortbl
+                        tw.Flush();
+
+                        // Start with the default style
+                        tw.Write(@"\f{0}\fs{1}\cf{2}\chshdng0\chcbpat{3}\cb{3} ", styles[Style.Default].FontIndex, (int)(styles[Style.Default].SizeF * 2), styles[Style.Default].ForeColorIndex, styles[Style.Default].BackColorIndex);
+                        if (styles[Style.Default].Italic != 0)
+                            tw.Write(@"\i");
+                        if (styles[Style.Default].Underline != 0)
+                            tw.Write(@"\ul");
+                        if (styles[Style.Default].Weight >= 700)
+                            tw.Write(@"\b");
+
+                        tw.AutoFlush = true;
+                        int lastStyle = Style.Default;
+                        bool unicodeLineEndings = (scintilla.DirectMessage(NativeMethods.SCI_GETLINEENDTYPESACTIVE).ToInt32() & NativeMethods.SC_LINE_END_TYPE_UNICODE) > 0;
+                        foreach (ArraySegment<byte> seg in styledSegments)
+                        {
+                            int endOffset = seg.Offset + seg.Count;
+                            for (int i = seg.Offset; i < endOffset; i += 2)
+                            {
+                                byte ch = seg.Array[i];
+                                byte style = seg.Array[i + 1];
+
+                                if (lastStyle != style)
+                                {
+                                    // Change the style
+                                    if (styles[lastStyle].FontIndex != styles[style].FontIndex)
+                                        tw.Write(@"\f{0}", styles[style].FontIndex);
+                                    if (styles[lastStyle].SizeF != styles[style].SizeF)
+                                        tw.Write(@"\fs{0}", (int)(styles[style].SizeF * 2));
+                                    if (styles[lastStyle].ForeColorIndex != styles[style].ForeColorIndex)
+                                        tw.Write(@"\cf{0}", styles[style].ForeColorIndex);
+                                    if (styles[lastStyle].BackColorIndex != styles[style].BackColorIndex)
+                                        tw.Write(@"\chshdng0\chcbpat{0}\cb{0}", styles[style].BackColorIndex);
+                                    if (styles[lastStyle].Italic != styles[style].Italic)
+                                        tw.Write(@"\i{0}", styles[style].Italic != 0 ? "" : "0");
+                                    if (styles[lastStyle].Underline != styles[style].Underline)
+                                        tw.Write(@"\ul{0}", styles[style].Underline != 0 ? "" : "0");
+                                    if (styles[lastStyle].Weight != styles[style].Weight)
+                                    {
+                                        if (styles[style].Weight >= 700 && styles[lastStyle].Weight < 700)
+                                            tw.Write(@"\b");
+                                        else if (styles[style].Weight < 700 && styles[lastStyle].Weight >= 700)
+                                            tw.Write(@"\b0");
+                                    }
+
+                                    // NOTE: We don't support StyleData.Visible and StyleData.Case in RTF
+
+                                    lastStyle = style;
+                                    tw.Write("\n"); // Delimiter
+                                }
+
+                                switch (ch)
+                                {
+                                    case (byte)'{':
+                                        tw.Write(@"\{");
+                                        break;
+
+                                    case (byte)'}':
+                                        tw.Write(@"\}");
+                                        break;
+
+                                    case (byte)'\\':
+                                        tw.Write(@"\\");
+                                        break;
+
+                                    case (byte)'\t':
+                                        tw.Write(@"\tab ");
+                                        break;
+
+                                    case (byte)'\r':
+                                        if (i + 2 < endOffset)
+                                        {
+                                            if (seg.Array[i + 2] == (byte)'\n')
+                                                i += 2;
+                                        }
+
+                                        // Either way, this is a line break
+                                        goto case (byte)'\n';
+
+                                    case 0xC2:
+                                        if (unicodeLineEndings && i + 2 < endOffset)
+                                        {
+                                            if (seg.Array[i + 2] == 0x85) // NEL \u0085
+                                            {
+                                                i += 2;
+                                                goto case (byte)'\n';
+                                            }
+                                        }
+
+                                        // Not a Unicode line break
+                                        goto default;
+
+                                    case 0xE2:
+                                        if (unicodeLineEndings && i + 4 < endOffset)
+                                        {
+                                            if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA8) // LS \u2028
+                                            {
+                                                i += 4;
+                                                goto case (byte)'\n';
+                                            }
+                                            else if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA9) // PS \u2029
+                                            {
+                                                i += 4;
+                                                goto case (byte)'\n';
+                                            }
+                                        }
+
+                                        // Not a Unicode line break
+                                        goto default;
+
+                                    case (byte)'\n':
+                                        // All your line breaks are belong to us
+                                        tw.WriteLine(@"\par");
+                                        break;
+
+                                    default:
+
+                                        if (ch == 0)
+                                        {
+                                            // Scintilla behavior is to allow control characters except for
+                                            // NULL which will cause the Clipboard to truncate the string.
+                                            tw.Write(" "); // Replace with space
+                                            break;
+                                        }
+
+                                        if (ch > 0x7F)
+                                        {
+                                            // Treat as UTF-8 code point
+                                            int unicode = 0;
+                                            if (ch < 0xE0 && i + 2 < endOffset)
+                                            {
+                                                unicode |= (0x1F & ch) << 6;
+                                                unicode |= 0x3F & seg.Array[i + 2];
+                                                tw.Write(@"\u{0}?", unicode);
+                                                i += 2;
+                                                break;
+                                            }
+                                            else if (ch < 0xF0 && i + 4 < endOffset)
+                                            {
+                                                unicode |= (0xF & ch) << 12;
+                                                unicode |= (0x3F & seg.Array[i + 2]) << 6;
+                                                unicode |= 0x3F & seg.Array[i + 4];
+                                                tw.Write(@"\u{0}?", unicode);
+                                                i += 4;
+                                                break;
+                                            }
+                                            else if (ch < 0xF8 && i + 6 < endOffset)
+                                            {
+                                                unicode |= (0x7 & ch) << 18;
+                                                unicode |= (0x3F & seg.Array[i + 2]) << 12;
+                                                unicode |= (0x3F & seg.Array[i + 4]) << 6;
+                                                unicode |= 0x3F & seg.Array[i + 6];
+                                                tw.Write(@"\u{0}?", unicode);
+                                                i += 6;
+                                                break;
+                                            }
+                                        }
+
+                                        // Regular ANSI char
+                                        ms.WriteByte(ch);
+                                        break;
+                                }
+                            }
+                        }
+
+                        tw.AutoFlush = false;
+                        tw.WriteLine("}"); // rtf1
+                        tw.Flush();
+
+                        // Terminator
+                        ms.WriteByte(0);
+
+                        // var str = GetString(ms.Pointer, (int)ms.Length, Encoding.ASCII);
+                        if (NativeMethods.SetClipboardData(CF_RTF, ms.Pointer) != IntPtr.Zero)
+                            ms.FreeOnDispose = false; // Clipboard will free memory
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Yes, we swallow any exceptions. That may seem like code smell but this matches
+                // the behavior of the Clipboard class, Windows Forms controls, and native Scintilla.
+                Debug.Fail(ex.Message, ex.ToString());
+            }
+        }
+
+        public static unsafe byte[] GetBytes(string text, Encoding encoding, bool zeroTerminated)
+        {
+            if (string.IsNullOrEmpty(text))
+                return zeroTerminated ? new byte[] { 0 } : new byte[0];
+
+            int count = encoding.GetByteCount(text);
             byte[] buffer = new byte[count + (zeroTerminated ? 1 : 0)];
+
             fixed (byte* bp = buffer)
-                encoding.GetBytes(cp, length, bp, buffer.Length);
+            fixed (char* ch = text)
+            {
+                encoding.GetBytes(ch, text.Length, bp, count);
+            }
 
             if (zeroTerminated)
                 buffer[buffer.Length - 1] = 0;
 
             return buffer;
         }
-    }
 
-    public static string GetHtml(Scintilla scintilla, int startBytePos, int endBytePos)
-    {
-        // If we ever allow more than UTF-8, this will have to be revisited
-        Debug.Assert(scintilla.DirectMessage(NativeMethods.SCI_GETCODEPAGE).ToInt32() == NativeMethods.SC_CP_UTF8);
-
-        if (startBytePos == endBytePos)
-            return string.Empty;
-
-        List<ArraySegment<byte>> styledSegments = GetStyledSegments(scintilla, false, false, startBytePos, endBytePos, out StyleData[] styles);
-
-        using var ms = new NativeMemoryStream(styledSegments.Sum(s => s.Count)); // Hint
-        using var sw = new StreamWriter(ms, new UTF8Encoding(false));
-        // Write the styles
-        sw.WriteLine(@"<style type=""text/css"" scoped="""">");
-        sw.Write("div#segments {");
-        sw.Write(" float: left;");
-        sw.Write(" white-space: pre;");
-        sw.Write(" line-height: {0}px;", scintilla.DirectMessage(NativeMethods.SCI_TEXTHEIGHT, new IntPtr(0)).ToInt32());
-        sw.Write(" background-color: #{0:X2}{1:X2}{2:X2};", (styles[Style.Default].BackColor >> 0) & 0xFF, (styles[Style.Default].BackColor >> 8) & 0xFF, (styles[Style.Default].BackColor >> 16) & 0xFF);
-        sw.WriteLine(" }");
-
-        for (int i = 0; i < styles.Length; i++)
+        public static unsafe byte[] GetBytes(char[] text, int length, Encoding encoding, bool zeroTerminated)
         {
-            if (!styles[i].Used)
-                continue;
-
-            sw.Write("span.s{0} {{", i);
-            sw.Write(@" font-family: ""{0}"";", styles[i].FontName);
-            sw.Write(" font-size: {0}pt;", styles[i].SizeF);
-            sw.Write(" font-weight: {0};", styles[i].Weight);
-            if (styles[i].Italic != 0)
-                sw.Write(" font-style: italic;");
-            if (styles[i].Underline != 0)
-                sw.Write(" text-decoration: underline;");
-            sw.Write(" background-color: #{0:X2}{1:X2}{2:X2};", (styles[i].BackColor >> 0) & 0xFF, (styles[i].BackColor >> 8) & 0xFF, (styles[i].BackColor >> 16) & 0xFF);
-            sw.Write(" color: #{0:X2}{1:X2}{2:X2};", (styles[i].ForeColor >> 0) & 0xFF, (styles[i].ForeColor >> 8) & 0xFF, (styles[i].ForeColor >> 16) & 0xFF);
-            switch ((StyleCase)styles[i].Case)
+            fixed (char* cp = text)
             {
-                case StyleCase.Upper:
-                    sw.Write(" text-transform: uppercase;");
-                    break;
-                case StyleCase.Lower:
-                    sw.Write(" text-transform: lowercase;");
-                    break;
-            }
+                int count = encoding.GetByteCount(cp, length);
+                byte[] buffer = new byte[count + (zeroTerminated ? 1 : 0)];
+                fixed (byte* bp = buffer)
+                    encoding.GetBytes(cp, length, bp, buffer.Length);
 
-            if (styles[i].Visible == 0)
-                sw.Write(" visibility: hidden;");
+                if (zeroTerminated)
+                    buffer[buffer.Length - 1] = 0;
 
-            sw.WriteLine(" }");
-        }
-
-        sw.WriteLine("</style>");
-
-        bool unicodeLineEndings = (scintilla.DirectMessage(NativeMethods.SCI_GETLINEENDTYPESACTIVE).ToInt32() & NativeMethods.SC_LINE_END_TYPE_UNICODE) > 0;
-        int tabSize = scintilla.DirectMessage(NativeMethods.SCI_GETTABWIDTH).ToInt32();
-        string tab = new(' ', tabSize);
-        int lastStyle = Style.Default;
-
-        // Write the styled text
-        sw.Write(@"<div id=""segments""><span class=""s{0}"">", Style.Default);
-        sw.Flush();
-        sw.AutoFlush = true;
-
-        foreach (ArraySegment<byte> seg in styledSegments)
-        {
-            int endOffset = seg.Offset + seg.Count;
-            for (int i = seg.Offset; i < endOffset; i += 2)
-            {
-                byte ch = seg.Array[i];
-                byte style = seg.Array[i + 1];
-
-                if (lastStyle != style)
-                {
-                    sw.Write(@"</span><span class=""s{0}"">", style);
-                    lastStyle = style;
-                }
-
-                switch (ch)
-                {
-                    case (byte)'<':
-                        sw.Write("&lt;");
-                        break;
-
-                    case (byte)'>':
-                        sw.Write("&gt;");
-                        break;
-
-                    case (byte)'&':
-                        sw.Write("&amp;");
-                        break;
-
-                    case (byte)'\t':
-                        sw.Write(tab);
-                        break;
-
-                    case (byte)'\r':
-                        if (i + 2 < endOffset)
-                        {
-                            if (seg.Array[i + 2] == (byte)'\n')
-                                i += 2;
-                        }
-
-                        // Either way, this is a line break
-                        goto case (byte)'\n';
-
-                    case 0xC2:
-                        if (unicodeLineEndings && i + 2 < endOffset)
-                        {
-                            if (seg.Array[i + 2] == 0x85) // NEL \u0085
-                            {
-                                i += 2;
-                                goto case (byte)'\n';
-                            }
-                        }
-
-                        // Not a Unicode line break
-                        goto default;
-
-                    case 0xE2:
-                        if (unicodeLineEndings && i + 4 < endOffset)
-                        {
-                            if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA8) // LS \u2028
-                            {
-                                i += 4;
-                                goto case (byte)'\n';
-                            }
-                            else if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA9) // PS \u2029
-                            {
-                                i += 4;
-                                goto case (byte)'\n';
-                            }
-                        }
-
-                        // Not a Unicode line break
-                        goto default;
-
-                    case (byte)'\n':
-                        // All your line breaks are belong to us
-                        sw.Write("\r\n");
-                        break;
-
-                    default:
-
-                        if (ch == 0)
-                        {
-                            // Replace NUL with space
-                            sw.Write(" ");
-                            break;
-                        }
-
-                        ms.WriteByte(ch);
-                        break;
-                }
+                return buffer;
             }
         }
 
-        sw.AutoFlush = false;
-        sw.WriteLine("</span></div>");
-        sw.Flush();
-
-        return GetString(ms.Pointer, (int)ms.Length, Encoding.UTF8);
-    }
-
-    public static unsafe string GetString(IntPtr bytes, int length, Encoding encoding)
-    {
-        sbyte* ptr = (sbyte*)bytes;
-        string str = new(ptr, 0, length, encoding);
-
-        return str;
-    }
-
-    private static unsafe List<ArraySegment<byte>> GetStyledSegments(Scintilla scintilla, bool currentSelection, bool currentLine, int startBytePos, int endBytePos, out StyleData[] styles)
-    {
-        var segments = new List<ArraySegment<byte>>();
-        if (currentSelection)
+        public static string GetHtml(Scintilla scintilla, int startBytePos, int endBytePos)
         {
-            // Get each selection as a segment.
-            // Rectangular selections are ordered top to bottom and have line breaks appended.
-            var ranges = new List<Tuple<int, int>>();
-            int selCount = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONS).ToInt32();
-            for (int i = 0; i < selCount; i++)
-            {
-                int selStartBytePos = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNSTART, new IntPtr(i)).ToInt32();
-                int selEndBytePos = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNEND, new IntPtr(i)).ToInt32();
+            // If we ever allow more than UTF-8, this will have to be revisited
+            Debug.Assert(scintilla.DirectMessage(NativeMethods.SCI_GETCODEPAGE).ToInt32() == NativeMethods.SC_CP_UTF8);
 
-                ranges.Add(Tuple.Create(selStartBytePos, selEndBytePos));
+            if (startBytePos == endBytePos)
+                return string.Empty;
+
+            List<ArraySegment<byte>> styledSegments = GetStyledSegments(scintilla, false, false, startBytePos, endBytePos, out StyleData[] styles);
+
+            using (var ms = new NativeMemoryStream(styledSegments.Sum(s => s.Count))) // Hint
+            {
+                using (var sw = new StreamWriter(ms, new UTF8Encoding(false)))
+                {
+                    // Write the styles
+                    sw.WriteLine(@"<style type=""text/css"" scoped="""">");
+                    sw.Write("div#segments {");
+                    sw.Write(" float: left;");
+                    sw.Write(" white-space: pre;");
+                    sw.Write(" line-height: {0}px;", scintilla.DirectMessage(NativeMethods.SCI_TEXTHEIGHT, new IntPtr(0)).ToInt32());
+                    sw.Write(" background-color: #{0:X2}{1:X2}{2:X2};", (styles[Style.Default].BackColor >> 0) & 0xFF, (styles[Style.Default].BackColor >> 8) & 0xFF, (styles[Style.Default].BackColor >> 16) & 0xFF);
+                    sw.WriteLine(" }");
+
+                    for (int i = 0; i < styles.Length; i++)
+                    {
+                        if (!styles[i].Used)
+                            continue;
+
+                        sw.Write("span.s{0} {{", i);
+                        sw.Write(@" font-family: ""{0}"";", styles[i].FontName);
+                        sw.Write(" font-size: {0}pt;", styles[i].SizeF);
+                        sw.Write(" font-weight: {0};", styles[i].Weight);
+                        if (styles[i].Italic != 0)
+                            sw.Write(" font-style: italic;");
+                        if (styles[i].Underline != 0)
+                            sw.Write(" text-decoration: underline;");
+                        sw.Write(" background-color: #{0:X2}{1:X2}{2:X2};", (styles[i].BackColor >> 0) & 0xFF, (styles[i].BackColor >> 8) & 0xFF, (styles[i].BackColor >> 16) & 0xFF);
+                        sw.Write(" color: #{0:X2}{1:X2}{2:X2};", (styles[i].ForeColor >> 0) & 0xFF, (styles[i].ForeColor >> 8) & 0xFF, (styles[i].ForeColor >> 16) & 0xFF);
+                        switch ((StyleCase)styles[i].Case)
+                        {
+                            case StyleCase.Upper:
+                                sw.Write(" text-transform: uppercase;");
+                                break;
+                            case StyleCase.Lower:
+                                sw.Write(" text-transform: lowercase;");
+                                break;
+                        }
+
+                        if (styles[i].Visible == 0)
+                            sw.Write(" visibility: hidden;");
+
+                        sw.WriteLine(" }");
+                    }
+
+                    sw.WriteLine("</style>");
+
+                    bool unicodeLineEndings = (scintilla.DirectMessage(NativeMethods.SCI_GETLINEENDTYPESACTIVE).ToInt32() & NativeMethods.SC_LINE_END_TYPE_UNICODE) > 0;
+                    int tabSize = scintilla.DirectMessage(NativeMethods.SCI_GETTABWIDTH).ToInt32();
+                    string tab = new string(' ', tabSize);
+                    int lastStyle = Style.Default;
+
+                    // Write the styled text
+                    sw.Write(@"<div id=""segments""><span class=""s{0}"">", Style.Default);
+                    sw.Flush();
+                    sw.AutoFlush = true;
+
+                    foreach (ArraySegment<byte> seg in styledSegments)
+                    {
+                        int endOffset = seg.Offset + seg.Count;
+                        for (int i = seg.Offset; i < endOffset; i += 2)
+                        {
+                            byte ch = seg.Array[i];
+                            byte style = seg.Array[i + 1];
+
+                            if (lastStyle != style)
+                            {
+                                sw.Write(@"</span><span class=""s{0}"">", style);
+                                lastStyle = style;
+                            }
+
+                            switch (ch)
+                            {
+                                case (byte)'<':
+                                    sw.Write("&lt;");
+                                    break;
+
+                                case (byte)'>':
+                                    sw.Write("&gt;");
+                                    break;
+
+                                case (byte)'&':
+                                    sw.Write("&amp;");
+                                    break;
+
+                                case (byte)'\t':
+                                    sw.Write(tab);
+                                    break;
+
+                                case (byte)'\r':
+                                    if (i + 2 < endOffset)
+                                    {
+                                        if (seg.Array[i + 2] == (byte)'\n')
+                                            i += 2;
+                                    }
+
+                                    // Either way, this is a line break
+                                    goto case (byte)'\n';
+
+                                case 0xC2:
+                                    if (unicodeLineEndings && i + 2 < endOffset)
+                                    {
+                                        if (seg.Array[i + 2] == 0x85) // NEL \u0085
+                                        {
+                                            i += 2;
+                                            goto case (byte)'\n';
+                                        }
+                                    }
+
+                                    // Not a Unicode line break
+                                    goto default;
+
+                                case 0xE2:
+                                    if (unicodeLineEndings && i + 4 < endOffset)
+                                    {
+                                        if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA8) // LS \u2028
+                                        {
+                                            i += 4;
+                                            goto case (byte)'\n';
+                                        }
+                                        else if (seg.Array[i + 2] == 0x80 && seg.Array[i + 4] == 0xA9) // PS \u2029
+                                        {
+                                            i += 4;
+                                            goto case (byte)'\n';
+                                        }
+                                    }
+
+                                    // Not a Unicode line break
+                                    goto default;
+
+                                case (byte)'\n':
+                                    // All your line breaks are belong to us
+                                    sw.Write("\r\n");
+                                    break;
+
+                                default:
+
+                                    if (ch == 0)
+                                    {
+                                        // Replace NUL with space
+                                        sw.Write(" ");
+                                        break;
+                                    }
+
+                                    ms.WriteByte(ch);
+                                    break;
+                            }
+                        }
+                    }
+
+                    sw.AutoFlush = false;
+                    sw.WriteLine("</span></div>");
+                    sw.Flush();
+
+                    return GetString(ms.Pointer, (int)ms.Length, Encoding.UTF8);
+                }
             }
+        }
 
-            bool selIsRect = scintilla.DirectMessage(NativeMethods.SCI_SELECTIONISRECTANGLE) != IntPtr.Zero;
-            if (selIsRect)
-                ranges.OrderBy(r => r.Item1); // Sort top to bottom
+        public static unsafe string GetString(IntPtr bytes, int length, Encoding encoding)
+        {
+            sbyte* ptr = (sbyte*)bytes;
+            string str = new string(ptr, 0, length, encoding);
 
-            foreach (Tuple<int, int> range in ranges)
+            return str;
+        }
+
+        private static unsafe List<ArraySegment<byte>> GetStyledSegments(Scintilla scintilla, bool currentSelection, bool currentLine, int startBytePos, int endBytePos, out StyleData[] styles)
+        {
+            var segments = new List<ArraySegment<byte>>();
+            if (currentSelection)
             {
-                ArraySegment<byte> styledText = GetStyledText(scintilla, range.Item1, range.Item2, selIsRect);
+                // Get each selection as a segment.
+                // Rectangular selections are ordered top to bottom and have line breaks appended.
+                var ranges = new List<Tuple<int, int>>();
+                int selCount = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONS).ToInt32();
+                for (int i = 0; i < selCount; i++)
+                {
+                    int selStartBytePos = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNSTART, new IntPtr(i)).ToInt32();
+                    int selEndBytePos = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNEND, new IntPtr(i)).ToInt32();
+
+                    ranges.Add(Tuple.Create(selStartBytePos, selEndBytePos));
+                }
+
+                bool selIsRect = scintilla.DirectMessage(NativeMethods.SCI_SELECTIONISRECTANGLE) != IntPtr.Zero;
+                if (selIsRect)
+                    ranges.OrderBy(r => r.Item1); // Sort top to bottom
+
+                foreach (Tuple<int, int> range in ranges)
+                {
+                    ArraySegment<byte> styledText = GetStyledText(scintilla, range.Item1, range.Item2, selIsRect);
+                    segments.Add(styledText);
+                }
+            }
+            else if (currentLine)
+            {
+                // Get the current line
+                int mainSelection = scintilla.DirectMessage(NativeMethods.SCI_GETMAINSELECTION).ToInt32();
+                int mainCaretPos = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNCARET, new IntPtr(mainSelection)).ToInt32();
+                int lineIndex = scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, new IntPtr(mainCaretPos)).ToInt32();
+                int lineStartBytePos = scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(lineIndex)).ToInt32();
+                int lineLength = scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(lineIndex)).ToInt32();
+
+                ArraySegment<byte> styledText = GetStyledText(scintilla, lineStartBytePos, lineStartBytePos + lineLength, false);
                 segments.Add(styledText);
             }
-        }
-        else if (currentLine)
-        {
-            // Get the current line
-            int mainSelection = scintilla.DirectMessage(NativeMethods.SCI_GETMAINSELECTION).ToInt32();
-            int mainCaretPos = scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNCARET, new IntPtr(mainSelection)).ToInt32();
-            int lineIndex = scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, new IntPtr(mainCaretPos)).ToInt32();
-            int lineStartBytePos = scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(lineIndex)).ToInt32();
-            int lineLength = scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(lineIndex)).ToInt32();
-
-            ArraySegment<byte> styledText = GetStyledText(scintilla, lineStartBytePos, lineStartBytePos + lineLength, false);
-            segments.Add(styledText);
-        }
-        else // User-specified range
-        {
-            Debug.Assert(startBytePos != endBytePos);
-            ArraySegment<byte> styledText = GetStyledText(scintilla, startBytePos, endBytePos, false);
-            segments.Add(styledText);
-        }
-
-        // Build a list of (used) styles
-        styles = new StyleData[NativeMethods.STYLE_MAX + 1];
-
-        styles[Style.Default].Used = true;
-        styles[Style.Default].FontName = scintilla.Styles[Style.Default].Font;
-        styles[Style.Default].SizeF = scintilla.Styles[Style.Default].SizeF;
-        styles[Style.Default].Weight = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETWEIGHT, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
-        styles[Style.Default].Italic = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETITALIC, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
-        styles[Style.Default].Underline = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETUNDERLINE, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
-        styles[Style.Default].BackColor = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETBACK, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
-        styles[Style.Default].ForeColor = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFORE, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
-        styles[Style.Default].Case = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETCASE, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
-        styles[Style.Default].Visible = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETVISIBLE, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
-
-        foreach (ArraySegment<byte> seg in segments)
-        {
-            for (int i = 0; i < seg.Count; i += 2)
+            else // User-specified range
             {
-                byte style = seg.Array[i + 1];
-                if (!styles[style].Used)
+                Debug.Assert(startBytePos != endBytePos);
+                ArraySegment<byte> styledText = GetStyledText(scintilla, startBytePos, endBytePos, false);
+                segments.Add(styledText);
+            }
+
+            // Build a list of (used) styles
+            styles = new StyleData[NativeMethods.STYLE_MAX + 1];
+
+            styles[Style.Default].Used = true;
+            styles[Style.Default].FontName = scintilla.Styles[Style.Default].Font;
+            styles[Style.Default].SizeF = scintilla.Styles[Style.Default].SizeF;
+            styles[Style.Default].Weight = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETWEIGHT, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
+            styles[Style.Default].Italic = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETITALIC, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
+            styles[Style.Default].Underline = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETUNDERLINE, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
+            styles[Style.Default].BackColor = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETBACK, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
+            styles[Style.Default].ForeColor = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFORE, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
+            styles[Style.Default].Case = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETCASE, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
+            styles[Style.Default].Visible = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETVISIBLE, new IntPtr(Style.Default), IntPtr.Zero).ToInt32();
+
+            foreach (ArraySegment<byte> seg in segments)
+            {
+                for (int i = 0; i < seg.Count; i += 2)
                 {
-                    styles[style].Used = true;
-                    styles[style].FontName = scintilla.Styles[style].Font;
-                    styles[style].SizeF = scintilla.Styles[style].SizeF;
-                    styles[style].Weight = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETWEIGHT, new IntPtr(style), IntPtr.Zero).ToInt32();
-                    styles[style].Italic = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETITALIC, new IntPtr(style), IntPtr.Zero).ToInt32();
-                    styles[style].Underline = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETUNDERLINE, new IntPtr(style), IntPtr.Zero).ToInt32();
-                    styles[style].BackColor = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETBACK, new IntPtr(style), IntPtr.Zero).ToInt32();
-                    styles[style].ForeColor = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFORE, new IntPtr(style), IntPtr.Zero).ToInt32();
-                    styles[style].Case = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETCASE, new IntPtr(style), IntPtr.Zero).ToInt32();
-                    styles[style].Visible = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETVISIBLE, new IntPtr(style), IntPtr.Zero).ToInt32();
+                    byte style = seg.Array[i + 1];
+                    if (!styles[style].Used)
+                    {
+                        styles[style].Used = true;
+                        styles[style].FontName = scintilla.Styles[style].Font;
+                        styles[style].SizeF = scintilla.Styles[style].SizeF;
+                        styles[style].Weight = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETWEIGHT, new IntPtr(style), IntPtr.Zero).ToInt32();
+                        styles[style].Italic = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETITALIC, new IntPtr(style), IntPtr.Zero).ToInt32();
+                        styles[style].Underline = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETUNDERLINE, new IntPtr(style), IntPtr.Zero).ToInt32();
+                        styles[style].BackColor = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETBACK, new IntPtr(style), IntPtr.Zero).ToInt32();
+                        styles[style].ForeColor = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFORE, new IntPtr(style), IntPtr.Zero).ToInt32();
+                        styles[style].Case = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETCASE, new IntPtr(style), IntPtr.Zero).ToInt32();
+                        styles[style].Visible = scintilla.DirectMessage(NativeMethods.SCI_STYLEGETVISIBLE, new IntPtr(style), IntPtr.Zero).ToInt32();
+                    }
                 }
             }
+
+            return segments;
         }
 
-        return segments;
-    }
-
-    private static unsafe ArraySegment<byte> GetStyledText(Scintilla scintilla, int startBytePos, int endBytePos, bool addLineBreak)
-    {
-        Debug.Assert(endBytePos > startBytePos);
-
-        // Make sure the range is styled
-        scintilla.DirectMessage(NativeMethods.SCI_COLOURISE, new IntPtr(startBytePos), new IntPtr(endBytePos));
-
-        int byteLength = endBytePos - startBytePos;
-        byte[] buffer = new byte[byteLength * 2 + (addLineBreak ? 4 : 0) + 2];
-        fixed (byte* bp = buffer)
+        private static unsafe ArraySegment<byte> GetStyledText(Scintilla scintilla, int startBytePos, int endBytePos, bool addLineBreak)
         {
-            NativeMethods.Sci_TextRange* tr = stackalloc NativeMethods.Sci_TextRange[1];
-            tr->chrg.cpMin = startBytePos;
-            tr->chrg.cpMax = endBytePos;
-            tr->lpstrText = new IntPtr(bp);
+            Debug.Assert(endBytePos > startBytePos);
 
-            scintilla.DirectMessage(NativeMethods.SCI_GETSTYLEDTEXT, IntPtr.Zero, new IntPtr(tr));
-            byteLength *= 2;
-        }
+            // Make sure the range is styled
+            scintilla.DirectMessage(NativeMethods.SCI_COLOURISE, new IntPtr(startBytePos), new IntPtr(endBytePos));
 
-        // Add a line break?
-        // We do this when this range is part of a rectangular selection.
-        if (addLineBreak)
-        {
-            byte style = buffer[byteLength - 1];
-
-            buffer[byteLength++] = (byte)'\r';
-            buffer[byteLength++] = style;
-            buffer[byteLength++] = (byte)'\n';
-            buffer[byteLength++] = style;
-
-            // Fix-up the NULL terminator just in case
-            buffer[byteLength] = 0;
-            buffer[byteLength + 1] = 0;
-        }
-
-        return new ArraySegment<byte>(buffer, 0, byteLength);
-    }
-
-    public static int TranslateKeys(Keys keys)
-    {
-        int keyCode;
-
-        // For some reason Scintilla uses different values for these keys...
-        switch (keys & Keys.KeyCode)
-        {
-            case Keys.Down:
-                keyCode = NativeMethods.SCK_DOWN;
-                break;
-            case Keys.Up:
-                keyCode = NativeMethods.SCK_UP;
-                break;
-            case Keys.Left:
-                keyCode = NativeMethods.SCK_LEFT;
-                break;
-            case Keys.Right:
-                keyCode = NativeMethods.SCK_RIGHT;
-                break;
-            case Keys.Home:
-                keyCode = NativeMethods.SCK_HOME;
-                break;
-            case Keys.End:
-                keyCode = NativeMethods.SCK_END;
-                break;
-            case Keys.Prior:
-                keyCode = NativeMethods.SCK_PRIOR;
-                break;
-            case Keys.Next:
-                keyCode = NativeMethods.SCK_NEXT;
-                break;
-            case Keys.Delete:
-                keyCode = NativeMethods.SCK_DELETE;
-                break;
-            case Keys.Insert:
-                keyCode = NativeMethods.SCK_INSERT;
-                break;
-            case Keys.Escape:
-                keyCode = NativeMethods.SCK_ESCAPE;
-                break;
-            case Keys.Back:
-                keyCode = NativeMethods.SCK_BACK;
-                break;
-            case Keys.Tab:
-                keyCode = NativeMethods.SCK_TAB;
-                break;
-            case Keys.Return:
-                keyCode = NativeMethods.SCK_RETURN;
-                break;
-            case Keys.Add:
-                keyCode = NativeMethods.SCK_ADD;
-                break;
-            case Keys.Subtract:
-                keyCode = NativeMethods.SCK_SUBTRACT;
-                break;
-            case Keys.Divide:
-                keyCode = NativeMethods.SCK_DIVIDE;
-                break;
-            case Keys.LWin:
-                keyCode = NativeMethods.SCK_WIN;
-                break;
-            case Keys.RWin:
-                keyCode = NativeMethods.SCK_RWIN;
-                break;
-            case Keys.Apps:
-                keyCode = NativeMethods.SCK_MENU;
-                break;
-            case Keys.Oem2:
-                keyCode = (byte)'/';
-                break;
-            case Keys.Oem3:
-                keyCode = (byte)'`';
-                break;
-            case Keys.Oem4:
-                keyCode = '[';
-                break;
-            case Keys.Oem5:
-                keyCode = '\\';
-                break;
-            case Keys.Oem6:
-                keyCode = ']';
-                break;
-            default:
-                keyCode = (int)(keys & Keys.KeyCode);
-                break;
-        }
-
-        // No translation necessary for the modifiers. Just add them back in.
-        int keyDefinition = keyCode | (int)(keys & Keys.Modifiers);
-        return keyDefinition;
-    }
-
-    // https://stackoverflow.com/questions/2709430/count-number-of-bits-in-a-64-bit-long-big-integer/2709523#2709523
-    public static byte PopCount(ulong i)
-    {
-        i -= ((i >> 1) & 0x5555555555555555UL);
-        i = (i & 0x3333333333333333UL) + ((i >> 2) & 0x3333333333333333UL);
-        return (byte)((((i + (i >> 4)) & 0xF0F0F0F0F0F0F0FUL) * 0x101010101010101UL) >> 56);
-    }
-
-    public static int MaxIndex<TSource>(this IEnumerable<TSource> source) => MaxIndex(source, comparer: null);
-
-    /// <summary>Returns index of the maximum value in a generic sequence.</summary>
-    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
-    /// <param name="source">A sequence of values to determine the index of the maximum value of.</param>
-    /// <param name="comparer">The <see cref="IComparer{T}" /> to compare values.</param>
-    /// <returns>The index of the maximum value in the sequence.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">No object in <paramref name="source" /> implements the <see cref="System.IComparable" /> or <see cref="System.IComparable{T}" /> interface.</exception>
-    /// <remarks>
-    /// <para>If type <typeparamref name="TSource" /> implements <see cref="System.IComparable{T}" />, the <see cref="MaxIndex{T}(IEnumerable{T})" /> method uses that implementation to compare values. Otherwise, if type <typeparamref name="TSource" /> implements <see cref="System.IComparable" />, that implementation is used to compare values.</para>
-    /// <para>If <typeparamref name="TSource" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns -1.</para>
-    /// </remarks>
-    public static int MaxIndex<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, int> comparer)
-    {
-        if (source == null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        comparer ??= Comparer<TSource>.Default.Compare;
-
-        int index = -1;
-        int maxIndex = index;
-        TSource value = default;
-        using (IEnumerator<TSource> e = source.GetEnumerator())
-        {
-            if (value == null)
+            int byteLength = endBytePos - startBytePos;
+            byte[] buffer = new byte[byteLength * 2 + (addLineBreak ? 4 : 0) + 2];
+            fixed (byte* bp = buffer)
             {
-                do
+                NativeMethods.Sci_TextRange* tr = stackalloc NativeMethods.Sci_TextRange[1];
+                tr->chrg.cpMin = startBytePos;
+                tr->chrg.cpMax = endBytePos;
+                tr->lpstrText = new IntPtr(bp);
+
+                scintilla.DirectMessage(NativeMethods.SCI_GETSTYLEDTEXT, IntPtr.Zero, new IntPtr(tr));
+                byteLength *= 2;
+            }
+
+            // Add a line break?
+            // We do this when this range is part of a rectangular selection.
+            if (addLineBreak)
+            {
+                byte style = buffer[byteLength - 1];
+
+                buffer[byteLength++] = (byte)'\r';
+                buffer[byteLength++] = style;
+                buffer[byteLength++] = (byte)'\n';
+                buffer[byteLength++] = style;
+
+                // Fix-up the NULL terminator just in case
+                buffer[byteLength] = 0;
+                buffer[byteLength + 1] = 0;
+            }
+
+            return new ArraySegment<byte>(buffer, 0, byteLength);
+        }
+
+        public static int TranslateKeys(Keys keys)
+        {
+            int keyCode;
+
+            // For some reason Scintilla uses different values for these keys...
+            switch (keys & Keys.KeyCode)
+            {
+                case Keys.Down:
+                    keyCode = NativeMethods.SCK_DOWN;
+                    break;
+                case Keys.Up:
+                    keyCode = NativeMethods.SCK_UP;
+                    break;
+                case Keys.Left:
+                    keyCode = NativeMethods.SCK_LEFT;
+                    break;
+                case Keys.Right:
+                    keyCode = NativeMethods.SCK_RIGHT;
+                    break;
+                case Keys.Home:
+                    keyCode = NativeMethods.SCK_HOME;
+                    break;
+                case Keys.End:
+                    keyCode = NativeMethods.SCK_END;
+                    break;
+                case Keys.Prior:
+                    keyCode = NativeMethods.SCK_PRIOR;
+                    break;
+                case Keys.Next:
+                    keyCode = NativeMethods.SCK_NEXT;
+                    break;
+                case Keys.Delete:
+                    keyCode = NativeMethods.SCK_DELETE;
+                    break;
+                case Keys.Insert:
+                    keyCode = NativeMethods.SCK_INSERT;
+                    break;
+                case Keys.Escape:
+                    keyCode = NativeMethods.SCK_ESCAPE;
+                    break;
+                case Keys.Back:
+                    keyCode = NativeMethods.SCK_BACK;
+                    break;
+                case Keys.Tab:
+                    keyCode = NativeMethods.SCK_TAB;
+                    break;
+                case Keys.Return:
+                    keyCode = NativeMethods.SCK_RETURN;
+                    break;
+                case Keys.Add:
+                    keyCode = NativeMethods.SCK_ADD;
+                    break;
+                case Keys.Subtract:
+                    keyCode = NativeMethods.SCK_SUBTRACT;
+                    break;
+                case Keys.Divide:
+                    keyCode = NativeMethods.SCK_DIVIDE;
+                    break;
+                case Keys.LWin:
+                    keyCode = NativeMethods.SCK_WIN;
+                    break;
+                case Keys.RWin:
+                    keyCode = NativeMethods.SCK_RWIN;
+                    break;
+                case Keys.Apps:
+                    keyCode = NativeMethods.SCK_MENU;
+                    break;
+                case Keys.Oem2:
+                    keyCode = (byte)'/';
+                    break;
+                case Keys.Oem3:
+                    keyCode = (byte)'`';
+                    break;
+                case Keys.Oem4:
+                    keyCode = '[';
+                    break;
+                case Keys.Oem5:
+                    keyCode = '\\';
+                    break;
+                case Keys.Oem6:
+                    keyCode = ']';
+                    break;
+                default:
+                    keyCode = (int)(keys & Keys.KeyCode);
+                    break;
+            }
+
+            // No translation necessary for the modifiers. Just add them back in.
+            int keyDefinition = keyCode | (int)(keys & Keys.Modifiers);
+            return keyDefinition;
+        }
+
+        // https://stackoverflow.com/questions/2709430/count-number-of-bits-in-a-64-bit-long-big-integer/2709523#2709523
+        public static byte PopCount(ulong i)
+        {
+            i -= (i >> 1) & 0x5555555555555555UL;
+            i = (i & 0x3333333333333333UL) + ((i >> 2) & 0x3333333333333333UL);
+            return (byte)((((i + (i >> 4)) & 0xF0F0F0F0F0F0F0FUL) * 0x101010101010101UL) >> 56);
+        }
+
+        public static int MaxIndex<TSource>(this IEnumerable<TSource> source) => MaxIndex(source, comparer: null);
+
+        /// <summary>Returns index of the maximum value in a generic sequence.</summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+        /// <param name="source">A sequence of values to determine the index of the maximum value of.</param>
+        /// <param name="comparer">The <see cref="IComparer{T}" /> to compare values.</param>
+        /// <returns>The index of the maximum value in the sequence.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException">No object in <paramref name="source" /> implements the <see cref="System.IComparable" /> or <see cref="System.IComparable{T}" /> interface.</exception>
+        /// <remarks>
+        /// <para>If type <typeparamref name="TSource" /> implements <see cref="System.IComparable{T}" />, the <see cref="MaxIndex{T}(IEnumerable{T})" /> method uses that implementation to compare values. Otherwise, if type <typeparamref name="TSource" /> implements <see cref="System.IComparable" />, that implementation is used to compare values.</para>
+        /// <para>If <typeparamref name="TSource" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns -1.</para>
+        /// </remarks>
+        public static int MaxIndex<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, int> comparer)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            comparer = comparer ?? Comparer<TSource>.Default.Compare;
+
+            int index = -1;
+            int maxIndex = index;
+            TSource value = default;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (value == null)
                 {
-                    if (!e.MoveNext())
+                    do
                     {
-                        return maxIndex;
-                    }
+                        if (!e.MoveNext())
+                        {
+                            return maxIndex;
+                        }
 
-                    index++;
+                        index++;
 
-                    value = e.Current;
-                    maxIndex = index;
-                }
-                while (value == null);
-
-                while (e.MoveNext())
-                {
-                    index++;
-                    TSource next = e.Current;
-                    if (next != null && comparer(next, value) > 0)
-                    {
-                        value = next;
+                        value = e.Current;
                         maxIndex = index;
                     }
-                }
-            }
-            else
-            {
-                if (!e.MoveNext())
-                {
-                    throw new InvalidOperationException("Sequence contains no elements");
-                }
+                    while (value == null);
 
-                index++;
-
-                value = e.Current;
-                maxIndex = index;
-                if (comparer == Comparer<TSource>.Default.Compare)
-                {
                     while (e.MoveNext())
                     {
                         index++;
                         TSource next = e.Current;
-                        if (Comparer<TSource>.Default.Compare(next, value) > 0)
+                        if (next != null && comparer(next, value) > 0)
                         {
                             value = next;
                             maxIndex = index;
@@ -1248,52 +1236,78 @@ internal static class Helpers
                 }
                 else
                 {
-                    while (e.MoveNext())
+                    if (!e.MoveNext())
                     {
-                        index++;
-                        TSource next = e.Current;
-                        if (comparer(next, value) > 0)
+                        throw new InvalidOperationException("Sequence contains no elements");
+                    }
+
+                    index++;
+
+                    value = e.Current;
+                    maxIndex = index;
+                    if (comparer == Comparer<TSource>.Default.Compare)
+                    {
+                        while (e.MoveNext())
                         {
-                            value = next;
-                            maxIndex = index;
+                            index++;
+                            TSource next = e.Current;
+                            if (Comparer<TSource>.Default.Compare(next, value) > 0)
+                            {
+                                value = next;
+                                maxIndex = index;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        while (e.MoveNext())
+                        {
+                            index++;
+                            TSource next = e.Current;
+                            if (comparer(next, value) > 0)
+                            {
+                                value = next;
+                                maxIndex = index;
+                            }
                         }
                     }
                 }
             }
+
+            return maxIndex;
         }
 
-        return maxIndex;
-    }
-
-    public static void ApplyToControlTree(Control control, Action<Control> action)
-    {
-        foreach (Control child in control.Controls)
+        public static void ApplyToControlTree(Control control, Action<Control> action)
         {
-            ApplyToControlTree(child, action);
+            foreach (Control child in control.Controls)
+            {
+                ApplyToControlTree(child, action);
+            }
+
+            action(control);
         }
-        action(control);
+
+        #endregion Methods
+
+        #region Types
+
+        private struct StyleData
+        {
+            public bool Used;
+            public string FontName;
+            public int FontIndex; // RTF Only
+            public float SizeF;
+            public int Weight;
+            public int Italic;
+            public int Underline;
+            public int BackColor;
+            public int BackColorIndex; // RTF Only
+            public int ForeColor;
+            public int ForeColorIndex; // RTF Only
+            public int Case; // HTML only
+            public int Visible; // HTML only
+        }
+
+        #endregion Types
     }
-
-    #endregion Methods
-
-    #region Types
-
-    private struct StyleData
-    {
-        public bool Used;
-        public string FontName;
-        public int FontIndex; // RTF Only
-        public float SizeF;
-        public int Weight;
-        public int Italic;
-        public int Underline;
-        public int BackColor;
-        public int BackColorIndex; // RTF Only
-        public int ForeColor;
-        public int ForeColorIndex; // RTF Only
-        public int Case; // HTML only
-        public int Visible; // HTML only
-    }
-
-    #endregion Types
 }

--- a/Scintilla.NET/HotspotClickEventArgs.cs
+++ b/Scintilla.NET/HotspotClickEventArgs.cs
@@ -1,49 +1,50 @@
 ﻿using System;
 using System.Windows.Forms;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.HotspotClick" />, <see cref="Scintilla.HotspotDoubleClick" />,
-/// and <see cref="Scintilla.HotspotReleaseClick" /> events.
-/// </summary>
-public class HotspotClickEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private int? position;
-
     /// <summary>
-    /// Gets the modifier keys (SHIFT, CTRL, ALT) held down when clicked.
+    /// Provides data for the <see cref="Scintilla.HotspotClick" />, <see cref="Scintilla.HotspotDoubleClick" />,
+    /// and <see cref="Scintilla.HotspotReleaseClick" /> events.
     /// </summary>
-    /// <returns>A bitwise combination of the Keys enumeration indicating the modifier keys.</returns>
-    /// <remarks>Only the state of the CTRL key is reported in the <see cref="Scintilla.HotspotReleaseClick" /> event.</remarks>
-    public Keys Modifiers { get; private set; }
-
-    /// <summary>
-    /// Gets the zero-based document position of the text clicked.
-    /// </summary>
-    /// <returns>The zero-based character position within the document of the clicked text.</returns>
-    public int Position
+    public class HotspotClickEventArgs : EventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private int? position;
+
+        /// <summary>
+        /// Gets the modifier keys (SHIFT, CTRL, ALT) held down when clicked.
+        /// </summary>
+        /// <returns>A bitwise combination of the Keys enumeration indicating the modifier keys.</returns>
+        /// <remarks>Only the state of the CTRL key is reported in the <see cref="Scintilla.HotspotReleaseClick" /> event.</remarks>
+        public Keys Modifiers { get; private set; }
+
+        /// <summary>
+        /// Gets the zero-based document position of the text clicked.
+        /// </summary>
+        /// <returns>The zero-based character position within the document of the clicked text.</returns>
+        public int Position
         {
-            this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+            get
+            {
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
-            return (int)this.position;
+                return (int)this.position;
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="HotspotClickEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="modifiers">The modifier keys that where held down at the time of the click.</param>
-    /// <param name="bytePosition">The zero-based byte position of the clicked text.</param>
-    public HotspotClickEventArgs(Scintilla scintilla, Keys modifiers, int bytePosition)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
-        Modifiers = modifiers;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HotspotClickEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="modifiers">The modifier keys that where held down at the time of the click.</param>
+        /// <param name="bytePosition">The zero-based byte position of the clicked text.</param>
+        public HotspotClickEventArgs(Scintilla scintilla, Keys modifiers, int bytePosition)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+            Modifiers = modifiers;
+        }
     }
 }

--- a/Scintilla.NET/ILoader.cs
+++ b/Scintilla.NET/ILoader.cs
@@ -1,37 +1,38 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Provides methods for loading and creating a <see cref="Document" /> on a background (non-UI) thread.
-/// </summary>
-/// <remarks>
-/// Internally an <see cref="ILoader" /> maintains a <see cref="Document" /> instance with a reference count of 1.
-/// You are responsible for ensuring the reference count eventually reaches 0 or memory leaks will occur.
-/// </remarks>
-public interface ILoader
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Adds the data specified to the internal document.
+    /// Provides methods for loading and creating a <see cref="Document" /> on a background (non-UI) thread.
     /// </summary>
-    /// <param name="data">The character buffer to copy to the new document.</param>
-    /// <param name="length">The number of characters in <paramref name="data" /> to copy.</param>
-    /// <returns>
-    /// true if the data was added successfully; otherwise, false.
-    /// A return value of false should be followed by a call to <see cref="Release" />.
-    /// </returns>
-    bool AddData(char[] data, int length);
+    /// <remarks>
+    /// Internally an <see cref="ILoader" /> maintains a <see cref="Document" /> instance with a reference count of 1.
+    /// You are responsible for ensuring the reference count eventually reaches 0 or memory leaks will occur.
+    /// </remarks>
+    public interface ILoader
+    {
+        /// <summary>
+        /// Adds the data specified to the internal document.
+        /// </summary>
+        /// <param name="data">The character buffer to copy to the new document.</param>
+        /// <param name="length">The number of characters in <paramref name="data" /> to copy.</param>
+        /// <returns>
+        /// true if the data was added successfully; otherwise, false.
+        /// A return value of false should be followed by a call to <see cref="Release" />.
+        /// </returns>
+        bool AddData(char[] data, int length);
 
-    /// <summary>
-    /// Returns the internal document.
-    /// </summary>
-    /// <returns>A <see cref="Document" /> containing the added text. The document has a reference count of 1.</returns>
-    Document ConvertToDocument();
+        /// <summary>
+        /// Returns the internal document.
+        /// </summary>
+        /// <returns>A <see cref="Document" /> containing the added text. The document has a reference count of 1.</returns>
+        Document ConvertToDocument();
 
-    /// <summary>
-    /// Called to release the internal document when an error occurs using <see cref="AddData" /> or to abandon loading.
-    /// </summary>
-    /// <returns>
-    /// The internal document reference count.
-    /// A return value of 0 indicates that the document has been destroyed and all associated memory released.
-    /// </returns>
-    int Release();
+        /// <summary>
+        /// Called to release the internal document when an error occurs using <see cref="AddData" /> or to abandon loading.
+        /// </summary>
+        /// <returns>
+        /// The internal document reference count.
+        /// A return value of 0 indicates that the document has been destroyed and all associated memory released.
+        /// </returns>
+        int Release();
+    }
 }

--- a/Scintilla.NET/IdleStyling.cs
+++ b/Scintilla.NET/IdleStyling.cs
@@ -1,32 +1,33 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Possible strategies for styling text using application idle time.
-/// </summary>
-/// <seealso cref="Scintilla.IdleStyling" />
-public enum IdleStyling
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Syntax styling is performed for all the currently visible text before displaying it.
-    /// This is the default.
+    /// Possible strategies for styling text using application idle time.
     /// </summary>
-    None = NativeMethods.SC_IDLESTYLING_NONE,
+    /// <seealso cref="Scintilla.IdleStyling" />
+    public enum IdleStyling
+    {
+        /// <summary>
+        /// Syntax styling is performed for all the currently visible text before displaying it.
+        /// This is the default.
+        /// </summary>
+        None = NativeMethods.SC_IDLESTYLING_NONE,
 
-    /// <summary>
-    /// A small amount of styling is performed before display and then further styling is performed incrementally in the background as an idle-time task.
-    /// This can improve initial display/scroll performance, but may result in the text initially appearing uncolored and then, some time later, it is colored.
-    /// </summary>
-    ToVisible = NativeMethods.SC_IDLESTYLING_TOVISIBLE,
+        /// <summary>
+        /// A small amount of styling is performed before display and then further styling is performed incrementally in the background as an idle-time task.
+        /// This can improve initial display/scroll performance, but may result in the text initially appearing uncolored and then, some time later, it is colored.
+        /// </summary>
+        ToVisible = NativeMethods.SC_IDLESTYLING_TOVISIBLE,
 
-    /// <summary>
-    /// Text after the currently visible portion may be styled as an idle-time task.
-    /// This will not improve initial display/scroll performance, but may improve subsequent display/scroll performance.
-    /// </summary>
-    AfterVisible = NativeMethods.SC_IDLESTYLING_AFTERVISIBLE,
+        /// <summary>
+        /// Text after the currently visible portion may be styled as an idle-time task.
+        /// This will not improve initial display/scroll performance, but may improve subsequent display/scroll performance.
+        /// </summary>
+        AfterVisible = NativeMethods.SC_IDLESTYLING_AFTERVISIBLE,
 
-    /// <summary>
-    /// Text before and after the current visible text.
-    /// This is a combination of <see cref="ToVisible" /> and <see cref="AfterVisible" />.
-    /// </summary>
-    All = NativeMethods.SC_IDLESTYLING_ALL
+        /// <summary>
+        /// Text before and after the current visible text.
+        /// This is a combination of <see cref="ToVisible" /> and <see cref="AfterVisible" />.
+        /// </summary>
+        All = NativeMethods.SC_IDLESTYLING_ALL
+    }
 }

--- a/Scintilla.NET/IndentView.cs
+++ b/Scintilla.NET/IndentView.cs
@@ -1,31 +1,32 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Options for displaying indentation guides in a <see cref="Scintilla" /> control.
-/// </summary>
-/// <remarks>Indentation guides can be styled using the <see cref="Style.IndentGuide" /> style.</remarks>
-public enum IndentView
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// No indentation guides are shown. This is the default.
+    /// Options for displaying indentation guides in a <see cref="Scintilla" /> control.
     /// </summary>
-    None = NativeMethods.SC_IV_NONE,
+    /// <remarks>Indentation guides can be styled using the <see cref="Style.IndentGuide" /> style.</remarks>
+    public enum IndentView
+    {
+        /// <summary>
+        /// No indentation guides are shown. This is the default.
+        /// </summary>
+        None = NativeMethods.SC_IV_NONE,
 
-    /// <summary>
-    /// Indentation guides are shown inside real indentation whitespace.
-    /// </summary>
-    Real = NativeMethods.SC_IV_REAL,
+        /// <summary>
+        /// Indentation guides are shown inside real indentation whitespace.
+        /// </summary>
+        Real = NativeMethods.SC_IV_REAL,
 
-    /// <summary>
-    /// Indentation guides are shown beyond the actual indentation up to the level of the next non-empty line.
-    /// If the previous non-empty line was a fold header then indentation guides are shown for one more level of indent than that line.
-    /// This setting is good for Python.
-    /// </summary>
-    LookForward = NativeMethods.SC_IV_LOOKFORWARD,
+        /// <summary>
+        /// Indentation guides are shown beyond the actual indentation up to the level of the next non-empty line.
+        /// If the previous non-empty line was a fold header then indentation guides are shown for one more level of indent than that line.
+        /// This setting is good for Python.
+        /// </summary>
+        LookForward = NativeMethods.SC_IV_LOOKFORWARD,
 
-    /// <summary>
-    /// Indentation guides are shown beyond the actual indentation up to the level of the next non-empty line or previous non-empty line whichever is the greater.
-    /// This setting is good for most languages.
-    /// </summary>
-    LookBoth = NativeMethods.SC_IV_LOOKBOTH
+        /// <summary>
+        /// Indentation guides are shown beyond the actual indentation up to the level of the next non-empty line or previous non-empty line whichever is the greater.
+        /// This setting is good for most languages.
+        /// </summary>
+        LookBoth = NativeMethods.SC_IV_LOOKBOTH
+    }
 }

--- a/Scintilla.NET/Indicator.cs
+++ b/Scintilla.NET/Indicator.cs
@@ -1,273 +1,274 @@
 ﻿using System;
 using System.Drawing;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Represents an indicator in a <see cref="Scintilla" /> control.
-/// </summary>
-public class Indicator
+namespace ScintillaNET
 {
-    #region Fields
-
-    private readonly Scintilla scintilla;
-
-    #endregion Fields
-
-    #region Constants
-
     /// <summary>
-    /// An OR mask to use with <see cref="Scintilla.IndicatorValue" /> and <see cref="IndicatorFlags.ValueFore" /> to indicate
-    /// that the user-defined indicator value should be treated as a RGB color.
+    /// Represents an indicator in a <see cref="Scintilla" /> control.
     /// </summary>
-    public const int ValueBit = NativeMethods.SC_INDICVALUEBIT;
-
-    /// <summary>
-    /// An AND mask to use with <see cref="Indicator.ValueAt" /> to retrieve the user-defined value as a RGB color when being treated as such.
-    /// </summary>
-    public const int ValueMask = NativeMethods.SC_INDICVALUEMASK;
-
-    #endregion Constants
-
-    #region Methods
-
-    /// <summary>
-    /// Given a document position which is filled with this indicator, will return the document position
-    /// where the use of this indicator ends.
-    /// </summary>
-    /// <param name="position">A zero-based document position using this indicator.</param>
-    /// <returns>The zero-based document position where the use of this indicator ends.</returns>
-    /// <remarks>
-    /// Specifying a <paramref name="position" /> which is not filled with this indicator will cause this method
-    /// to return the end position of the range where this indicator is not in use (the negative space). If this
-    /// indicator is not in use anywhere within the document the return value will be 0.
-    /// </remarks>
-    public int End(int position)
+    public class Indicator
     {
-        position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
-        position = this.scintilla.Lines.CharToBytePosition(position);
-        position = this.scintilla.DirectMessage(NativeMethods.SCI_INDICATOREND, new IntPtr(Index), new IntPtr(position)).ToInt32();
-        return this.scintilla.Lines.ByteToCharPosition(position);
+        #region Fields
+
+        private readonly Scintilla scintilla;
+
+        #endregion Fields
+
+        #region Constants
+
+        /// <summary>
+        /// An OR mask to use with <see cref="Scintilla.IndicatorValue" /> and <see cref="IndicatorFlags.ValueFore" /> to indicate
+        /// that the user-defined indicator value should be treated as a RGB color.
+        /// </summary>
+        public const int ValueBit = NativeMethods.SC_INDICVALUEBIT;
+
+        /// <summary>
+        /// An AND mask to use with <see cref="Indicator.ValueAt" /> to retrieve the user-defined value as a RGB color when being treated as such.
+        /// </summary>
+        public const int ValueMask = NativeMethods.SC_INDICVALUEMASK;
+
+        #endregion Constants
+
+        #region Methods
+
+        /// <summary>
+        /// Given a document position which is filled with this indicator, will return the document position
+        /// where the use of this indicator ends.
+        /// </summary>
+        /// <param name="position">A zero-based document position using this indicator.</param>
+        /// <returns>The zero-based document position where the use of this indicator ends.</returns>
+        /// <remarks>
+        /// Specifying a <paramref name="position" /> which is not filled with this indicator will cause this method
+        /// to return the end position of the range where this indicator is not in use (the negative space). If this
+        /// indicator is not in use anywhere within the document the return value will be 0.
+        /// </remarks>
+        public int End(int position)
+        {
+            position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
+            position = this.scintilla.Lines.CharToBytePosition(position);
+            position = this.scintilla.DirectMessage(NativeMethods.SCI_INDICATOREND, new IntPtr(Index), new IntPtr(position)).ToInt32();
+            return this.scintilla.Lines.ByteToCharPosition(position);
+        }
+
+        /// <summary>
+        /// Given a document position which is filled with this indicator, will return the document position
+        /// where the use of this indicator starts.
+        /// </summary>
+        /// <param name="position">A zero-based document position using this indicator.</param>
+        /// <returns>The zero-based document position where the use of this indicator starts.</returns>
+        /// <remarks>
+        /// Specifying a <paramref name="position" /> which is not filled with this indicator will cause this method
+        /// to return the start position of the range where this indicator is not in use (the negative space). If this
+        /// indicator is not in use anywhere within the document the return value will be 0.
+        /// </remarks>
+        public int Start(int position)
+        {
+            position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
+            position = this.scintilla.Lines.CharToBytePosition(position);
+            position = this.scintilla.DirectMessage(NativeMethods.SCI_INDICATORSTART, new IntPtr(Index), new IntPtr(position)).ToInt32();
+            return this.scintilla.Lines.ByteToCharPosition(position);
+        }
+
+        /// <summary>
+        /// Returns the user-defined value for the indicator at the specified position.
+        /// </summary>
+        /// <param name="position">The zero-based document position to get the indicator value for.</param>
+        /// <returns>The user-defined value at the specified <paramref name="position" />.</returns>
+        public int ValueAt(int position)
+        {
+            position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
+            position = this.scintilla.Lines.CharToBytePosition(position);
+
+            return this.scintilla.DirectMessage(NativeMethods.SCI_INDICATORVALUEAT, new IntPtr(Index), new IntPtr(position)).ToInt32();
+        }
+
+        #endregion Methods
+
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the alpha transparency of the indicator.
+        /// </summary>
+        /// <returns>
+        /// The alpha transparency ranging from 0 (completely transparent)
+        /// to 255 (no transparency). The default is 30.
+        /// </returns>
+        public int Alpha
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETALPHA, new IntPtr(Index)).ToInt32();
+            }
+            set
+            {
+                value = Helpers.Clamp(value, 0, 255);
+                this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETALPHA, new IntPtr(Index), new IntPtr(value));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the indicator flags.
+        /// </summary>
+        /// <returns>
+        /// A bitwise combination of the <see cref="IndicatorFlags" /> enumeration.
+        /// The default is <see cref="IndicatorFlags.None" />.
+        /// </returns>
+        public IndicatorFlags Flags
+        {
+            get
+            {
+                return (IndicatorFlags)this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETFLAGS, new IntPtr(Index));
+            }
+            set
+            {
+                int flags = (int)value;
+                this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETFLAGS, new IntPtr(Index), new IntPtr(flags));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the color used to draw an indicator.
+        /// </summary>
+        /// <returns>The Color used to draw an indicator. The default varies.</returns>
+        /// <remarks>Changing the <see cref="ForeColor" /> property will reset the <see cref="HoverForeColor" />.</remarks>
+        /// <seealso cref="HoverForeColor" />
+        public Color ForeColor
+        {
+            get
+            {
+                int color = this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETFORE, new IntPtr(Index)).ToInt32();
+                return HelperMethods.FromWin32ColorOpaque(color);
+            }
+            set
+            {
+                int color = HelperMethods.ToWin32ColorOpaque(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETFORE, new IntPtr(Index), new IntPtr(color));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the color used to draw an indicator when the mouse or caret is over an indicator.
+        /// </summary>
+        /// <returns>
+        /// The Color used to draw an indicator.
+        /// By default, the hover style is equal to the regular <see cref="ForeColor" />.
+        /// </returns>
+        /// <remarks>Changing the <see cref="ForeColor" /> property will reset the <see cref="HoverForeColor" />.</remarks>
+        /// <seealso cref="ForeColor" />
+        public Color HoverForeColor
+        {
+            get
+            {
+                int color = this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETHOVERFORE, new IntPtr(Index)).ToInt32();
+                return HelperMethods.FromWin32ColorOpaque(color);
+            }
+            set
+            {
+                int color = HelperMethods.ToWin32ColorOpaque(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETHOVERFORE, new IntPtr(Index), new IntPtr(color));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the indicator style used when the mouse or caret is over an indicator.
+        /// </summary>
+        /// <returns>
+        /// One of the <see cref="ScintillaNET.IndicatorStyle" /> enumeration values.
+        /// By default, the hover style is equal to the regular <see cref="Style" />.
+        /// </returns>
+        /// <remarks>Changing the <see cref="Style" /> property will reset the <see cref="HoverStyle" />.</remarks>
+        /// <seealso cref="Style" />
+        public IndicatorStyle HoverStyle
+        {
+            get
+            {
+                return (IndicatorStyle)this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETHOVERSTYLE, new IntPtr(Index));
+            }
+            set
+            {
+                int style = (int)value;
+                this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETHOVERSTYLE, new IntPtr(Index), new IntPtr(style));
+            }
+        }
+
+        /// <summary>
+        /// Gets the zero-based indicator index this object represents.
+        /// </summary>
+        /// <returns>The indicator definition index within the <see cref="IndicatorCollection" />.</returns>
+        public int Index { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the alpha transparency of the indicator outline.
+        /// </summary>
+        /// <returns>
+        /// The alpha transparency ranging from 0 (completely transparent)
+        /// to 255 (no transparency). The default is 50.
+        /// </returns>
+        public int OutlineAlpha
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETOUTLINEALPHA, new IntPtr(Index)).ToInt32();
+            }
+            set
+            {
+                value = Helpers.Clamp(value, 0, 255);
+                this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETOUTLINEALPHA, new IntPtr(Index), new IntPtr(value));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the indicator style.
+        /// </summary>
+        /// <returns>One of the <see cref="ScintillaNET.IndicatorStyle" /> enumeration values. The default varies.</returns>
+        /// <remarks>Changing the <see cref="Style" /> property will reset the <see cref="HoverStyle" />.</remarks>
+        /// <seealso cref="HoverStyle" />
+        public IndicatorStyle Style
+        {
+            get
+            {
+                return (IndicatorStyle)this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETSTYLE, new IntPtr(Index));
+            }
+            set
+            {
+                int style = (int)value;
+                this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETSTYLE, new IntPtr(Index), new IntPtr(style));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether indicators are drawn under or over text.
+        /// </summary>
+        /// <returns>true to draw the indicator under text; otherwise, false. The default is false.</returns>
+        /// <remarks>Drawing indicators under text requires <see cref="Phases.One" /> or <see cref="Phases.Multiple" /> drawing.</remarks>
+        public bool Under
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETUNDER, new IntPtr(Index)) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr under = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETUNDER, new IntPtr(Index), under);
+            }
+        }
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Indicator" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this indicator.</param>
+        /// <param name="index">The index of this style within the <see cref="IndicatorCollection" /> that created it.</param>
+        public Indicator(Scintilla scintilla, int index)
+        {
+            this.scintilla = scintilla;
+            Index = index;
+        }
+
+        #endregion Constructors
     }
-
-    /// <summary>
-    /// Given a document position which is filled with this indicator, will return the document position
-    /// where the use of this indicator starts.
-    /// </summary>
-    /// <param name="position">A zero-based document position using this indicator.</param>
-    /// <returns>The zero-based document position where the use of this indicator starts.</returns>
-    /// <remarks>
-    /// Specifying a <paramref name="position" /> which is not filled with this indicator will cause this method
-    /// to return the start position of the range where this indicator is not in use (the negative space). If this
-    /// indicator is not in use anywhere within the document the return value will be 0.
-    /// </remarks>
-    public int Start(int position)
-    {
-        position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
-        position = this.scintilla.Lines.CharToBytePosition(position);
-        position = this.scintilla.DirectMessage(NativeMethods.SCI_INDICATORSTART, new IntPtr(Index), new IntPtr(position)).ToInt32();
-        return this.scintilla.Lines.ByteToCharPosition(position);
-    }
-
-    /// <summary>
-    /// Returns the user-defined value for the indicator at the specified position.
-    /// </summary>
-    /// <param name="position">The zero-based document position to get the indicator value for.</param>
-    /// <returns>The user-defined value at the specified <paramref name="position" />.</returns>
-    public int ValueAt(int position)
-    {
-        position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
-        position = this.scintilla.Lines.CharToBytePosition(position);
-
-        return this.scintilla.DirectMessage(NativeMethods.SCI_INDICATORVALUEAT, new IntPtr(Index), new IntPtr(position)).ToInt32();
-    }
-
-    #endregion Methods
-
-    #region Properties
-
-    /// <summary>
-    /// Gets or sets the alpha transparency of the indicator.
-    /// </summary>
-    /// <returns>
-    /// The alpha transparency ranging from 0 (completely transparent)
-    /// to 255 (no transparency). The default is 30.
-    /// </returns>
-    public int Alpha
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETALPHA, new IntPtr(Index)).ToInt32();
-        }
-        set
-        {
-            value = Helpers.Clamp(value, 0, 255);
-            this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETALPHA, new IntPtr(Index), new IntPtr(value));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the indicator flags.
-    /// </summary>
-    /// <returns>
-    /// A bitwise combination of the <see cref="IndicatorFlags" /> enumeration.
-    /// The default is <see cref="IndicatorFlags.None" />.
-    /// </returns>
-    public IndicatorFlags Flags
-    {
-        get
-        {
-            return (IndicatorFlags)this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETFLAGS, new IntPtr(Index));
-        }
-        set
-        {
-            int flags = (int)value;
-            this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETFLAGS, new IntPtr(Index), new IntPtr(flags));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the color used to draw an indicator.
-    /// </summary>
-    /// <returns>The Color used to draw an indicator. The default varies.</returns>
-    /// <remarks>Changing the <see cref="ForeColor" /> property will reset the <see cref="HoverForeColor" />.</remarks>
-    /// <seealso cref="HoverForeColor" />
-    public Color ForeColor
-    {
-        get
-        {
-            int color = this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETFORE, new IntPtr(Index)).ToInt32();
-            return HelperMethods.FromWin32ColorOpaque(color);
-        }
-        set
-        {
-            int color = HelperMethods.ToWin32ColorOpaque(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETFORE, new IntPtr(Index), new IntPtr(color));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the color used to draw an indicator when the mouse or caret is over an indicator.
-    /// </summary>
-    /// <returns>
-    /// The Color used to draw an indicator.
-    /// By default, the hover style is equal to the regular <see cref="ForeColor" />.
-    /// </returns>
-    /// <remarks>Changing the <see cref="ForeColor" /> property will reset the <see cref="HoverForeColor" />.</remarks>
-    /// <seealso cref="ForeColor" />
-    public Color HoverForeColor
-    {
-        get
-        {
-            int color = this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETHOVERFORE, new IntPtr(Index)).ToInt32();
-            return HelperMethods.FromWin32ColorOpaque(color);
-        }
-        set
-        {
-            int color = HelperMethods.ToWin32ColorOpaque(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETHOVERFORE, new IntPtr(Index), new IntPtr(color));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the indicator style used when the mouse or caret is over an indicator.
-    /// </summary>
-    /// <returns>
-    /// One of the <see cref="ScintillaNET.IndicatorStyle" /> enumeration values.
-    /// By default, the hover style is equal to the regular <see cref="Style" />.
-    /// </returns>
-    /// <remarks>Changing the <see cref="Style" /> property will reset the <see cref="HoverStyle" />.</remarks>
-    /// <seealso cref="Style" />
-    public IndicatorStyle HoverStyle
-    {
-        get
-        {
-            return (IndicatorStyle)this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETHOVERSTYLE, new IntPtr(Index));
-        }
-        set
-        {
-            int style = (int)value;
-            this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETHOVERSTYLE, new IntPtr(Index), new IntPtr(style));
-        }
-    }
-
-    /// <summary>
-    /// Gets the zero-based indicator index this object represents.
-    /// </summary>
-    /// <returns>The indicator definition index within the <see cref="IndicatorCollection" />.</returns>
-    public int Index { get; private set; }
-
-    /// <summary>
-    /// Gets or sets the alpha transparency of the indicator outline.
-    /// </summary>
-    /// <returns>
-    /// The alpha transparency ranging from 0 (completely transparent)
-    /// to 255 (no transparency). The default is 50.
-    /// </returns>
-    public int OutlineAlpha
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETOUTLINEALPHA, new IntPtr(Index)).ToInt32();
-        }
-        set
-        {
-            value = Helpers.Clamp(value, 0, 255);
-            this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETOUTLINEALPHA, new IntPtr(Index), new IntPtr(value));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the indicator style.
-    /// </summary>
-    /// <returns>One of the <see cref="ScintillaNET.IndicatorStyle" /> enumeration values. The default varies.</returns>
-    /// <remarks>Changing the <see cref="Style" /> property will reset the <see cref="HoverStyle" />.</remarks>
-    /// <seealso cref="HoverStyle" />
-    public IndicatorStyle Style
-    {
-        get
-        {
-            return (IndicatorStyle)this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETSTYLE, new IntPtr(Index));
-        }
-        set
-        {
-            int style = (int)value;
-            this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETSTYLE, new IntPtr(Index), new IntPtr(style));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets whether indicators are drawn under or over text.
-    /// </summary>
-    /// <returns>true to draw the indicator under text; otherwise, false. The default is false.</returns>
-    /// <remarks>Drawing indicators under text requires <see cref="Phases.One" /> or <see cref="Phases.Multiple" /> drawing.</remarks>
-    public bool Under
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_INDICGETUNDER, new IntPtr(Index)) != IntPtr.Zero;
-        }
-        set
-        {
-            IntPtr under = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_INDICSETUNDER, new IntPtr(Index), under);
-        }
-    }
-
-    #endregion Properties
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Indicator" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this indicator.</param>
-    /// <param name="index">The index of this style within the <see cref="IndicatorCollection" /> that created it.</param>
-    public Indicator(Scintilla scintilla, int index)
-    {
-        this.scintilla = scintilla;
-        Index = index;
-    }
-
-    #endregion Constructors
 }

--- a/Scintilla.NET/IndicatorClickEventArgs.cs
+++ b/Scintilla.NET/IndicatorClickEventArgs.cs
@@ -1,26 +1,27 @@
 ﻿using System.Windows.Forms;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.IndicatorClick" /> event.
-/// </summary>
-public class IndicatorClickEventArgs : IndicatorReleaseEventArgs
+namespace ScintillaNET
 {
     /// <summary>
-    /// Gets the modifier keys (SHIFT, CTRL, ALT) held down when clicked.
+    /// Provides data for the <see cref="Scintilla.IndicatorClick" /> event.
     /// </summary>
-    /// <returns>A bitwise combination of the Keys enumeration indicating the modifier keys.</returns>
-    public Keys Modifiers { get; private set; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IndicatorClickEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="modifiers">The modifier keys that where held down at the time of the click.</param>
-    /// <param name="bytePosition">The zero-based byte position of the clicked text.</param>
-    public IndicatorClickEventArgs(Scintilla scintilla, Keys modifiers, int bytePosition) : base(scintilla, bytePosition)
+    public class IndicatorClickEventArgs : IndicatorReleaseEventArgs
     {
-        Modifiers = modifiers;
+        /// <summary>
+        /// Gets the modifier keys (SHIFT, CTRL, ALT) held down when clicked.
+        /// </summary>
+        /// <returns>A bitwise combination of the Keys enumeration indicating the modifier keys.</returns>
+        public Keys Modifiers { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IndicatorClickEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="modifiers">The modifier keys that where held down at the time of the click.</param>
+        /// <param name="bytePosition">The zero-based byte position of the clicked text.</param>
+        public IndicatorClickEventArgs(Scintilla scintilla, Keys modifiers, int bytePosition) : base(scintilla, bytePosition)
+        {
+            Modifiers = modifiers;
+        }
     }
 }

--- a/Scintilla.NET/IndicatorCollection.cs
+++ b/Scintilla.NET/IndicatorCollection.cs
@@ -2,73 +2,74 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// An immutable collection of indicators in a <see cref="Scintilla" /> control.
-/// </summary>
-public class IndicatorCollection : IEnumerable<Indicator>
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-
     /// <summary>
-    /// Provides an enumerator that iterates through the collection.
+    /// An immutable collection of indicators in a <see cref="Scintilla" /> control.
     /// </summary>
-    /// <returns>An object that contains all <see cref="Indicator" /> objects within the <see cref="IndicatorCollection" />.</returns>
-    public IEnumerator<Indicator> GetEnumerator()
+    public class IndicatorCollection : IEnumerable<Indicator>
     {
-        int count = Count;
-        for (int i = 0; i < count; i++)
-            yield return this[i];
+        private readonly Scintilla scintilla;
 
-        yield break;
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    /// <summary>
-    /// Gets the number of indicators.
-    /// </summary>
-    /// <returns>The number of indicators in the <see cref="IndicatorCollection" />.</returns>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int Count
-    {
-        get
+        /// <summary>
+        /// Provides an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An object that contains all <see cref="Indicator" /> objects within the <see cref="IndicatorCollection" />.</returns>
+        public IEnumerator<Indicator> GetEnumerator()
         {
-            return NativeMethods.INDICATOR_MAX + 1;
-        }
-    }
+            int count = Count;
+            for (int i = 0; i < count; i++)
+                yield return this[i];
 
-    /// <summary>
-    /// Gets an <see cref="Indicator" /> object at the specified index.
-    /// </summary>
-    /// <param name="index">The indicator index.</param>
-    /// <returns>An object representing the indicator at the specified <paramref name="index" />.</returns>
-    /// <remarks>
-    /// Indicators 0 through 7 are used by lexers.
-    /// Indicators 32 through 35 are used for IME.
-    /// </remarks>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public Indicator this[int index]
-    {
-        get
+            yield break;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            index = Helpers.Clamp(index, 0, Count - 1);
-            return new Indicator(this.scintilla, index);
+            return GetEnumerator();
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IndicatorCollection" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
-    public IndicatorCollection(Scintilla scintilla)
-    {
-        this.scintilla = scintilla;
+        /// <summary>
+        /// Gets the number of indicators.
+        /// </summary>
+        /// <returns>The number of indicators in the <see cref="IndicatorCollection" />.</returns>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int Count
+        {
+            get
+            {
+                return NativeMethods.INDICATOR_MAX + 1;
+            }
+        }
+
+        /// <summary>
+        /// Gets an <see cref="Indicator" /> object at the specified index.
+        /// </summary>
+        /// <param name="index">The indicator index.</param>
+        /// <returns>An object representing the indicator at the specified <paramref name="index" />.</returns>
+        /// <remarks>
+        /// Indicators 0 through 7 are used by lexers.
+        /// Indicators 32 through 35 are used for IME.
+        /// </remarks>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public Indicator this[int index]
+        {
+            get
+            {
+                index = Helpers.Clamp(index, 0, Count - 1);
+                return new Indicator(this.scintilla, index);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IndicatorCollection" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
+        public IndicatorCollection(Scintilla scintilla)
+        {
+            this.scintilla = scintilla;
+        }
     }
 }

--- a/Scintilla.NET/IndicatorFlags.cs
+++ b/Scintilla.NET/IndicatorFlags.cs
@@ -1,23 +1,24 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Flags associated with a <see cref="Indicator" />.
-/// </summary>
-/// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
-[Flags]
-public enum IndicatorFlags
+namespace ScintillaNET
 {
     /// <summary>
-    /// No flags. This is the default.
+    /// Flags associated with a <see cref="Indicator" />.
     /// </summary>
-    None = 0,
+    /// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
+    [Flags]
+    public enum IndicatorFlags
+    {
+        /// <summary>
+        /// No flags. This is the default.
+        /// </summary>
+        None = 0,
 
-    /// <summary>
-    /// When set, will treat an indicator value as a RGB color that has been OR'd with <see cref="Indicator.ValueBit" />
-    /// and will use that instead of the value specified in the <see cref="Indicator.ForeColor" /> property. This allows
-    /// an indicator to display more than one color.
-    /// </summary>
-    ValueFore = NativeMethods.SC_INDICFLAG_VALUEFORE
+        /// <summary>
+        /// When set, will treat an indicator value as a RGB color that has been OR'd with <see cref="Indicator.ValueBit" />
+        /// and will use that instead of the value specified in the <see cref="Indicator.ForeColor" /> property. This allows
+        /// an indicator to display more than one color.
+        /// </summary>
+        ValueFore = NativeMethods.SC_INDICFLAG_VALUEFORE
+    }
 }

--- a/Scintilla.NET/IndicatorReleaseEventArgs.cs
+++ b/Scintilla.NET/IndicatorReleaseEventArgs.cs
@@ -1,38 +1,39 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.IndicatorRelease" /> event.
-/// </summary>
-public class IndicatorReleaseEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private int? position;
-
     /// <summary>
-    /// Gets the zero-based document position of the text clicked.
+    /// Provides data for the <see cref="Scintilla.IndicatorRelease" /> event.
     /// </summary>
-    /// <returns>The zero-based character position within the document of the clicked text.</returns>
-    public int Position
+    public class IndicatorReleaseEventArgs : EventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private int? position;
+
+        /// <summary>
+        /// Gets the zero-based document position of the text clicked.
+        /// </summary>
+        /// <returns>The zero-based character position within the document of the clicked text.</returns>
+        public int Position
         {
-            this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+            get
+            {
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
-            return (int)this.position;
+                return (int)this.position;
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IndicatorReleaseEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="bytePosition">The zero-based byte position of the clicked text.</param>
-    public IndicatorReleaseEventArgs(Scintilla scintilla, int bytePosition)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IndicatorReleaseEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="bytePosition">The zero-based byte position of the clicked text.</param>
+        public IndicatorReleaseEventArgs(Scintilla scintilla, int bytePosition)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+        }
     }
 }

--- a/Scintilla.NET/IndicatorStyle.cs
+++ b/Scintilla.NET/IndicatorStyle.cs
@@ -1,128 +1,129 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The visual appearance of an indicator.
-/// </summary>
-public enum IndicatorStyle
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Underlined with a single, straight line.
+    /// The visual appearance of an indicator.
     /// </summary>
-    Plain = NativeMethods.INDIC_PLAIN,
+    public enum IndicatorStyle
+    {
+        /// <summary>
+        /// Underlined with a single, straight line.
+        /// </summary>
+        Plain = NativeMethods.INDIC_PLAIN,
 
-    /// <summary>
-    /// A squiggly underline. Requires 3 pixels of descender space.
-    /// </summary>
-    Squiggle = NativeMethods.INDIC_SQUIGGLE,
+        /// <summary>
+        /// A squiggly underline. Requires 3 pixels of descender space.
+        /// </summary>
+        Squiggle = NativeMethods.INDIC_SQUIGGLE,
 
-    /// <summary>
-    /// A line of small T shapes.
-    /// </summary>
-    TT = NativeMethods.INDIC_TT,
+        /// <summary>
+        /// A line of small T shapes.
+        /// </summary>
+        TT = NativeMethods.INDIC_TT,
 
-    /// <summary>
-    /// Diagonal hatching.
-    /// </summary>
-    Diagonal = NativeMethods.INDIC_DIAGONAL,
+        /// <summary>
+        /// Diagonal hatching.
+        /// </summary>
+        Diagonal = NativeMethods.INDIC_DIAGONAL,
 
-    /// <summary>
-    /// Strike out.
-    /// </summary>
-    Strike = NativeMethods.INDIC_STRIKE,
+        /// <summary>
+        /// Strike out.
+        /// </summary>
+        Strike = NativeMethods.INDIC_STRIKE,
 
-    /// <summary>
-    /// An indicator with no visual effect.
-    /// </summary>
-    Hidden = NativeMethods.INDIC_HIDDEN,
+        /// <summary>
+        /// An indicator with no visual effect.
+        /// </summary>
+        Hidden = NativeMethods.INDIC_HIDDEN,
 
-    /// <summary>
-    /// A rectangle around the text.
-    /// </summary>
-    Box = NativeMethods.INDIC_BOX,
+        /// <summary>
+        /// A rectangle around the text.
+        /// </summary>
+        Box = NativeMethods.INDIC_BOX,
 
-    /// <summary>
-    /// A rectangle around the text with rounded corners. The rectangle outline and fill transparencies can be adjusted using
-    /// <see cref="Indicator.Alpha" /> and <see cref="Indicator.OutlineAlpha" />.
-    /// </summary>
-    RoundBox = NativeMethods.INDIC_ROUNDBOX,
+        /// <summary>
+        /// A rectangle around the text with rounded corners. The rectangle outline and fill transparencies can be adjusted using
+        /// <see cref="Indicator.Alpha" /> and <see cref="Indicator.OutlineAlpha" />.
+        /// </summary>
+        RoundBox = NativeMethods.INDIC_ROUNDBOX,
 
-    /// <summary>
-    /// A rectangle around the text. The rectangle outline and fill transparencies can be adjusted using
-    /// <see cref="Indicator.Alpha" /> and <see cref="Indicator.OutlineAlpha"/>.
-    /// </summary>
-    StraightBox = NativeMethods.INDIC_STRAIGHTBOX,
+        /// <summary>
+        /// A rectangle around the text. The rectangle outline and fill transparencies can be adjusted using
+        /// <see cref="Indicator.Alpha" /> and <see cref="Indicator.OutlineAlpha"/>.
+        /// </summary>
+        StraightBox = NativeMethods.INDIC_STRAIGHTBOX,
 
-    /// <summary>
-    /// A dashed underline.
-    /// </summary>
-    Dash = NativeMethods.INDIC_DASH,
+        /// <summary>
+        /// A dashed underline.
+        /// </summary>
+        Dash = NativeMethods.INDIC_DASH,
 
-    /// <summary>
-    /// A dotted underline.
-    /// </summary>
-    Dots = NativeMethods.INDIC_DOTS,
+        /// <summary>
+        /// A dotted underline.
+        /// </summary>
+        Dots = NativeMethods.INDIC_DOTS,
 
-    /// <summary>
-    /// Similar to <see cref="Squiggle" /> but only using 2 vertical pixels so will fit under small fonts.
-    /// </summary>
-    SquiggleLow = NativeMethods.INDIC_SQUIGGLELOW,
+        /// <summary>
+        /// Similar to <see cref="Squiggle" /> but only using 2 vertical pixels so will fit under small fonts.
+        /// </summary>
+        SquiggleLow = NativeMethods.INDIC_SQUIGGLELOW,
 
-    /// <summary>
-    /// A dotted rectangle around the text. The dots transparencies can be adjusted using
-    /// <see cref="Indicator.Alpha" /> and <see cref="Indicator.OutlineAlpha" />.
-    /// </summary>
-    DotBox = NativeMethods.INDIC_DOTBOX,
+        /// <summary>
+        /// A dotted rectangle around the text. The dots transparencies can be adjusted using
+        /// <see cref="Indicator.Alpha" /> and <see cref="Indicator.OutlineAlpha" />.
+        /// </summary>
+        DotBox = NativeMethods.INDIC_DOTBOX,
 
-    /// <summary>
-    /// A version of Squiggle that draws using a pixmap instead of as a series of line segments for performance.
-    /// </summary>
-    SquigglePixmap = NativeMethods.INDIC_SQUIGGLEPIXMAP,
+        /// <summary>
+        /// A version of Squiggle that draws using a pixmap instead of as a series of line segments for performance.
+        /// </summary>
+        SquigglePixmap = NativeMethods.INDIC_SQUIGGLEPIXMAP,
 
-    // PIXMAP
+        // PIXMAP
 
-    /// <summary>
-    /// A 2-pixel thick underline with 1 pixel insets on either side.
-    /// </summary>
-    CompositionThick = NativeMethods.INDIC_COMPOSITIONTHICK,
+        /// <summary>
+        /// A 2-pixel thick underline with 1 pixel insets on either side.
+        /// </summary>
+        CompositionThick = NativeMethods.INDIC_COMPOSITIONTHICK,
 
-    /// <summary>
-    /// A 1-pixel thick underline with 1 pixel insets on either side.
-    /// </summary>
-    CompositionThin = NativeMethods.INDIC_COMPOSITIONTHIN,
+        /// <summary>
+        /// A 1-pixel thick underline with 1 pixel insets on either side.
+        /// </summary>
+        CompositionThin = NativeMethods.INDIC_COMPOSITIONTHIN,
 
-    /// <summary>
-    /// A rectangle around the entire character area. The rectangle outline and fill transparencies can be adjusted using
-    /// <see cref="Indicator.Alpha" /> and <see cref="Indicator.OutlineAlpha"/>.
-    /// </summary>
-    FullBox = NativeMethods.INDIC_FULLBOX,
+        /// <summary>
+        /// A rectangle around the entire character area. The rectangle outline and fill transparencies can be adjusted using
+        /// <see cref="Indicator.Alpha" /> and <see cref="Indicator.OutlineAlpha"/>.
+        /// </summary>
+        FullBox = NativeMethods.INDIC_FULLBOX,
 
-    /// <summary>
-    /// An indicator that will change the foreground color of text to the foreground color of the indicator.
-    /// </summary>
-    TextFore = NativeMethods.INDIC_TEXTFORE,
+        /// <summary>
+        /// An indicator that will change the foreground color of text to the foreground color of the indicator.
+        /// </summary>
+        TextFore = NativeMethods.INDIC_TEXTFORE,
 
-    /// <summary>
-    /// A triangle below the start of the indicator range.
-    /// </summary>
-    Point = NativeMethods.INDIC_POINT,
+        /// <summary>
+        /// A triangle below the start of the indicator range.
+        /// </summary>
+        Point = NativeMethods.INDIC_POINT,
 
-    /// <summary>
-    /// A triangle below the center of the first character of the indicator range.
-    /// </summary>
-    PointCharacter = NativeMethods.INDIC_POINTCHARACTER,
+        /// <summary>
+        /// A triangle below the center of the first character of the indicator range.
+        /// </summary>
+        PointCharacter = NativeMethods.INDIC_POINTCHARACTER,
 
-    /// <summary>
-    /// A vertical gradient between a color and alpha at top to fully transparent at bottom.
-    /// </summary>
-    Gradient = NativeMethods.INDIC_GRADIENT,
+        /// <summary>
+        /// A vertical gradient between a color and alpha at top to fully transparent at bottom.
+        /// </summary>
+        Gradient = NativeMethods.INDIC_GRADIENT,
 
-    /// <summary>
-    /// A vertical gradient with color and alpha in the mid-line fading to fully transparent at top and bottom.
-    /// </summary>
-    GradientCenter = NativeMethods.INDIC_GRADIENTCENTRE,
+        /// <summary>
+        /// A vertical gradient with color and alpha in the mid-line fading to fully transparent at top and bottom.
+        /// </summary>
+        GradientCenter = NativeMethods.INDIC_GRADIENTCENTRE,
 
-    /// <summary>
-    /// A triangle above the start of the indicator range.
-    /// </summary>
-    PointTop = NativeMethods.INDIC_POINT_TOP,
+        /// <summary>
+        /// A triangle above the start of the indicator range.
+        /// </summary>
+        PointTop = NativeMethods.INDIC_POINT_TOP,
+    }
 }

--- a/Scintilla.NET/Layer.cs
+++ b/Scintilla.NET/Layer.cs
@@ -1,23 +1,24 @@
-namespace ScintillaNET;
-
-/// <summary>
-/// The layer on which a <see cref="Scintilla"/> control will draw elements like for example the text selection.
-/// </summary>
-public enum Layer
+namespace ScintillaNET
 {
     /// <summary>
-    /// Draw the selection background opaquely on the base layer.
+    /// The layer on which a <see cref="Scintilla"/> control will draw elements like for example the text selection.
     /// </summary>
-    Base = NativeMethods.SC_LAYER_BASE,
+    public enum Layer
+    {
+        /// <summary>
+        /// Draw the selection background opaquely on the base layer.
+        /// </summary>
+        Base = NativeMethods.SC_LAYER_BASE,
 
-    /// <summary>
-    /// Draw the selection background translucently under the text. This will not work in single phase drawing mode.
-    /// (<see cref="Phases.One"/>) as there is no under-text phase.
-    /// </summary>
-    UnderText = NativeMethods.SC_LAYER_UNDER_TEXT,
+        /// <summary>
+        /// Draw the selection background translucently under the text. This will not work in single phase drawing mode.
+        /// (<see cref="Phases.One"/>) as there is no under-text phase.
+        /// </summary>
+        UnderText = NativeMethods.SC_LAYER_UNDER_TEXT,
 
-    /// <summary>
-    /// Draw the selection background translucently over the text.
-    /// </summary>
-    OverText = NativeMethods.SC_LAYER_OVER_TEXT
+        /// <summary>
+        /// Draw the selection background translucently over the text.
+        /// </summary>
+        OverText = NativeMethods.SC_LAYER_OVER_TEXT
+    }
 }

--- a/Scintilla.NET/Lexer.cs
+++ b/Scintilla.NET/Lexer.cs
@@ -1,558 +1,559 @@
-namespace ScintillaNET;
-
-/// <summary>
-/// Supported lexer names helper.
-/// </summary>
-public enum Lexer
+namespace ScintillaNET
 {
     /// <summary>
-    /// Lexer for Assembler, just for the MASM syntax
-    /// </summary>
-    SCLEX_A68K,
-    /// <summary>
-    /// Lexer for APDL. Based on the lexer for Assembler by The Black Horus.
-    /// </summary>
-    SCLEX_ADPL,
-    /// <summary>
-    /// This lexer is for the Asymptote vector graphics language
-    /// </summary>
-    SCLEX_ASYMPTOTE,
-    /// <summary>
-    /// Lexer for AutoIt3
-    /// </summary>
-    SCLEX_AU3,
-    /// <summary>
-    /// Lexer for Avenue
-    /// </summary>
-    SCLEX_AVE,
-    /// <summary>
-    /// Lexer for AviSynth
-    /// </summary>
-    SCLEX_AVS,
-    /// <summary>
-    /// Lexer for ABAQUS. Based on the lexer for APDL by Hadar Raz.
-    /// </summary>
-    SCLEX_ABAQUS,
-    /// <summary>
-    /// Lexer for Ada 95
-    /// </summary>
-    SCLEX_ADA,
-    /// <summary>
-    /// Lexer for Asciidoc
-    /// </summary>
-    SCLEX_ASCIIDOC,
-    /// <summary>
-    /// Lexer for Assembler, just for the MASM syntax
-    /// </summary>
-    SCLEX_ASM,
-    /// <summary>
-    /// Lexer for Assembler
-    /// </summary>
-    SCLEX_AS,
-    /// <summary>
-    /// Lexer for ASN.1
-    /// </summary>
-    SCLEX_ASN1,
-    /// <summary>
-    /// Lexer for Baan.
-    /// </summary>
-    SCLEX_BAAN,
-    /// <summary>
-    /// Lexer for Bash.
-    /// </summary>
-    SCLEX_BASH,
-    /// <summary>
-    /// Lexer for BlitzBasic.
-    /// </summary>
-    SCLEX_BLITZBASIC,
-    /// <summary>
-    /// Lexer for PureBasic.
-    /// </summary>
-    SCLEX_PUREBASIC,
-    /// <summary>
-    /// Lexer for FreeBasic.
-    /// </summary>
-    SCLEX_FREEBASIC,
-    /// <summary>
-    /// Lexer for batch files
-    /// </summary>
-    SCLEX_BATCH,
-    /// <summary>
-    /// Lexer for BibTeX coloring scheme.
-    /// </summary>
-    SCLEX_BIBTEX,
-    /// <summary>
-    /// Lexer for Bullant
-    /// </summary>
-    SCLEX_BULLANT,
-    /// <summary>
-    /// Lexer for Common Intermediate Language (CIL)
-    /// </summary>
-    SCLEX_CIL,
-    /// <summary>
-    /// Case Sensitive Clarion Language Lexer
-    /// </summary>
-    SCLEX_CLW,
-    /// <summary>
-    /// Lexer for Clarion with no case sensitivity.
-    /// </summary>
-    SCLEX_CLWNOCASE,
-    /// <summary>
-    /// Lexer for COBOL
-    /// </summary>
-    SCLEX_COBOL,
-    /// <summary>
-    /// Lexer for Case Sensitive C++
-    /// </summary>
-    SCLEX_CPP,
-    /// <summary>
-    /// Lexer for no case sensitivity C++
-    /// </summary>
-    SCLEX_CPPNOCASE,
-    /// <summary>
-    /// Lexer for C#
-    /// </summary>
-    SCLEX_CSHARP,
-    /// <summary>
-    /// Lexer for Cascading Style Sheets
-    /// </summary>
-    SCLEX_CSS,
-    /// <summary>
-    /// Lexer for Java
-    /// </summary>
-    SCLEX_JAVA,
-    /// <summary>
-    /// Lexer for JavaScript
-    /// </summary>
-    SCLEX_JAVASCRIPT,
-    /// <summary>
-    /// Lexer for Objective Caml.
-    /// </summary>
-    SCLEX_CAML,
-    /// <summary>
-    /// Lexer for Cmake
-    /// </summary>
-    SCLEX_CMAKE,
-    /// <summary>
-    /// Lexer for CoffeeScript.
-    /// </summary>
-    SCLEX_COFFEESCRIPT,
-    /// <summary>
-    /// Apache Configuration Files
-    /// </summary>
-    SCLEX_CONF,
-    /// <summary>
-    /// Lexer to use with extended crontab files used by a powerful
-    /// Windows scheduler/event monitor/automation manager nnCron.
-    /// </summary>
-    SCLEX_NNCRONTAB,
-    /// <summary>
-    /// Lexer for Csound (Orchestra and Score)
-    /// </summary>
-    SCLEX_CSOUND,
-    /// <summary>
-    /// Lexer for D
-    /// </summary>
-    SCLEX_D,
-    /// <summary>
-    /// Lexer for MSC Nastran DMAP.
-    /// </summary>
-    SCLEX_DMAP,
-    /// <summary>
-    /// Lexer for DMIS.
-    /// </summary>
-    SCLEX_DMIS,
-    /// <summary>
-    /// Lexer for DataFlex.
-    /// </summary>
-    SCLEX_DATAFLEX,
-    /// <summary>
-    /// Lexer for diff results.
-    /// </summary>
-    SCLEX_DIFF,
-    /// <summary>
-    /// Lexer for ECL.
-    /// </summary>
-    SCLEX_ECL,
-    /// <summary>
-    /// Lexer for EDIFACT
-    /// </summary>
-    SCLEX_EDIFACT,
-    /// <summary>
-    /// Lexer for ESCRIPT
-    /// </summary>
-    SCLEX_ESCRIPT,
-    /// <summary>
-    /// Lexer for Eiffel.
-    /// </summary>
-    SCLEX_EIFFEL,
-    /// <summary>
-    /// Lexer for EiffelKW
-    /// </summary>
-    SCLEX_EIFFELKW,
-    /// <summary>
-    /// Lexer for Erlang.
-    /// </summary>
-    SCLEX_ERLANG,
-    /// <summary>
-    /// Lexer for error lists. Used for the output pane in SciTE
-    /// </summary>
-    SCLEX_ERRORLIST,
-    /// <summary>
-    /// Lexer for F# 5.0
-    /// </summary>
-    SCLEX_FSHARP,
-    /// <summary>
-    /// Lexer for Harbour and FlagShip.
-    /// </summary>
-    SCLEX_FLAGSHIP,
-    /// <summary>
-    /// Lexer for Forth
-    /// </summary>
-    SCLEX_FORTH,
-    /// <summary>
-    /// Lexer for Fortran
-    /// </summary>
-    SCLEX_FORTRAN,
-    /// <summary>
-    /// Lexer for Fortran 77
-    /// </summary>
-    SCLEX_F77,
-    /// <summary>
-    /// Lexer for the GAP language. (The GAP System for Computational Discrete Algebra)
-    /// </summary>
-    SCLEX_GAP,
-    /// <summary>
-    /// Lexer for GDScript.
-    /// </summary>
-    SCLEX_GDSCRIPT,
-    /// <summary>
-    /// This is the Lexer for Gui4Cli, included in SciLexer.dll
-    /// </summary>
-    SCLEX_GUI4CLI,
-    /// <summary>
-    /// Lexer for HTML
-    /// </summary>
-    SCLEX_HTML,
-    /// <summary>
-    /// Lexer for XML
-    /// </summary>
-    SCLEX_XML,
-    /// <summary>
-    /// Lexer for PHPScript
-    /// </summary>
-    SCLEX_PHPSCRIPT,
-    /// <summary>
-    /// A haskell lexer for the scintilla code control.
-    /// </summary>
-    SCLEX_HASKELL,
-    /// <summary>
-    /// Lexer for Literate Haskell
-    /// </summary>
-    SCLEX_LITERATEHASKELL,
-    /// <summary>
-    /// Lexer for Motorola S-Record.
-    /// </summary>
-    SCLEX_SREC,
-    /// <summary>
-    /// Lexer for Intel HEX
-    /// </summary>
-    SCLEX_IHEX,
-    /// <summary>
-    /// Lexer for Tektronix extended HEX
-    /// </summary>
-    SCLEX_TEHEX,
-    /// <summary>
-    /// Lexer for Hollywood
-    /// </summary>
-    SCLEX_HOLLYWOOD,
-    /// <summary>
-    /// Lexer for no language. Used for indentation-based folding of files.
-    /// </summary>
-    SCLEX_INDENT,
-    /// <summary>
-    /// Lexer for Inno Setup scripts.
-    /// </summary>
-    SCLEX_INNOSETUP,
-    /// <summary>
-    /// Lexer for JSON and JSON-LD formats
-    /// </summary>
-    SCLEX_JSON,
-    /// <summary>
-    /// Lexer for Julia
-    /// </summary>
-    SCLEX_JULIA,
-    /// <summary>
-    /// Lexer for KIX-Scripts.
-    /// </summary>
-    SCLEX_KIX,
-    /// <summary>
-    /// Lexer for KVIrc script.
-    /// </summary>
-    SCLEX_KVIRC,
-    /// <summary>
-    /// Lexer for LaTeX2e.
-    /// </summary>
-    SCLEX_LATEX,
-    /// <summary>
-    /// Lexer for Lisp
-    /// </summary>
-    SCLEX_LISP,
-    /// <summary>
-    /// Lexer for the Basser Lout (>= version 3) typesetting language
-    /// </summary>
-    SCLEX_LOUT,
-    /// <summary>
-    /// Lexer for Lua language
-    /// </summary>
-    SCLEX_LUA,
-    /// <summary>
-    /// Lexer for MMIX Assembler Language.
-    /// </summary>
-    SCLEX_MMIXAL,
-    /// <summary>
-    /// Lexer for MPT specific files. Based on LexOthers.cxx
-    /// LOT = the text log file created by the MPT application while running a test program
-    /// </summary>
-    SCLEX_LOT,
-    /// <summary>
-    /// Lexer for MSSQL
-    /// </summary>
-    SCLEX_MSSQL,
-    /// <summary>
-    /// Lexer for GE(r) Smallworld(tm) MagikSF
-    /// </summary>
-    SCLEX_MAGIK,
-    /// <summary>
-    /// Lexer for make files.
-    /// </summary>
-    SCLEX_MAKEFILE,
-    /// <summary>
-    /// A simple Markdown lexer for scintilla.
-    /// </summary>
-    SCLEX_MARKDOWN,
-    /// <summary>
-    /// Lexer for Matlab.
-    /// </summary>
-    SCLEX_MATLAB,
-    /// <summary>
-    /// Lexer for Octave
-    /// </summary>
-    SCLEX_OCTAVE,
-    /// <summary>
-    /// Lexer for Maxima 
-    /// </summary>
-    SCLEX_MAXIMA,
-    /// <summary>
-    /// Lexer for general context conformant metapost coloring scheme
-    /// </summary>
-    SCLEX_METAPOST,
-    /// <summary>
-    /// Lexer for Modula-2/3 documents.
-    /// </summary>
-    SCLEX_MODULA,
-    /// <summary>
-    /// Lexer for MySQL
-    /// </summary>
-    SCLEX_MYSQL,
-    /// <summary>
-    /// Lexer for NIM
-    /// </summary>
-    SCLEX_NIM,
-    /// <summary>
-    /// Lexer for NIMROD
-    /// </summary>
-    SCLEX_NIMROD,
-    /// <summary>
-    /// Lexer for NSIS
-    /// </summary>
-    SCLEX_NSIS,
-    /// <summary>
-    /// Lexer for no language. Used for plain text and unrecognized files.
-    /// </summary>
-    SCLEX_NULL,
-    /// <summary>
-    /// Lexer for OScript sources; ocx files and/or OSpace dumps.
-    /// </summary>
-    SCLEX_OSCRIPT,
-    /// <summary>
-    /// Lexer for OPAL (functional language similar to Haskell)
-    /// </summary>
-    SCLEX_OPAL,
-    /// <summary>
-    /// Lexer for PowerBasic 
-    /// </summary>
-    SCLEX_POWERBASIC,
-    /// <summary>
-    /// Lexer for PL/M
-    /// </summary>
-    SCLEX_PLM,
-    /// <summary>
-    /// Lexer for GetText Translation (PO) files.
-    /// </summary>
-    SCLEX_PO,
-    /// <summary>
-    /// Lexer for POV-Ray SDL
-    /// </summary>
-    SCLEX_POV,
-    /// <summary>
-    /// Lexer for PostScript
-    /// </summary>
-    SCLEX_POSTSCRIPT,
-    /// <summary>
-    /// Lexer for Pascal
-    /// </summary>
-    SCLEX_PASCAL,
-    /// <summary>
-    /// Lexer for Perl
-    /// </summary>
-    SCLEX_PERL,
-    /// <summary>
-    /// Lexer for PowerPro
-    /// </summary>
-    SCLEX_POWERPRO,
-    /// <summary>
-    /// Lexer for PowerShellj scripts
-    /// </summary>
-    SCLEX_POWERSHELL,
-    /// <summary>
-    /// Lexer for Progress 4GL.
-    /// </summary>
-    SCLEX_PROGRESS,
-    /// <summary>
-    /// Lexer for properties files.
-    /// </summary>
-    SCLEX_PROPERTIES,
-    /// <summary>
-    /// Lexer for Python
-    /// </summary>
-    SCLEX_PYTHON,
-    /// <summary>
-    /// Lexer for R.
-    /// </summary>
-    SCLEX_R,
-    /// <summary>
-    /// Lexer for S.
-    /// </summary>
-    SCLEX_S,
-    /// <summary>
-    /// Lexer for SPlus Statistics Program.
-    /// </summary>
-    SCLEX_SPLUS,
-    /// <summary>
-    /// Lexer for Raku
-    /// </summary>
-    SCLEX_RAKU,
-    /// <summary>
-    /// Lexer for REBOL
-    /// </summary>
-    SCLEX_REBOL,
-    /// <summary>
-    /// Lexer for Windows registration files(.reg)
-    /// </summary>
-    SCLEX_REGISTRY,
-    /// <summary>
-    /// Lexer for Ruby
-    /// </summary>
-    SCLEX_RUBY,
-    /// <summary>
-    /// Lexer for Rust
-    /// </summary>
-    SCLEX_RUST,
-    /// <summary>
-    /// Lexer for SAS
-    /// </summary>
-    SCLEX_SAS,
-    /// <summary>
-    /// Lexer for SML
-    /// </summary>
-    SCLEX_SML,
-    /// <summary>
-    /// Lexer for SQL, including PL/SQL and SQL*Plus.
-    /// </summary>
-    SCLEX_SQL,
-    /// <summary>
-    /// Lexer for Structured Text language.
-    /// </summary>
-    SCLEX_STTXT,
-    /// <summary>
-    /// Lexer for Scriptol
-    /// </summary>
-    SCLEX_SCRIPTOL,
-    /// <summary>
-    /// Lexer for SmallTalk
-    /// </summary>
-    SCLEX_SMALLTALK,
-    /// <summary>
-    /// Lexer for SORCUS installation files
-    /// </summary>
-    SCLEX_SORCUS,
-    /// <summary>
-    /// Lexer for Specman E language.
-    /// </summary>
-    SCLEX_SPECMAN,
-    /// <summary>
-    /// Lexer for SPICE
-    /// </summary>
-    SCLEX_SPICE,
-    /// <summary>
-    /// Lexer for Stata
-    /// </summary>
-    SCLEX_STATA,
-    /// <summary>
-    /// Lexer for TACL
-    /// </summary>
-    SCLEX_TACL,
-    /// <summary>
-    /// Lexer for TADS3
-    /// </summary>
-    SCLEX_TADS3,
-    /// <summary>
-    /// Lexer for TAL
-    /// </summary>
-    SCLEX_TAL,
-    /// <summary>
-    /// Lexer for TCL
-    /// </summary>
-    SCLEX_TCL,
-    /// <summary>
-    /// Lexer for Take Command / TCC batch scripts (.bat, .btm, .cmd).
-    /// </summary>
-    SCLEX_TCMD,
-    /// <summary>
-    /// Lexer for LaTeX general context conformant tex coloring scheme
-    /// </summary>
-    SCLEX_TEX,
-    /// <summary>
-    /// A simple Txt2tags lexer for scintilla.
-    /// </summary>
-    SCLEX_TXT2TAGS,
-    /// <summary>
-    /// Visual Basic
-    /// </summary>
-    SCLEX_VB,
-    /// <summary>
-    /// Visual Basic Script
-    /// </summary>
-    SCLEX_VBSCRIPT,
-    /// <summary>
-    /// Lexer for vhdl
-    /// </summary>
-    SCLEX_VHDL,
-    /// <summary>
-    /// Lexer for Verilog
-    /// </summary>
-    SCLEX_VERILOG,
-    /// <summary>
-    /// Lexer for Visual Prolog
-    /// </summary>
-    SCLEX_VISUALPROLOG,
-    /// <summary>
-    /// Lexer for X12
-    /// </summary>
-    SCLEX_X12,
-    /// <summary>
-    /// Lexer for Yaml
-    /// </summary>
-    SCLEX_YAML,
+    /// Supported lexer names helper.
+    /// </summary>
+    public enum Lexer
+    {
+        /// <summary>
+        /// Lexer for Assembler, just for the MASM syntax
+        /// </summary>
+        SCLEX_A68K,
+        /// <summary>
+        /// Lexer for APDL. Based on the lexer for Assembler by The Black Horus.
+        /// </summary>
+        SCLEX_ADPL,
+        /// <summary>
+        /// This lexer is for the Asymptote vector graphics language
+        /// </summary>
+        SCLEX_ASYMPTOTE,
+        /// <summary>
+        /// Lexer for AutoIt3
+        /// </summary>
+        SCLEX_AU3,
+        /// <summary>
+        /// Lexer for Avenue
+        /// </summary>
+        SCLEX_AVE,
+        /// <summary>
+        /// Lexer for AviSynth
+        /// </summary>
+        SCLEX_AVS,
+        /// <summary>
+        /// Lexer for ABAQUS. Based on the lexer for APDL by Hadar Raz.
+        /// </summary>
+        SCLEX_ABAQUS,
+        /// <summary>
+        /// Lexer for Ada 95
+        /// </summary>
+        SCLEX_ADA,
+        /// <summary>
+        /// Lexer for Asciidoc
+        /// </summary>
+        SCLEX_ASCIIDOC,
+        /// <summary>
+        /// Lexer for Assembler, just for the MASM syntax
+        /// </summary>
+        SCLEX_ASM,
+        /// <summary>
+        /// Lexer for Assembler
+        /// </summary>
+        SCLEX_AS,
+        /// <summary>
+        /// Lexer for ASN.1
+        /// </summary>
+        SCLEX_ASN1,
+        /// <summary>
+        /// Lexer for Baan.
+        /// </summary>
+        SCLEX_BAAN,
+        /// <summary>
+        /// Lexer for Bash.
+        /// </summary>
+        SCLEX_BASH,
+        /// <summary>
+        /// Lexer for BlitzBasic.
+        /// </summary>
+        SCLEX_BLITZBASIC,
+        /// <summary>
+        /// Lexer for PureBasic.
+        /// </summary>
+        SCLEX_PUREBASIC,
+        /// <summary>
+        /// Lexer for FreeBasic.
+        /// </summary>
+        SCLEX_FREEBASIC,
+        /// <summary>
+        /// Lexer for batch files
+        /// </summary>
+        SCLEX_BATCH,
+        /// <summary>
+        /// Lexer for BibTeX coloring scheme.
+        /// </summary>
+        SCLEX_BIBTEX,
+        /// <summary>
+        /// Lexer for Bullant
+        /// </summary>
+        SCLEX_BULLANT,
+        /// <summary>
+        /// Lexer for Common Intermediate Language (CIL)
+        /// </summary>
+        SCLEX_CIL,
+        /// <summary>
+        /// Case Sensitive Clarion Language Lexer
+        /// </summary>
+        SCLEX_CLW,
+        /// <summary>
+        /// Lexer for Clarion with no case sensitivity.
+        /// </summary>
+        SCLEX_CLWNOCASE,
+        /// <summary>
+        /// Lexer for COBOL
+        /// </summary>
+        SCLEX_COBOL,
+        /// <summary>
+        /// Lexer for Case Sensitive C++
+        /// </summary>
+        SCLEX_CPP,
+        /// <summary>
+        /// Lexer for no case sensitivity C++
+        /// </summary>
+        SCLEX_CPPNOCASE,
+        /// <summary>
+        /// Lexer for C#
+        /// </summary>
+        SCLEX_CSHARP,
+        /// <summary>
+        /// Lexer for Cascading Style Sheets
+        /// </summary>
+        SCLEX_CSS,
+        /// <summary>
+        /// Lexer for Java
+        /// </summary>
+        SCLEX_JAVA,
+        /// <summary>
+        /// Lexer for JavaScript
+        /// </summary>
+        SCLEX_JAVASCRIPT,
+        /// <summary>
+        /// Lexer for Objective Caml.
+        /// </summary>
+        SCLEX_CAML,
+        /// <summary>
+        /// Lexer for Cmake
+        /// </summary>
+        SCLEX_CMAKE,
+        /// <summary>
+        /// Lexer for CoffeeScript.
+        /// </summary>
+        SCLEX_COFFEESCRIPT,
+        /// <summary>
+        /// Apache Configuration Files
+        /// </summary>
+        SCLEX_CONF,
+        /// <summary>
+        /// Lexer to use with extended crontab files used by a powerful
+        /// Windows scheduler/event monitor/automation manager nnCron.
+        /// </summary>
+        SCLEX_NNCRONTAB,
+        /// <summary>
+        /// Lexer for Csound (Orchestra and Score)
+        /// </summary>
+        SCLEX_CSOUND,
+        /// <summary>
+        /// Lexer for D
+        /// </summary>
+        SCLEX_D,
+        /// <summary>
+        /// Lexer for MSC Nastran DMAP.
+        /// </summary>
+        SCLEX_DMAP,
+        /// <summary>
+        /// Lexer for DMIS.
+        /// </summary>
+        SCLEX_DMIS,
+        /// <summary>
+        /// Lexer for DataFlex.
+        /// </summary>
+        SCLEX_DATAFLEX,
+        /// <summary>
+        /// Lexer for diff results.
+        /// </summary>
+        SCLEX_DIFF,
+        /// <summary>
+        /// Lexer for ECL.
+        /// </summary>
+        SCLEX_ECL,
+        /// <summary>
+        /// Lexer for EDIFACT
+        /// </summary>
+        SCLEX_EDIFACT,
+        /// <summary>
+        /// Lexer for ESCRIPT
+        /// </summary>
+        SCLEX_ESCRIPT,
+        /// <summary>
+        /// Lexer for Eiffel.
+        /// </summary>
+        SCLEX_EIFFEL,
+        /// <summary>
+        /// Lexer for EiffelKW
+        /// </summary>
+        SCLEX_EIFFELKW,
+        /// <summary>
+        /// Lexer for Erlang.
+        /// </summary>
+        SCLEX_ERLANG,
+        /// <summary>
+        /// Lexer for error lists. Used for the output pane in SciTE
+        /// </summary>
+        SCLEX_ERRORLIST,
+        /// <summary>
+        /// Lexer for F# 5.0
+        /// </summary>
+        SCLEX_FSHARP,
+        /// <summary>
+        /// Lexer for Harbour and FlagShip.
+        /// </summary>
+        SCLEX_FLAGSHIP,
+        /// <summary>
+        /// Lexer for Forth
+        /// </summary>
+        SCLEX_FORTH,
+        /// <summary>
+        /// Lexer for Fortran
+        /// </summary>
+        SCLEX_FORTRAN,
+        /// <summary>
+        /// Lexer for Fortran 77
+        /// </summary>
+        SCLEX_F77,
+        /// <summary>
+        /// Lexer for the GAP language. (The GAP System for Computational Discrete Algebra)
+        /// </summary>
+        SCLEX_GAP,
+        /// <summary>
+        /// Lexer for GDScript.
+        /// </summary>
+        SCLEX_GDSCRIPT,
+        /// <summary>
+        /// This is the Lexer for Gui4Cli, included in SciLexer.dll
+        /// </summary>
+        SCLEX_GUI4CLI,
+        /// <summary>
+        /// Lexer for HTML
+        /// </summary>
+        SCLEX_HTML,
+        /// <summary>
+        /// Lexer for XML
+        /// </summary>
+        SCLEX_XML,
+        /// <summary>
+        /// Lexer for PHPScript
+        /// </summary>
+        SCLEX_PHPSCRIPT,
+        /// <summary>
+        /// A haskell lexer for the scintilla code control.
+        /// </summary>
+        SCLEX_HASKELL,
+        /// <summary>
+        /// Lexer for Literate Haskell
+        /// </summary>
+        SCLEX_LITERATEHASKELL,
+        /// <summary>
+        /// Lexer for Motorola S-Record.
+        /// </summary>
+        SCLEX_SREC,
+        /// <summary>
+        /// Lexer for Intel HEX
+        /// </summary>
+        SCLEX_IHEX,
+        /// <summary>
+        /// Lexer for Tektronix extended HEX
+        /// </summary>
+        SCLEX_TEHEX,
+        /// <summary>
+        /// Lexer for Hollywood
+        /// </summary>
+        SCLEX_HOLLYWOOD,
+        /// <summary>
+        /// Lexer for no language. Used for indentation-based folding of files.
+        /// </summary>
+        SCLEX_INDENT,
+        /// <summary>
+        /// Lexer for Inno Setup scripts.
+        /// </summary>
+        SCLEX_INNOSETUP,
+        /// <summary>
+        /// Lexer for JSON and JSON-LD formats
+        /// </summary>
+        SCLEX_JSON,
+        /// <summary>
+        /// Lexer for Julia
+        /// </summary>
+        SCLEX_JULIA,
+        /// <summary>
+        /// Lexer for KIX-Scripts.
+        /// </summary>
+        SCLEX_KIX,
+        /// <summary>
+        /// Lexer for KVIrc script.
+        /// </summary>
+        SCLEX_KVIRC,
+        /// <summary>
+        /// Lexer for LaTeX2e.
+        /// </summary>
+        SCLEX_LATEX,
+        /// <summary>
+        /// Lexer for Lisp
+        /// </summary>
+        SCLEX_LISP,
+        /// <summary>
+        /// Lexer for the Basser Lout (>= version 3) typesetting language
+        /// </summary>
+        SCLEX_LOUT,
+        /// <summary>
+        /// Lexer for Lua language
+        /// </summary>
+        SCLEX_LUA,
+        /// <summary>
+        /// Lexer for MMIX Assembler Language.
+        /// </summary>
+        SCLEX_MMIXAL,
+        /// <summary>
+        /// Lexer for MPT specific files. Based on LexOthers.cxx
+        /// LOT = the text log file created by the MPT application while running a test program
+        /// </summary>
+        SCLEX_LOT,
+        /// <summary>
+        /// Lexer for MSSQL
+        /// </summary>
+        SCLEX_MSSQL,
+        /// <summary>
+        /// Lexer for GE(r) Smallworld(tm) MagikSF
+        /// </summary>
+        SCLEX_MAGIK,
+        /// <summary>
+        /// Lexer for make files.
+        /// </summary>
+        SCLEX_MAKEFILE,
+        /// <summary>
+        /// A simple Markdown lexer for scintilla.
+        /// </summary>
+        SCLEX_MARKDOWN,
+        /// <summary>
+        /// Lexer for Matlab.
+        /// </summary>
+        SCLEX_MATLAB,
+        /// <summary>
+        /// Lexer for Octave
+        /// </summary>
+        SCLEX_OCTAVE,
+        /// <summary>
+        /// Lexer for Maxima 
+        /// </summary>
+        SCLEX_MAXIMA,
+        /// <summary>
+        /// Lexer for general context conformant metapost coloring scheme
+        /// </summary>
+        SCLEX_METAPOST,
+        /// <summary>
+        /// Lexer for Modula-2/3 documents.
+        /// </summary>
+        SCLEX_MODULA,
+        /// <summary>
+        /// Lexer for MySQL
+        /// </summary>
+        SCLEX_MYSQL,
+        /// <summary>
+        /// Lexer for NIM
+        /// </summary>
+        SCLEX_NIM,
+        /// <summary>
+        /// Lexer for NIMROD
+        /// </summary>
+        SCLEX_NIMROD,
+        /// <summary>
+        /// Lexer for NSIS
+        /// </summary>
+        SCLEX_NSIS,
+        /// <summary>
+        /// Lexer for no language. Used for plain text and unrecognized files.
+        /// </summary>
+        SCLEX_NULL,
+        /// <summary>
+        /// Lexer for OScript sources; ocx files and/or OSpace dumps.
+        /// </summary>
+        SCLEX_OSCRIPT,
+        /// <summary>
+        /// Lexer for OPAL (functional language similar to Haskell)
+        /// </summary>
+        SCLEX_OPAL,
+        /// <summary>
+        /// Lexer for PowerBasic 
+        /// </summary>
+        SCLEX_POWERBASIC,
+        /// <summary>
+        /// Lexer for PL/M
+        /// </summary>
+        SCLEX_PLM,
+        /// <summary>
+        /// Lexer for GetText Translation (PO) files.
+        /// </summary>
+        SCLEX_PO,
+        /// <summary>
+        /// Lexer for POV-Ray SDL
+        /// </summary>
+        SCLEX_POV,
+        /// <summary>
+        /// Lexer for PostScript
+        /// </summary>
+        SCLEX_POSTSCRIPT,
+        /// <summary>
+        /// Lexer for Pascal
+        /// </summary>
+        SCLEX_PASCAL,
+        /// <summary>
+        /// Lexer for Perl
+        /// </summary>
+        SCLEX_PERL,
+        /// <summary>
+        /// Lexer for PowerPro
+        /// </summary>
+        SCLEX_POWERPRO,
+        /// <summary>
+        /// Lexer for PowerShellj scripts
+        /// </summary>
+        SCLEX_POWERSHELL,
+        /// <summary>
+        /// Lexer for Progress 4GL.
+        /// </summary>
+        SCLEX_PROGRESS,
+        /// <summary>
+        /// Lexer for properties files.
+        /// </summary>
+        SCLEX_PROPERTIES,
+        /// <summary>
+        /// Lexer for Python
+        /// </summary>
+        SCLEX_PYTHON,
+        /// <summary>
+        /// Lexer for R.
+        /// </summary>
+        SCLEX_R,
+        /// <summary>
+        /// Lexer for S.
+        /// </summary>
+        SCLEX_S,
+        /// <summary>
+        /// Lexer for SPlus Statistics Program.
+        /// </summary>
+        SCLEX_SPLUS,
+        /// <summary>
+        /// Lexer for Raku
+        /// </summary>
+        SCLEX_RAKU,
+        /// <summary>
+        /// Lexer for REBOL
+        /// </summary>
+        SCLEX_REBOL,
+        /// <summary>
+        /// Lexer for Windows registration files(.reg)
+        /// </summary>
+        SCLEX_REGISTRY,
+        /// <summary>
+        /// Lexer for Ruby
+        /// </summary>
+        SCLEX_RUBY,
+        /// <summary>
+        /// Lexer for Rust
+        /// </summary>
+        SCLEX_RUST,
+        /// <summary>
+        /// Lexer for SAS
+        /// </summary>
+        SCLEX_SAS,
+        /// <summary>
+        /// Lexer for SML
+        /// </summary>
+        SCLEX_SML,
+        /// <summary>
+        /// Lexer for SQL, including PL/SQL and SQL*Plus.
+        /// </summary>
+        SCLEX_SQL,
+        /// <summary>
+        /// Lexer for Structured Text language.
+        /// </summary>
+        SCLEX_STTXT,
+        /// <summary>
+        /// Lexer for Scriptol
+        /// </summary>
+        SCLEX_SCRIPTOL,
+        /// <summary>
+        /// Lexer for SmallTalk
+        /// </summary>
+        SCLEX_SMALLTALK,
+        /// <summary>
+        /// Lexer for SORCUS installation files
+        /// </summary>
+        SCLEX_SORCUS,
+        /// <summary>
+        /// Lexer for Specman E language.
+        /// </summary>
+        SCLEX_SPECMAN,
+        /// <summary>
+        /// Lexer for SPICE
+        /// </summary>
+        SCLEX_SPICE,
+        /// <summary>
+        /// Lexer for Stata
+        /// </summary>
+        SCLEX_STATA,
+        /// <summary>
+        /// Lexer for TACL
+        /// </summary>
+        SCLEX_TACL,
+        /// <summary>
+        /// Lexer for TADS3
+        /// </summary>
+        SCLEX_TADS3,
+        /// <summary>
+        /// Lexer for TAL
+        /// </summary>
+        SCLEX_TAL,
+        /// <summary>
+        /// Lexer for TCL
+        /// </summary>
+        SCLEX_TCL,
+        /// <summary>
+        /// Lexer for Take Command / TCC batch scripts (.bat, .btm, .cmd).
+        /// </summary>
+        SCLEX_TCMD,
+        /// <summary>
+        /// Lexer for LaTeX general context conformant tex coloring scheme
+        /// </summary>
+        SCLEX_TEX,
+        /// <summary>
+        /// A simple Txt2tags lexer for scintilla.
+        /// </summary>
+        SCLEX_TXT2TAGS,
+        /// <summary>
+        /// Visual Basic
+        /// </summary>
+        SCLEX_VB,
+        /// <summary>
+        /// Visual Basic Script
+        /// </summary>
+        SCLEX_VBSCRIPT,
+        /// <summary>
+        /// Lexer for vhdl
+        /// </summary>
+        SCLEX_VHDL,
+        /// <summary>
+        /// Lexer for Verilog
+        /// </summary>
+        SCLEX_VERILOG,
+        /// <summary>
+        /// Lexer for Visual Prolog
+        /// </summary>
+        SCLEX_VISUALPROLOG,
+        /// <summary>
+        /// Lexer for X12
+        /// </summary>
+        SCLEX_X12,
+        /// <summary>
+        /// Lexer for Yaml
+        /// </summary>
+        SCLEX_YAML,
+    }
 }

--- a/Scintilla.NET/Lexilla.cs
+++ b/Scintilla.NET/Lexilla.cs
@@ -3,151 +3,152 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// A class containing methods for interacting with the Lexilla library.
-/// </summary>
-public class Lexilla
+namespace ScintillaNET
 {
     /// <summary>
-    /// Initializes the Lexilla.dll library.
+    /// A class containing methods for interacting with the Lexilla library.
     /// </summary>
-    /// <param name="lexillaHandle">The handle to the Lexilla.dll file.</param>
-    internal Lexilla(IntPtr lexillaHandle)
+    public class Lexilla
     {
-        const string win32Error = "The Scintilla module has no export for the '{0}' procedure.";
-
-        string lpProcName = nameof(NativeMethods.CreateLexer);
-
-        // Get the Lexilla functions needed to define lexers and create managed callbacks...
-
-        IntPtr functionPointer = NativeMethods.GetProcAddress(new HandleRef(this, lexillaHandle), lpProcName);
-        if (functionPointer == IntPtr.Zero)
+        /// <summary>
+        /// Initializes the Lexilla.dll library.
+        /// </summary>
+        /// <param name="lexillaHandle">The handle to the Lexilla.dll file.</param>
+        internal Lexilla(IntPtr lexillaHandle)
         {
-            throw new Win32Exception(string.Format(win32Error, lpProcName),
-                new Win32Exception()); // Calls GetLastError
+            const string win32Error = "The Scintilla module has no export for the '{0}' procedure.";
+
+            string lpProcName = nameof(NativeMethods.CreateLexer);
+
+            // Get the Lexilla functions needed to define lexers and create managed callbacks...
+
+            IntPtr functionPointer = NativeMethods.GetProcAddress(new HandleRef(this, lexillaHandle), lpProcName);
+            if (functionPointer == IntPtr.Zero)
+            {
+                throw new Win32Exception(string.Format(win32Error, lpProcName),
+                    new Win32Exception()); // Calls GetLastError
+            }
+
+            createLexer = (NativeMethods.CreateLexer)Marshal.GetDelegateForFunctionPointer(
+                functionPointer, typeof(NativeMethods.CreateLexer));
+
+            lpProcName = nameof(NativeMethods.GetLexerName);
+
+            functionPointer = NativeMethods.GetProcAddress(new HandleRef(this, lexillaHandle), lpProcName);
+            if (functionPointer == IntPtr.Zero)
+            {
+                throw new Win32Exception(string.Format(win32Error, lpProcName),
+                    new Win32Exception()); // Calls GetLastError
+            }
+
+            getLexerName = (NativeMethods.GetLexerName)Marshal.GetDelegateForFunctionPointer(
+                functionPointer, typeof(NativeMethods.GetLexerName));
+
+            lpProcName = nameof(NativeMethods.GetLexerCount);
+
+            functionPointer = NativeMethods.GetProcAddress(new HandleRef(this, lexillaHandle), lpProcName);
+            if (functionPointer == IntPtr.Zero)
+            {
+                throw new Win32Exception(string.Format(win32Error, lpProcName),
+                    new Win32Exception()); // Calls GetLastError
+            }
+
+            getLexerCount = (NativeMethods.GetLexerCount)Marshal.GetDelegateForFunctionPointer(
+                functionPointer, typeof(NativeMethods.GetLexerCount));
+
+            lpProcName = nameof(NativeMethods.LexerNameFromID);
+
+            functionPointer = NativeMethods.GetProcAddress(new HandleRef(this, lexillaHandle), lpProcName);
+            if (functionPointer == IntPtr.Zero)
+            {
+                throw new Win32Exception(string.Format(win32Error, lpProcName),
+                    new Win32Exception()); // Calls GetLastError
+            }
+
+            lexerNameFromId = (NativeMethods.LexerNameFromID)Marshal.GetDelegateForFunctionPointer(
+                functionPointer, typeof(NativeMethods.LexerNameFromID));
+
+            //initialized = true;
         }
 
-        createLexer = (NativeMethods.CreateLexer)Marshal.GetDelegateForFunctionPointer(
-            functionPointer, typeof(NativeMethods.CreateLexer));
+        #region Fields
 
-        lpProcName = nameof(NativeMethods.GetLexerName);
+        //private static bool initialized;
 
-        functionPointer = NativeMethods.GetProcAddress(new HandleRef(this, lexillaHandle), lpProcName);
-        if (functionPointer == IntPtr.Zero)
+        #endregion
+
+        #region DllCalls
+        private static NativeMethods.GetLexerCount getLexerCount;
+
+        private static NativeMethods.GetLexerName getLexerName;
+
+        private static NativeMethods.CreateLexer createLexer;
+
+        private static NativeMethods.LexerNameFromID lexerNameFromId;
+        #endregion
+
+        #region DllWrapping
+
+        /// <summary>
+        /// Gets the lexer count in the Lexilla library.
+        /// </summary>
+        /// <returns>Amount of lexers defined in the Lexilla library.</returns>
+        public static int GetLexerCount()
         {
-            throw new Win32Exception(string.Format(win32Error, lpProcName),
-                new Win32Exception()); // Calls GetLastError
+            return (int)getLexerCount();
         }
 
-        getLexerName = (NativeMethods.GetLexerName)Marshal.GetDelegateForFunctionPointer(
-            functionPointer, typeof(NativeMethods.GetLexerName));
-
-        lpProcName = nameof(NativeMethods.GetLexerCount);
-
-        functionPointer = NativeMethods.GetProcAddress(new HandleRef(this, lexillaHandle), lpProcName);
-        if (functionPointer == IntPtr.Zero)
+        /// <summary>
+        /// Creates a lexer with the specified name.
+        /// </summary>
+        /// <param name="lexerName">The name of the lexer to create.</param>
+        /// <returns>A <see cref="IntPtr"/> containing the lexer interface pointer.</returns>
+        public static IntPtr CreateLexer(string lexerName)
         {
-            throw new Win32Exception(string.Format(win32Error, lpProcName),
-                new Win32Exception()); // Calls GetLastError
+            return createLexer(lexerName);
         }
 
-        getLexerCount = (NativeMethods.GetLexerCount)Marshal.GetDelegateForFunctionPointer(
-            functionPointer, typeof(NativeMethods.GetLexerCount));
-
-        lpProcName = nameof(NativeMethods.LexerNameFromID);
-
-        functionPointer = NativeMethods.GetProcAddress(new HandleRef(this, lexillaHandle), lpProcName);
-        if (functionPointer == IntPtr.Zero)
+        /// <summary>
+        /// Gets the name of the lexer specified by an index number.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns>The name of the lexer if one was found with the specified index; <c>null</c> otherwise.</returns>
+        public static string GetLexerName(int index)
         {
-            throw new Win32Exception(string.Format(win32Error, lpProcName),
-                new Win32Exception()); // Calls GetLastError
+            IntPtr pointer = Marshal.AllocHGlobal(1024);
+            try
+            {
+                getLexerName((UIntPtr)index, pointer, new IntPtr(1024));
+                return Marshal.PtrToStringAnsi(pointer);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(pointer);
+            }
         }
 
-        lexerNameFromId = (NativeMethods.LexerNameFromID)Marshal.GetDelegateForFunctionPointer(
-            functionPointer, typeof(NativeMethods.LexerNameFromID));
+        /// <summary>
+        /// Returns a lexer name with the specified identifier.
+        /// </summary>
+        /// <param name="identifier">The lexer identifier.</param>
+        /// <returns>The name of the lexer if one was found with the specified identifier; <c>null</c> otherwise.</returns>
+        public static string LexerNameFromId(int identifier)
+        {
+            return lexerNameFromId(new IntPtr(identifier));
+        }
 
-        //initialized = true;
+        /// <summary>
+        /// Gets the lexer names contained in the Lexilla library.
+        /// </summary>
+        /// <returns>An IEnumerable&lt;System.String&gt; value with the lexer names.</returns>
+        public static IEnumerable<string> GetLexerNames()
+        {
+            int count = GetLexerCount();
+            for (int i = 0; i < count; i++)
+            {
+                yield return GetLexerName(i);
+            }
+        }
+        #endregion
     }
-
-    #region Fields
-
-    //private static bool initialized;
-
-    #endregion
-
-    #region DllCalls
-    private static NativeMethods.GetLexerCount getLexerCount;
-
-    private static NativeMethods.GetLexerName getLexerName;
-
-    private static NativeMethods.CreateLexer createLexer;
-
-    private static NativeMethods.LexerNameFromID lexerNameFromId;
-    #endregion
-
-    #region DllWrapping
-
-    /// <summary>
-    /// Gets the lexer count in the Lexilla library.
-    /// </summary>
-    /// <returns>Amount of lexers defined in the Lexilla library.</returns>
-    public static int GetLexerCount()
-    {
-        return (int)getLexerCount();
-    }
-
-    /// <summary>
-    /// Creates a lexer with the specified name.
-    /// </summary>
-    /// <param name="lexerName">The name of the lexer to create.</param>
-    /// <returns>A <see cref="IntPtr"/> containing the lexer interface pointer.</returns>
-    public static IntPtr CreateLexer(string lexerName)
-    {
-        return createLexer(lexerName);
-    }
-
-    /// <summary>
-    /// Gets the name of the lexer specified by an index number.
-    /// </summary>
-    /// <param name="index">The index.</param>
-    /// <returns>The name of the lexer if one was found with the specified index; <c>null</c> otherwise.</returns>
-    public static string GetLexerName(int index)
-    {
-        IntPtr pointer = Marshal.AllocHGlobal(1024);
-        try
-        {
-            getLexerName((UIntPtr)index, pointer, new IntPtr(1024));
-            return Marshal.PtrToStringAnsi(pointer);
-        }
-        finally
-        {
-            Marshal.FreeHGlobal(pointer);
-        }
-    }
-
-    /// <summary>
-    /// Returns a lexer name with the specified identifier.
-    /// </summary>
-    /// <param name="identifier">The lexer identifier.</param>
-    /// <returns>The name of the lexer if one was found with the specified identifier; <c>null</c> otherwise.</returns>
-    public static string LexerNameFromId(int identifier)
-    {
-        return lexerNameFromId(new IntPtr(identifier));
-    }
-
-    /// <summary>
-    /// Gets the lexer names contained in the Lexilla library.
-    /// </summary>
-    /// <returns>An IEnumerable&lt;System.String&gt; value with the lexer names.</returns>
-    public static IEnumerable<string> GetLexerNames()
-    {
-        int count = GetLexerCount();
-        for (int i = 0; i < count; i++)
-        {
-            yield return GetLexerName(i);
-        }
-    }
-    #endregion
 }

--- a/Scintilla.NET/Line.cs
+++ b/Scintilla.NET/Line.cs
@@ -1,648 +1,649 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Represents a line of text in a <see cref="Scintilla" /> control.
-/// </summary>
-public class Line
+namespace ScintillaNET
 {
-    #region Fields
-
-    private readonly Scintilla scintilla;
-
-    #endregion Fields
-
-    #region Methods
-
     /// <summary>
-    /// Expands any parent folds to ensure the line is visible.
+    /// Represents a line of text in a <see cref="Scintilla" /> control.
     /// </summary>
-    public void EnsureVisible()
+    public class Line
     {
-        this.scintilla.DirectMessage(NativeMethods.SCI_ENSUREVISIBLE, new IntPtr(Index));
-    }
+        #region Fields
 
-    //public void ExpandChildren(int level)
-    //{
-    //}
+        private readonly Scintilla scintilla;
 
-    /// <summary>
-    /// Performs the specified fold action on the current line and all child lines.
-    /// </summary>
-    /// <param name="action">One of the <see cref="FoldAction" /> enumeration values.</param>
-    public void FoldChildren(FoldAction action)
-    {
-        this.scintilla.DirectMessage(NativeMethods.SCI_FOLDCHILDREN, new IntPtr(Index), new IntPtr((int)action));
-    }
+        #endregion Fields
 
-    /// <summary>
-    /// Performs the specified fold action on the current line.
-    /// </summary>
-    /// <param name="action">One of the <see cref="FoldAction" /> enumeration values.</param>
-    public void FoldLine(FoldAction action)
-    {
-        this.scintilla.DirectMessage(NativeMethods.SCI_FOLDLINE, new IntPtr(Index), new IntPtr((int)action));
-    }
+        #region Methods
 
-    /// <summary>
-    /// Searches for the next line that has a folding level that is less than or equal to <paramref name="level" />
-    /// and returns the previous line index.
-    /// </summary>
-    /// <param name="level">The level of the line to search for. A value of -1 will use the current line <see cref="FoldLevel" />.</param>
-    /// <returns>
-    /// The zero-based index of the next line that has a <see cref="FoldLevel" /> less than or equal
-    /// to <paramref name="level" />. If the current line is a fold point and <paramref name="level"/> is -1 the
-    /// index returned is the last line that would be made visible or hidden by toggling the fold state.
-    /// </returns>
-    public int GetLastChild(int level)
-    {
-        return this.scintilla.DirectMessage(NativeMethods.SCI_GETLASTCHILD, new IntPtr(Index), new IntPtr(level)).ToInt32();
-    }
-
-    /// <summary>
-    /// Navigates the caret to the start of the line.
-    /// </summary>
-    /// <remarks>Any selection is discarded.</remarks>
-    public void Goto()
-    {
-        this.scintilla.DirectMessage(NativeMethods.SCI_GOTOLINE, new IntPtr(Index));
-    }
-
-    /// <summary>
-    /// Adds the specified <see cref="Marker" /> to the line.
-    /// </summary>
-    /// <param name="marker">The zero-based index of the marker to add to the line.</param>
-    /// <returns>A <see cref="MarkerHandle" /> which can be used to track the line.</returns>
-    /// <remarks>This method does not check if the line already contains the <paramref name="marker" />.</remarks>
-    public MarkerHandle MarkerAdd(int marker)
-    {
-        marker = Helpers.Clamp(marker, 0, this.scintilla.Markers.Count - 1);
-        IntPtr handle = this.scintilla.DirectMessage(NativeMethods.SCI_MARKERADD, new IntPtr(Index), new IntPtr(marker));
-        return new MarkerHandle { Value = handle };
-    }
-
-    /// <summary>
-    /// Adds one or more markers to the line in a single call using a bit mask.
-    /// </summary>
-    /// <param name="markerMask">An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Margin" /> indexes to add.</param>
-    public void MarkerAddSet(uint markerMask)
-    {
-        int mask = unchecked((int)markerMask);
-        this.scintilla.DirectMessage(NativeMethods.SCI_MARKERADDSET, new IntPtr(Index), new IntPtr(mask));
-    }
-
-    /// <summary>
-    /// Removes the specified <see cref="Marker" /> from the line.
-    /// </summary>
-    /// <param name="marker">The zero-based index of the marker to remove from the line or -1 to delete all markers from the line.</param>
-    /// <remarks>If the same marker has been added to the line more than once, this will delete one copy each time it is used.</remarks>
-    public void MarkerDelete(int marker)
-    {
-        marker = Helpers.Clamp(marker, -1, this.scintilla.Markers.Count - 1);
-        this.scintilla.DirectMessage(NativeMethods.SCI_MARKERDELETE, new IntPtr(Index), new IntPtr(marker));
-    }
-
-    /// <summary>
-    /// Returns a bit mask indicating which markers are present on the line.
-    /// </summary>
-    /// <returns>An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Marker" /> indexes.</returns>
-    public uint MarkerGet()
-    {
-        int mask = this.scintilla.DirectMessage(NativeMethods.SCI_MARKERGET, new IntPtr(Index)).ToInt32();
-        return unchecked((uint)mask);
-    }
-
-    /// <summary>
-    /// Efficiently searches from the current line forward to the end of the document for the specified markers.
-    /// </summary>
-    /// <param name="markerMask">An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Margin" /> indexes.</param>
-    /// <returns>If found, the zero-based line index containing one of the markers in <paramref name="markerMask" />; otherwise, -1.</returns>
-    /// <remarks>For example, the mask for marker index 10 is 1 shifted left 10 times (1 &lt;&lt; 10).</remarks>
-    public int MarkerNext(uint markerMask)
-    {
-        int mask = unchecked((int)markerMask);
-        return this.scintilla.DirectMessage(NativeMethods.SCI_MARKERNEXT, new IntPtr(Index), new IntPtr(mask)).ToInt32();
-    }
-
-    /// <summary>
-    /// Efficiently searches from the current line backward to the start of the document for the specified markers.
-    /// </summary>
-    /// <param name="markerMask">An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Margin" /> indexes.</param>
-    /// <returns>If found, the zero-based line index containing one of the markers in <paramref name="markerMask" />; otherwise, -1.</returns>
-    /// <remarks>For example, the mask for marker index 10 is 1 shifted left 10 times (1 &lt;&lt; 10).</remarks>
-    public int MarkerPrevious(uint markerMask)
-    {
-        int mask = unchecked((int)markerMask);
-        return this.scintilla.DirectMessage(NativeMethods.SCI_MARKERPREVIOUS, new IntPtr(Index), new IntPtr(mask)).ToInt32();
-    }
-
-    /// <summary>
-    /// Toggles the folding state of the line; expanding or contracting all child lines.
-    /// </summary>
-    /// <remarks>The line must be set as a <see cref="ScintillaNET.FoldLevelFlags.Header" />.</remarks>
-    /// <seealso cref="ToggleFoldShowText"/>
-    public void ToggleFold()
-    {
-        this.scintilla.DirectMessage(NativeMethods.SCI_TOGGLEFOLD, new IntPtr(Index));
-    }
-
-    /// <summary>
-    /// Toggles the folding state of the line; expanding or contracting all child lines, and specifies the text tag to display to the right of the fold.
-    /// </summary>
-    /// <param name="text">The text tag to show to the right of the folded text.</param>
-    /// <remarks>The display of fold text tags are determined by the <see cref="Scintilla.FoldDisplayTextSetStyle" /> method.</remarks>
-    /// <seealso cref="Scintilla.FoldDisplayTextSetStyle" />
-    public unsafe void ToggleFoldShowText(string text)
-    {
-        if (string.IsNullOrEmpty(text))
+        /// <summary>
+        /// Expands any parent folds to ensure the line is visible.
+        /// </summary>
+        public void EnsureVisible()
         {
-            this.scintilla.DirectMessage(NativeMethods.SCI_TOGGLEFOLDSHOWTEXT, new IntPtr(Index), IntPtr.Zero);
+            this.scintilla.DirectMessage(NativeMethods.SCI_ENSUREVISIBLE, new IntPtr(Index));
         }
-        else
+
+        //public void ExpandChildren(int level)
+        //{
+        //}
+
+        /// <summary>
+        /// Performs the specified fold action on the current line and all child lines.
+        /// </summary>
+        /// <param name="action">One of the <see cref="FoldAction" /> enumeration values.</param>
+        public void FoldChildren(FoldAction action)
         {
-            byte[] bytes = Helpers.GetBytes(text, this.scintilla.Encoding, zeroTerminated: true);
-            fixed (byte* bp = bytes)
-                this.scintilla.DirectMessage(NativeMethods.SCI_TOGGLEFOLDSHOWTEXT, new IntPtr(Index), new IntPtr(bp));
+            this.scintilla.DirectMessage(NativeMethods.SCI_FOLDCHILDREN, new IntPtr(Index), new IntPtr((int)action));
         }
-    }
 
-    #endregion Methods
-
-    #region Properties
-
-    /// <summary>
-    /// Gets the number of annotation lines of text.
-    /// </summary>
-    /// <returns>The number of annotation lines.</returns>
-    public int AnnotationLines
-    {
-        get
+        /// <summary>
+        /// Performs the specified fold action on the current line.
+        /// </summary>
+        /// <param name="action">One of the <see cref="FoldAction" /> enumeration values.</param>
+        public void FoldLine(FoldAction action)
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETLINES, new IntPtr(Index)).ToInt32();
+            this.scintilla.DirectMessage(NativeMethods.SCI_FOLDLINE, new IntPtr(Index), new IntPtr((int)action));
         }
-    }
 
-    /// <summary>
-    /// Gets or sets the style of the annotation text.
-    /// </summary>
-    /// <returns>
-    /// The zero-based index of the annotation text <see cref="Style" /> or 256 when <see cref="AnnotationStyles" />
-    /// has been used to set individual character styles.
-    /// </returns>
-    /// <seealso cref="AnnotationStyles" />
-    public int AnnotationStyle
-    {
-        get
+        /// <summary>
+        /// Searches for the next line that has a folding level that is less than or equal to <paramref name="level" />
+        /// and returns the previous line index.
+        /// </summary>
+        /// <param name="level">The level of the line to search for. A value of -1 will use the current line <see cref="FoldLevel" />.</param>
+        /// <returns>
+        /// The zero-based index of the next line that has a <see cref="FoldLevel" /> less than or equal
+        /// to <paramref name="level" />. If the current line is a fold point and <paramref name="level"/> is -1 the
+        /// index returned is the last line that would be made visible or hidden by toggling the fold state.
+        /// </returns>
+        public int GetLastChild(int level)
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETSTYLE, new IntPtr(Index)).ToInt32();
+            return this.scintilla.DirectMessage(NativeMethods.SCI_GETLASTCHILD, new IntPtr(Index), new IntPtr(level)).ToInt32();
         }
-        set
+
+        /// <summary>
+        /// Navigates the caret to the start of the line.
+        /// </summary>
+        /// <remarks>Any selection is discarded.</remarks>
+        public void Goto()
         {
-            value = Helpers.Clamp(value, 0, this.scintilla.Styles.Count - 1);
-            this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONSETSTYLE, new IntPtr(Index), new IntPtr(value));
+            this.scintilla.DirectMessage(NativeMethods.SCI_GOTOLINE, new IntPtr(Index));
         }
-    }
 
-    /// <summary>
-    /// Gets or sets an array of style indexes corresponding to each charcter in the <see cref="AnnotationText" />
-    /// so that each character may be individually styled.
-    /// </summary>
-    /// <returns>
-    /// An array of <see cref="Style" /> indexes corresponding with each annotation text character or an uninitialized
-    /// array when <see cref="AnnotationStyle" /> has been used to set a single style for all characters.
-    /// </returns>
-    /// <remarks>
-    /// <see cref="AnnotationText" /> must be set prior to setting this property.
-    /// The <paramref name="value" /> specified should have a length equal to the <see cref="AnnotationText" /> length to properly style all characters.
-    /// </remarks>
-    /// <seealso cref="AnnotationStyle" />
-    public unsafe byte[] AnnotationStyles
-    {
-        get
+        /// <summary>
+        /// Adds the specified <see cref="Marker" /> to the line.
+        /// </summary>
+        /// <param name="marker">The zero-based index of the marker to add to the line.</param>
+        /// <returns>A <see cref="MarkerHandle" /> which can be used to track the line.</returns>
+        /// <remarks>This method does not check if the line already contains the <paramref name="marker" />.</remarks>
+        public MarkerHandle MarkerAdd(int marker)
         {
-            int length = this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index)).ToInt32();
-            if (length == 0)
-                return new byte[0];
+            marker = Helpers.Clamp(marker, 0, this.scintilla.Markers.Count - 1);
+            IntPtr handle = this.scintilla.DirectMessage(NativeMethods.SCI_MARKERADD, new IntPtr(Index), new IntPtr(marker));
+            return new MarkerHandle { Value = handle };
+        }
 
-            byte[] text = new byte[length + 1];
-            byte[] styles = new byte[length + 1];
+        /// <summary>
+        /// Adds one or more markers to the line in a single call using a bit mask.
+        /// </summary>
+        /// <param name="markerMask">An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Margin" /> indexes to add.</param>
+        public void MarkerAddSet(uint markerMask)
+        {
+            int mask = unchecked((int)markerMask);
+            this.scintilla.DirectMessage(NativeMethods.SCI_MARKERADDSET, new IntPtr(Index), new IntPtr(mask));
+        }
 
-            fixed (byte* textPtr = text)
-            fixed (byte* stylePtr = styles)
+        /// <summary>
+        /// Removes the specified <see cref="Marker" /> from the line.
+        /// </summary>
+        /// <param name="marker">The zero-based index of the marker to remove from the line or -1 to delete all markers from the line.</param>
+        /// <remarks>If the same marker has been added to the line more than once, this will delete one copy each time it is used.</remarks>
+        public void MarkerDelete(int marker)
+        {
+            marker = Helpers.Clamp(marker, -1, this.scintilla.Markers.Count - 1);
+            this.scintilla.DirectMessage(NativeMethods.SCI_MARKERDELETE, new IntPtr(Index), new IntPtr(marker));
+        }
+
+        /// <summary>
+        /// Returns a bit mask indicating which markers are present on the line.
+        /// </summary>
+        /// <returns>An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Marker" /> indexes.</returns>
+        public uint MarkerGet()
+        {
+            int mask = this.scintilla.DirectMessage(NativeMethods.SCI_MARKERGET, new IntPtr(Index)).ToInt32();
+            return unchecked((uint)mask);
+        }
+
+        /// <summary>
+        /// Efficiently searches from the current line forward to the end of the document for the specified markers.
+        /// </summary>
+        /// <param name="markerMask">An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Margin" /> indexes.</param>
+        /// <returns>If found, the zero-based line index containing one of the markers in <paramref name="markerMask" />; otherwise, -1.</returns>
+        /// <remarks>For example, the mask for marker index 10 is 1 shifted left 10 times (1 &lt;&lt; 10).</remarks>
+        public int MarkerNext(uint markerMask)
+        {
+            int mask = unchecked((int)markerMask);
+            return this.scintilla.DirectMessage(NativeMethods.SCI_MARKERNEXT, new IntPtr(Index), new IntPtr(mask)).ToInt32();
+        }
+
+        /// <summary>
+        /// Efficiently searches from the current line backward to the start of the document for the specified markers.
+        /// </summary>
+        /// <param name="markerMask">An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Margin" /> indexes.</param>
+        /// <returns>If found, the zero-based line index containing one of the markers in <paramref name="markerMask" />; otherwise, -1.</returns>
+        /// <remarks>For example, the mask for marker index 10 is 1 shifted left 10 times (1 &lt;&lt; 10).</remarks>
+        public int MarkerPrevious(uint markerMask)
+        {
+            int mask = unchecked((int)markerMask);
+            return this.scintilla.DirectMessage(NativeMethods.SCI_MARKERPREVIOUS, new IntPtr(Index), new IntPtr(mask)).ToInt32();
+        }
+
+        /// <summary>
+        /// Toggles the folding state of the line; expanding or contracting all child lines.
+        /// </summary>
+        /// <remarks>The line must be set as a <see cref="ScintillaNET.FoldLevelFlags.Header" />.</remarks>
+        /// <seealso cref="ToggleFoldShowText"/>
+        public void ToggleFold()
+        {
+            this.scintilla.DirectMessage(NativeMethods.SCI_TOGGLEFOLD, new IntPtr(Index));
+        }
+
+        /// <summary>
+        /// Toggles the folding state of the line; expanding or contracting all child lines, and specifies the text tag to display to the right of the fold.
+        /// </summary>
+        /// <param name="text">The text tag to show to the right of the folded text.</param>
+        /// <remarks>The display of fold text tags are determined by the <see cref="Scintilla.FoldDisplayTextSetStyle" /> method.</remarks>
+        /// <seealso cref="Scintilla.FoldDisplayTextSetStyle" />
+        public unsafe void ToggleFoldShowText(string text)
+        {
+            if (string.IsNullOrEmpty(text))
             {
-                this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index), new IntPtr(textPtr));
-                this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETSTYLES, new IntPtr(Index), new IntPtr(stylePtr));
-
-                return Helpers.ByteToCharStyles(stylePtr, textPtr, length, this.scintilla.Encoding);
-            }
-        }
-        set
-        {
-            int length = this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index)).ToInt32();
-            if (length == 0)
-                return;
-
-            byte[] text = new byte[length + 1];
-            fixed (byte* textPtr = text)
-            {
-                this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index), new IntPtr(textPtr));
-
-                byte[] styles = Helpers.CharToByteStyles(value ?? new byte[0], textPtr, length, this.scintilla.Encoding);
-                fixed (byte* stylePtr = styles)
-                    this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONSETSTYLES, new IntPtr(Index), new IntPtr(stylePtr));
-            }
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the line annotation text.
-    /// </summary>
-    /// <returns>A String representing the line annotation text.</returns>
-    public unsafe string AnnotationText
-    {
-        get
-        {
-            int length = this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index)).ToInt32();
-            if (length == 0)
-                return string.Empty;
-
-            byte[] bytes = new byte[length + 1];
-            fixed (byte* bp = bytes)
-            {
-                this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index), new IntPtr(bp));
-                return Helpers.GetString(new IntPtr(bp), length, this.scintilla.Encoding);
-            }
-        }
-        set
-        {
-            // allow empty annotation, set to null to remove
-            if (value == null)
-            {
-                // Scintilla docs suggest that setting to NULL rather than an empty string will free memory
-                this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONSETTEXT, new IntPtr(Index), IntPtr.Zero);
+                this.scintilla.DirectMessage(NativeMethods.SCI_TOGGLEFOLDSHOWTEXT, new IntPtr(Index), IntPtr.Zero);
             }
             else
             {
-                byte[] bytes = Helpers.GetBytes(value, this.scintilla.Encoding, zeroTerminated: true);
+                byte[] bytes = Helpers.GetBytes(text, this.scintilla.Encoding, zeroTerminated: true);
                 fixed (byte* bp = bytes)
-                    this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONSETTEXT, new IntPtr(Index), new IntPtr(bp));
+                    this.scintilla.DirectMessage(NativeMethods.SCI_TOGGLEFOLDSHOWTEXT, new IntPtr(Index), new IntPtr(bp));
             }
         }
-    }
 
-    /// <summary>
-    /// Searches from the current line to find the index of the next contracted fold header.
-    /// </summary>
-    /// <returns>The zero-based line index of the next contracted folder header.</returns>
-    /// <remarks>If the current line is contracted the current line index is returned.</remarks>
-    public int ContractedFoldNext
-    {
-        get
+        #endregion Methods
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the number of annotation lines of text.
+        /// </summary>
+        /// <returns>The number of annotation lines.</returns>
+        public int AnnotationLines
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_CONTRACTEDFOLDNEXT, new IntPtr(Index)).ToInt32();
-        }
-    }
-
-    /// <summary>
-    /// Gets the zero-based index of the line as displayed in a <see cref="Scintilla" /> control
-    /// taking into consideration folded (hidden) lines.
-    /// </summary>
-    /// <returns>The zero-based display line index.</returns>
-    /// <seealso cref="Scintilla.DocLineFromVisible" />
-    public int DisplayIndex
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_VISIBLEFROMDOCLINE, new IntPtr(Index)).ToInt32();
-        }
-    }
-
-    /// <summary>
-    /// Gets the zero-based character position in the document where the line ends (exclusive).
-    /// </summary>
-    /// <returns>The equivalent of <see cref="Position" /> + <see cref="Length" />.</returns>
-    public int EndPosition
-    {
-        get
-        {
-            return Position + Length;
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the expanded state (not the visible state) of the line.
-    /// </summary>
-    /// <remarks>
-    /// For toggling the fold state of a single line the <see cref="ToggleFold" /> method should be used.
-    /// This property is useful for toggling the state of many folds without updating the display until finished.
-    /// </remarks>
-    /// <seealso cref="ToggleFold" />
-    public bool Expanded
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETFOLDEXPANDED, new IntPtr(Index)) != IntPtr.Zero;
-        }
-        set
-        {
-            IntPtr expanded = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETFOLDEXPANDED, new IntPtr(Index), expanded);
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the fold level of the line.
-    /// </summary>
-    /// <returns>The fold level ranging from 0 to 4095. The default is 1024.</returns>
-    public int FoldLevel
-    {
-        get
-        {
-            int level = this.scintilla.DirectMessage(NativeMethods.SCI_GETFOLDLEVEL, new IntPtr(Index)).ToInt32();
-            return level & NativeMethods.SC_FOLDLEVELNUMBERMASK;
-        }
-        set
-        {
-            int bits = (int)FoldLevelFlags;
-            bits |= value;
-
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETFOLDLEVEL, new IntPtr(Index), new IntPtr(bits));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the fold level flags.
-    /// </summary>
-    /// <returns>A bitwise combination of the <see cref="FoldLevelFlags" /> enumeration.</returns>
-    public FoldLevelFlags FoldLevelFlags
-    {
-        get
-        {
-            int flags = this.scintilla.DirectMessage(NativeMethods.SCI_GETFOLDLEVEL, new IntPtr(Index)).ToInt32();
-            return (FoldLevelFlags)(flags & ~NativeMethods.SC_FOLDLEVELNUMBERMASK);
-        }
-        set
-        {
-            int bits = FoldLevel;
-            bits |= (int)value;
-
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETFOLDLEVEL, new IntPtr(Index), new IntPtr(bits));
-        }
-    }
-
-    /// <summary>
-    /// Gets the zero-based line index of the first line before the current line that is marked as
-    /// <see cref="ScintillaNET.FoldLevelFlags.Header" /> and has a <see cref="FoldLevel" /> less than the current line.
-    /// </summary>
-    /// <returns>The zero-based line index of the fold parent if present; otherwise, -1.</returns>
-    public int FoldParent
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETFOLDPARENT, new IntPtr(Index)).ToInt32();
-        }
-    }
-
-    /// <summary>
-    /// Gets the height of the line in pixels.
-    /// </summary>
-    /// <returns>The height in pixels of the line.</returns>
-    /// <remarks>Currently all lines are the same height.</remarks>
-    public int Height
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_TEXTHEIGHT, new IntPtr(Index)).ToInt32();
-        }
-    }
-
-    /// <summary>
-    /// Gets the line index.
-    /// </summary>
-    /// <returns>The zero-based line index within the <see cref="LineCollection" /> that created it.</returns>
-    public int Index { get; private set; }
-
-    /// <summary>
-    /// Gets the length of the line.
-    /// </summary>
-    /// <returns>The number of characters in the line including any end of line characters.</returns>
-    public int Length
-    {
-        get
-        {
-            return this.scintilla.Lines.CharLineLength(Index);
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the style of the margin text in a <see cref="MarginType.Text" /> or <see cref="MarginType.RightText" /> margin.
-    /// </summary>
-    /// <returns>
-    /// The zero-based index of the margin text <see cref="Style" /> or 256 when <see cref="MarginStyles" />
-    /// has been used to set individual character styles.
-    /// </returns>
-    /// <seealso cref="MarginStyles" />
-    public int MarginStyle
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETSTYLE, new IntPtr(Index)).ToInt32();
-        }
-        set
-        {
-            value = Helpers.Clamp(value, 0, this.scintilla.Styles.Count - 1);
-            this.scintilla.DirectMessage(NativeMethods.SCI_MARGINSETSTYLE, new IntPtr(Index), new IntPtr(value));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets an array of style indexes corresponding to each charcter in the <see cref="MarginText" />
-    /// so that each character may be individually styled.
-    /// </summary>
-    /// <returns>
-    /// An array of <see cref="Style" /> indexes corresponding with each margin text character or an uninitialized
-    /// array when <see cref="MarginStyle" /> has been used to set a single style for all characters.
-    /// </returns>
-    /// <remarks>
-    /// <see cref="MarginText" /> must be set prior to setting this property.
-    /// The <paramref name="value" /> specified should have a length equal to the <see cref="MarginText" /> length to properly style all characters.
-    /// </remarks>
-    /// <seealso cref="MarginStyle" />
-    public unsafe byte[] MarginStyles
-    {
-        get
-        {
-            int length = this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index)).ToInt32();
-            if (length == 0)
-                return new byte[0];
-
-            byte[] text = new byte[length + 1];
-            byte[] styles = new byte[length + 1];
-
-            fixed (byte* textPtr = text)
-            fixed (byte* stylePtr = styles)
+            get
             {
-                this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index), new IntPtr(textPtr));
-                this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETSTYLES, new IntPtr(Index), new IntPtr(stylePtr));
-
-                return Helpers.ByteToCharStyles(stylePtr, textPtr, length, this.scintilla.Encoding);
+                return this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETLINES, new IntPtr(Index)).ToInt32();
             }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets the style of the annotation text.
+        /// </summary>
+        /// <returns>
+        /// The zero-based index of the annotation text <see cref="Style" /> or 256 when <see cref="AnnotationStyles" />
+        /// has been used to set individual character styles.
+        /// </returns>
+        /// <seealso cref="AnnotationStyles" />
+        public int AnnotationStyle
         {
-            int length = this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index)).ToInt32();
-            if (length == 0)
-                return;
-
-            byte[] text = new byte[length + 1];
-            fixed (byte* textPtr = text)
+            get
             {
-                this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index), new IntPtr(textPtr));
+                return this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETSTYLE, new IntPtr(Index)).ToInt32();
+            }
+            set
+            {
+                value = Helpers.Clamp(value, 0, this.scintilla.Styles.Count - 1);
+                this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONSETSTYLE, new IntPtr(Index), new IntPtr(value));
+            }
+        }
 
-                byte[] styles = Helpers.CharToByteStyles(value ?? new byte[0], textPtr, length, this.scintilla.Encoding);
+        /// <summary>
+        /// Gets or sets an array of style indexes corresponding to each charcter in the <see cref="AnnotationText" />
+        /// so that each character may be individually styled.
+        /// </summary>
+        /// <returns>
+        /// An array of <see cref="Style" /> indexes corresponding with each annotation text character or an uninitialized
+        /// array when <see cref="AnnotationStyle" /> has been used to set a single style for all characters.
+        /// </returns>
+        /// <remarks>
+        /// <see cref="AnnotationText" /> must be set prior to setting this property.
+        /// The <paramref name="value" /> specified should have a length equal to the <see cref="AnnotationText" /> length to properly style all characters.
+        /// </remarks>
+        /// <seealso cref="AnnotationStyle" />
+        public unsafe byte[] AnnotationStyles
+        {
+            get
+            {
+                int length = this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index)).ToInt32();
+                if (length == 0)
+                    return new byte[0];
+
+                byte[] text = new byte[length + 1];
+                byte[] styles = new byte[length + 1];
+
+                fixed (byte* textPtr = text)
                 fixed (byte* stylePtr = styles)
-                    this.scintilla.DirectMessage(NativeMethods.SCI_MARGINSETSTYLES, new IntPtr(Index), new IntPtr(stylePtr));
+                {
+                    this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index), new IntPtr(textPtr));
+                    this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETSTYLES, new IntPtr(Index), new IntPtr(stylePtr));
+
+                    return Helpers.ByteToCharStyles(stylePtr, textPtr, length, this.scintilla.Encoding);
+                }
+            }
+            set
+            {
+                int length = this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index)).ToInt32();
+                if (length == 0)
+                    return;
+
+                byte[] text = new byte[length + 1];
+                fixed (byte* textPtr = text)
+                {
+                    this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index), new IntPtr(textPtr));
+
+                    byte[] styles = Helpers.CharToByteStyles(value ?? new byte[0], textPtr, length, this.scintilla.Encoding);
+                    fixed (byte* stylePtr = styles)
+                        this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONSETSTYLES, new IntPtr(Index), new IntPtr(stylePtr));
+                }
             }
         }
-    }
 
-    /// <summary>
-    /// Gets or sets the text displayed in the line margin when the margin type is
-    /// <see cref="MarginType.Text" /> or <see cref="MarginType.RightText" />.
-    /// </summary>
-    /// <returns>The text displayed in the line margin.</returns>
-    public unsafe string MarginText
-    {
-        get
+        /// <summary>
+        /// Gets or sets the line annotation text.
+        /// </summary>
+        /// <returns>A String representing the line annotation text.</returns>
+        public unsafe string AnnotationText
         {
-            int length = this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index)).ToInt32();
-            if (length == 0)
-                return string.Empty;
+            get
+            {
+                int length = this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index)).ToInt32();
+                if (length == 0)
+                    return string.Empty;
 
-            byte[] bytes = new byte[length + 1];
-            fixed (byte* bp = bytes)
-            {
-                this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index), new IntPtr(bp));
-                return Helpers.GetString(new IntPtr(bp), length, this.scintilla.Encoding);
-            }
-        }
-        set
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                // Scintilla docs suggest that setting to NULL rather than an empty string will free memory
-                this.scintilla.DirectMessage(NativeMethods.SCI_MARGINSETTEXT, new IntPtr(Index), IntPtr.Zero);
-            }
-            else
-            {
-                byte[] bytes = Helpers.GetBytes(value, this.scintilla.Encoding, zeroTerminated: true);
+                byte[] bytes = new byte[length + 1];
                 fixed (byte* bp = bytes)
-                    this.scintilla.DirectMessage(NativeMethods.SCI_MARGINSETTEXT, new IntPtr(Index), new IntPtr(bp));
+                {
+                    this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONGETTEXT, new IntPtr(Index), new IntPtr(bp));
+                    return Helpers.GetString(new IntPtr(bp), length, this.scintilla.Encoding);
+                }
+            }
+            set
+            {
+                // allow empty annotation, set to null to remove
+                if (value == null)
+                {
+                    // Scintilla docs suggest that setting to NULL rather than an empty string will free memory
+                    this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONSETTEXT, new IntPtr(Index), IntPtr.Zero);
+                }
+                else
+                {
+                    byte[] bytes = Helpers.GetBytes(value, this.scintilla.Encoding, zeroTerminated: true);
+                    fixed (byte* bp = bytes)
+                        this.scintilla.DirectMessage(NativeMethods.SCI_ANNOTATIONSETTEXT, new IntPtr(Index), new IntPtr(bp));
+                }
             }
         }
-    }
 
-    /// <summary>
-    /// Gets the zero-based character position in the document where the line begins.
-    /// </summary>
-    /// <returns>The document position of the first character in the line.</returns>
-    public int Position
-    {
-        get
+        /// <summary>
+        /// Searches from the current line to find the index of the next contracted fold header.
+        /// </summary>
+        /// <returns>The zero-based line index of the next contracted folder header.</returns>
+        /// <remarks>If the current line is contracted the current line index is returned.</remarks>
+        public int ContractedFoldNext
         {
-            return this.scintilla.Lines.CharPositionFromLine(Index);
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_CONTRACTEDFOLDNEXT, new IntPtr(Index)).ToInt32();
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets the line text.
-    /// </summary>
-    /// <returns>A string representing the document line.</returns>
-    /// <remarks>The returned text includes any end of line characters.</remarks>
-    public unsafe string Text
-    {
-        get
+        /// <summary>
+        /// Gets the zero-based index of the line as displayed in a <see cref="Scintilla" /> control
+        /// taking into consideration folded (hidden) lines.
+        /// </summary>
+        /// <returns>The zero-based display line index.</returns>
+        /// <seealso cref="Scintilla.DocLineFromVisible" />
+        public int DisplayIndex
         {
-            IntPtr start = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(Index));
-            IntPtr length = this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(Index));
-            IntPtr ptr = this.scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, start, length);
-            if (ptr == IntPtr.Zero)
-                return string.Empty;
-
-            string text = new((sbyte*)ptr, 0, length.ToInt32(), this.scintilla.Encoding);
-            return text;
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_VISIBLEFROMDOCLINE, new IntPtr(Index)).ToInt32();
+            }
         }
-    }
 
-    /// <summary>
-    /// Sets or gets the line indentation.
-    /// </summary>
-    /// <returns>The indentation measured in character columns, which corresponds to the width of space characters.</returns>
-    public int Indentation
-    {
-        get
+        /// <summary>
+        /// Gets the zero-based character position in the document where the line ends (exclusive).
+        /// </summary>
+        /// <returns>The equivalent of <see cref="Position" /> + <see cref="Length" />.</returns>
+        public int EndPosition
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETLINEINDENTATION, new IntPtr(Index)).ToInt32();
+            get
+            {
+                return Position + Length;
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets the expanded state (not the visible state) of the line.
+        /// </summary>
+        /// <remarks>
+        /// For toggling the fold state of a single line the <see cref="ToggleFold" /> method should be used.
+        /// This property is useful for toggling the state of many folds without updating the display until finished.
+        /// </remarks>
+        /// <seealso cref="ToggleFold" />
+        public bool Expanded
         {
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETLINEINDENTATION, new IntPtr(Index), new IntPtr(value));
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETFOLDEXPANDED, new IntPtr(Index)) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr expanded = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETFOLDEXPANDED, new IntPtr(Index), expanded);
+            }
         }
-    }
 
-    /// <summary>
-    /// This returns the position at the end of indentation of a line.
-    /// </summary>
-    public int IndentPosition
-    {
-        get
+        /// <summary>
+        /// Gets or sets the fold level of the line.
+        /// </summary>
+        /// <returns>The fold level ranging from 0 to 4095. The default is 1024.</returns>
+        public int FoldLevel
         {
-            IntPtr pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETLINEINDENTPOSITION, new IntPtr(Index));
-            return this.scintilla.Lines.ByteToCharPosition(pos.ToInt32());
-        }
-    }
+            get
+            {
+                int level = this.scintilla.DirectMessage(NativeMethods.SCI_GETFOLDLEVEL, new IntPtr(Index)).ToInt32();
+                return level & NativeMethods.SC_FOLDLEVELNUMBERMASK;
+            }
+            set
+            {
+                int bits = (int)FoldLevelFlags;
+                bits |= value;
 
-    /// <summary>
-    /// Gets a value indicating whether the line is visible.
-    /// </summary>
-    /// <returns>true if the line is visible; otherwise, false.</returns>
-    /// <seealso cref="Scintilla.ShowLines" />
-    /// <seealso cref="Scintilla.HideLines" />
-    public bool Visible
-    {
-        get
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETFOLDLEVEL, new IntPtr(Index), new IntPtr(bits));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the fold level flags.
+        /// </summary>
+        /// <returns>A bitwise combination of the <see cref="FoldLevelFlags" /> enumeration.</returns>
+        public FoldLevelFlags FoldLevelFlags
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETLINEVISIBLE, new IntPtr(Index)) != IntPtr.Zero;
-        }
-    }
+            get
+            {
+                int flags = this.scintilla.DirectMessage(NativeMethods.SCI_GETFOLDLEVEL, new IntPtr(Index)).ToInt32();
+                return (FoldLevelFlags)(flags & ~NativeMethods.SC_FOLDLEVELNUMBERMASK);
+            }
+            set
+            {
+                int bits = FoldLevel;
+                bits |= (int)value;
 
-    /// <summary>
-    /// Gets the number of display lines this line would occupy when wrapping is enabled.
-    /// </summary>
-    /// <returns>The number of display lines needed to wrap the current document line.</returns>
-    public int WrapCount
-    {
-        get
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETFOLDLEVEL, new IntPtr(Index), new IntPtr(bits));
+            }
+        }
+
+        /// <summary>
+        /// Gets the zero-based line index of the first line before the current line that is marked as
+        /// <see cref="ScintillaNET.FoldLevelFlags.Header" /> and has a <see cref="FoldLevel" /> less than the current line.
+        /// </summary>
+        /// <returns>The zero-based line index of the fold parent if present; otherwise, -1.</returns>
+        public int FoldParent
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_WRAPCOUNT, new IntPtr(Index)).ToInt32();
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETFOLDPARENT, new IntPtr(Index)).ToInt32();
+            }
         }
+
+        /// <summary>
+        /// Gets the height of the line in pixels.
+        /// </summary>
+        /// <returns>The height in pixels of the line.</returns>
+        /// <remarks>Currently all lines are the same height.</remarks>
+        public int Height
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_TEXTHEIGHT, new IntPtr(Index)).ToInt32();
+            }
+        }
+
+        /// <summary>
+        /// Gets the line index.
+        /// </summary>
+        /// <returns>The zero-based line index within the <see cref="LineCollection" /> that created it.</returns>
+        public int Index { get; private set; }
+
+        /// <summary>
+        /// Gets the length of the line.
+        /// </summary>
+        /// <returns>The number of characters in the line including any end of line characters.</returns>
+        public int Length
+        {
+            get
+            {
+                return this.scintilla.Lines.CharLineLength(Index);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the style of the margin text in a <see cref="MarginType.Text" /> or <see cref="MarginType.RightText" /> margin.
+        /// </summary>
+        /// <returns>
+        /// The zero-based index of the margin text <see cref="Style" /> or 256 when <see cref="MarginStyles" />
+        /// has been used to set individual character styles.
+        /// </returns>
+        /// <seealso cref="MarginStyles" />
+        public int MarginStyle
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETSTYLE, new IntPtr(Index)).ToInt32();
+            }
+            set
+            {
+                value = Helpers.Clamp(value, 0, this.scintilla.Styles.Count - 1);
+                this.scintilla.DirectMessage(NativeMethods.SCI_MARGINSETSTYLE, new IntPtr(Index), new IntPtr(value));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets an array of style indexes corresponding to each charcter in the <see cref="MarginText" />
+        /// so that each character may be individually styled.
+        /// </summary>
+        /// <returns>
+        /// An array of <see cref="Style" /> indexes corresponding with each margin text character or an uninitialized
+        /// array when <see cref="MarginStyle" /> has been used to set a single style for all characters.
+        /// </returns>
+        /// <remarks>
+        /// <see cref="MarginText" /> must be set prior to setting this property.
+        /// The <paramref name="value" /> specified should have a length equal to the <see cref="MarginText" /> length to properly style all characters.
+        /// </remarks>
+        /// <seealso cref="MarginStyle" />
+        public unsafe byte[] MarginStyles
+        {
+            get
+            {
+                int length = this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index)).ToInt32();
+                if (length == 0)
+                    return new byte[0];
+
+                byte[] text = new byte[length + 1];
+                byte[] styles = new byte[length + 1];
+
+                fixed (byte* textPtr = text)
+                fixed (byte* stylePtr = styles)
+                {
+                    this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index), new IntPtr(textPtr));
+                    this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETSTYLES, new IntPtr(Index), new IntPtr(stylePtr));
+
+                    return Helpers.ByteToCharStyles(stylePtr, textPtr, length, this.scintilla.Encoding);
+                }
+            }
+            set
+            {
+                int length = this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index)).ToInt32();
+                if (length == 0)
+                    return;
+
+                byte[] text = new byte[length + 1];
+                fixed (byte* textPtr = text)
+                {
+                    this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index), new IntPtr(textPtr));
+
+                    byte[] styles = Helpers.CharToByteStyles(value ?? new byte[0], textPtr, length, this.scintilla.Encoding);
+                    fixed (byte* stylePtr = styles)
+                        this.scintilla.DirectMessage(NativeMethods.SCI_MARGINSETSTYLES, new IntPtr(Index), new IntPtr(stylePtr));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the text displayed in the line margin when the margin type is
+        /// <see cref="MarginType.Text" /> or <see cref="MarginType.RightText" />.
+        /// </summary>
+        /// <returns>The text displayed in the line margin.</returns>
+        public unsafe string MarginText
+        {
+            get
+            {
+                int length = this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index)).ToInt32();
+                if (length == 0)
+                    return string.Empty;
+
+                byte[] bytes = new byte[length + 1];
+                fixed (byte* bp = bytes)
+                {
+                    this.scintilla.DirectMessage(NativeMethods.SCI_MARGINGETTEXT, new IntPtr(Index), new IntPtr(bp));
+                    return Helpers.GetString(new IntPtr(bp), length, this.scintilla.Encoding);
+                }
+            }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    // Scintilla docs suggest that setting to NULL rather than an empty string will free memory
+                    this.scintilla.DirectMessage(NativeMethods.SCI_MARGINSETTEXT, new IntPtr(Index), IntPtr.Zero);
+                }
+                else
+                {
+                    byte[] bytes = Helpers.GetBytes(value, this.scintilla.Encoding, zeroTerminated: true);
+                    fixed (byte* bp = bytes)
+                        this.scintilla.DirectMessage(NativeMethods.SCI_MARGINSETTEXT, new IntPtr(Index), new IntPtr(bp));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the zero-based character position in the document where the line begins.
+        /// </summary>
+        /// <returns>The document position of the first character in the line.</returns>
+        public int Position
+        {
+            get
+            {
+                return this.scintilla.Lines.CharPositionFromLine(Index);
+            }
+        }
+
+        /// <summary>
+        /// Gets the line text.
+        /// </summary>
+        /// <returns>A string representing the document line.</returns>
+        /// <remarks>The returned text includes any end of line characters.</remarks>
+        public unsafe string Text
+        {
+            get
+            {
+                IntPtr start = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(Index));
+                IntPtr length = this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(Index));
+                IntPtr ptr = this.scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, start, length);
+                if (ptr == IntPtr.Zero)
+                    return string.Empty;
+
+                string text = new string((sbyte*)ptr, 0, length.ToInt32(), this.scintilla.Encoding);
+                return text;
+            }
+        }
+
+        /// <summary>
+        /// Sets or gets the line indentation.
+        /// </summary>
+        /// <returns>The indentation measured in character columns, which corresponds to the width of space characters.</returns>
+        public int Indentation
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETLINEINDENTATION, new IntPtr(Index)).ToInt32();
+            }
+            set
+            {
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETLINEINDENTATION, new IntPtr(Index), new IntPtr(value));
+            }
+        }
+
+        /// <summary>
+        /// This returns the position at the end of indentation of a line.
+        /// </summary>
+        public int IndentPosition
+        {
+            get
+            {
+                IntPtr pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETLINEINDENTPOSITION, new IntPtr(Index));
+                return this.scintilla.Lines.ByteToCharPosition(pos.ToInt32());
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the line is visible.
+        /// </summary>
+        /// <returns>true if the line is visible; otherwise, false.</returns>
+        /// <seealso cref="Scintilla.ShowLines" />
+        /// <seealso cref="Scintilla.HideLines" />
+        public bool Visible
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETLINEVISIBLE, new IntPtr(Index)) != IntPtr.Zero;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of display lines this line would occupy when wrapping is enabled.
+        /// </summary>
+        /// <returns>The number of display lines needed to wrap the current document line.</returns>
+        public int WrapCount
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_WRAPCOUNT, new IntPtr(Index)).ToInt32();
+            }
+        }
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Line" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this line.</param>
+        /// <param name="index">The index of this line within the <see cref="LineCollection" /> that created it.</param>
+        public Line(Scintilla scintilla, int index)
+        {
+            this.scintilla = scintilla;
+            Index = index;
+        }
+
+        #endregion Constructors
     }
-
-    #endregion Properties
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Line" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this line.</param>
-    /// <param name="index">The index of this line within the <see cref="LineCollection" /> that created it.</param>
-    public Line(Scintilla scintilla, int index)
-    {
-        this.scintilla = scintilla;
-        Index = index;
-    }
-
-    #endregion Constructors
 }

--- a/Scintilla.NET/LineCollection.cs
+++ b/Scintilla.NET/LineCollection.cs
@@ -5,567 +5,569 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 
-namespace ScintillaNET;
-// TODO Revisit this following Scintilla v3.7.0 because is said to be better about character handling
-
-/// <summary>
-/// An immutable collection of lines of text in a <see cref="Scintilla" /> control.
-/// </summary>
-public class LineCollection : IEnumerable<Line>
+namespace ScintillaNET
 {
-    #region Fields
-
-    private readonly Scintilla scintilla;
-    private GapBuffer<PerLine> perLineData;
-
-    // The 'step' is a break in the continuity of our line starts. It allows us
-    // to delay the updating of every line start when text is inserted/deleted.
-    private int stepLine;
-    private int stepLength;
-
-    #endregion Fields
-
-    #region Methods
+    // TODO Revisit this following Scintilla v3.7.0 because is said to be better about character handling
 
     /// <summary>
-    /// Adjust the number of CHARACTERS in a line.
+    /// An immutable collection of lines of text in a <see cref="Scintilla" /> control.
     /// </summary>
-    private void AdjustLineLength(int index, int delta)
+    public class LineCollection : IEnumerable<Line>
     {
-        MoveStep(index);
-        this.stepLength += delta;
+        #region Fields
 
-        // Invalidate multibyte flag
-        PerLine perLine = this.perLineData[index];
-        perLine.ContainsMultibyte = ContainsMultibyte.Unkown;
-        this.perLineData[index] = perLine;
-    }
+        private readonly Scintilla scintilla;
+        private GapBuffer<PerLine> perLineData;
 
-    /// <summary>
-    /// Converts a BYTE offset to a CHARACTER offset.
-    /// </summary>
-    internal int ByteToCharPosition(int pos)
-    {
-        Debug.Assert(pos >= 0);
-        Debug.Assert(pos <= this.scintilla.DirectMessage(NativeMethods.SCI_GETLENGTH).ToInt32());
+        // The 'step' is a break in the continuity of our line starts. It allows us
+        // to delay the updating of every line start when text is inserted/deleted.
+        private int stepLine;
+        private int stepLength;
 
-        int line = this.scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, new IntPtr(pos)).ToInt32();
-        int byteStart = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(line)).ToInt32();
-        int count = CharPositionFromLine(line) + GetCharCount(byteStart, pos - byteStart);
+        #endregion Fields
 
-        return count;
-    }
+        #region Methods
 
-    /// <summary>
-    /// Returns the number of CHARACTERS in a line.
-    /// </summary>
-    internal int CharLineLength(int index)
-    {
-        Debug.Assert(index >= 0);
-        Debug.Assert(index < Count);
-
-        // A line's length is calculated by subtracting its start offset from
-        // the start of the line following. We keep a terminal (faux) line at
-        // the end of the list so we can calculate the length of the last line.
-
-        if (index + 1 <= this.stepLine)
-            return this.perLineData[index + 1].Start - this.perLineData[index].Start;
-        else if (index <= this.stepLine)
-            return this.perLineData[index + 1].Start + this.stepLength - this.perLineData[index].Start;
-        else
-            return this.perLineData[index + 1].Start + this.stepLength - (this.perLineData[index].Start + this.stepLength);
-    }
-
-    /// <summary>
-    /// Returns the CHARACTER offset where the line begins.
-    /// </summary>
-    internal int CharPositionFromLine(int index)
-    {
-        Debug.Assert(index >= 0);
-        Debug.Assert(index < this.perLineData.Count); // Allow query of terminal line start
-
-        int start = this.perLineData[index].Start;
-        if (index > this.stepLine)
-            start += this.stepLength;
-
-        return start;
-    }
-
-    internal int CharToWideBytePosition(int pos)
-    {
-        Debug.Assert(pos >= 0);
-        Debug.Assert(pos <= TextLength);
-
-        // Adjust to the nearest line start
-        int line = LineFromCharPosition(pos);
-        int bytePos = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(line)).ToInt32();
-        pos -= CharPositionFromLine(line);
-
-        // Optimization when the line contains NO multibyte characters
-        if (!LineContainsMultibyteChar(line))
-            return bytePos + pos;
-
-        int prevBytePos;
-        while (pos > 0)
+        /// <summary>
+        /// Adjust the number of CHARACTERS in a line.
+        /// </summary>
+        private void AdjustLineLength(int index, int delta)
         {
-            // hang onto the prev byte position so we can determine if we are single or multi byte
-            prevBytePos = bytePos;
-            bytePos = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONRELATIVE, new IntPtr(bytePos), new IntPtr(1)).ToInt32();
+            MoveStep(index);
+            this.stepLength += delta;
 
-            if (bytePos - prevBytePos == 1)
-            {
-                // if the byte position is 1, we are single byte
-                pos--;
-            }
-            else
-            {
-                // if the byte position > 1, we are multi byte
-                pos -= 2;
-            }
-        }
-
-        return bytePos;
-    }
-
-    internal int CharToBytePosition(int pos)
-    {
-        Debug.Assert(pos >= 0);
-        Debug.Assert(pos <= TextLength);
-
-        // Adjust to the nearest line start
-        int line = LineFromCharPosition(pos);
-        int bytePos = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(line)).ToInt32();
-        pos -= CharPositionFromLine(line);
-
-        // Optimization when the line contains NO multibyte characters
-        if (!LineContainsMultibyteChar(line))
-            return bytePos + pos;
-
-        while (pos > 0)
-        {
-            // Move char-by-char
-            bytePos = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONRELATIVE, new IntPtr(bytePos),
-                new IntPtr(1)).ToInt32();
-            pos--;
-        }
-
-        return bytePos;
-    }
-
-    private void DeletePerLine(int index)
-    {
-        Debug.Assert(index != 0);
-
-        MoveStep(index);
-
-        // Subtract the line length
-        this.stepLength -= CharLineLength(index);
-
-        // Remove the line
-        this.perLineData.RemoveAt(index);
-
-        // Move the step to the line before the one removed
-        this.stepLine--;
-    }
-
-#if DEBUG
-
-    /// <summary>
-    /// Dumps the line buffer to a string.
-    /// </summary>
-    /// <returns>A string representing the line buffer.</returns>
-    public string Dump()
-    {
-        using var writer = new StringWriter();
-        this.scintilla.Lines.Dump(writer);
-        return writer.ToString();
-    }
-
-    /// <summary>
-    /// Dumps the line buffer to the specified TextWriter.
-    /// </summary>
-    /// <param name="writer">The writer to use for dumping the line buffer.</param>
-    public unsafe void Dump(TextWriter writer)
-    {
-        int totalChars = 0;
-
-        for (int i = 0; i < this.perLineData.Count; i++)
-        {
-            string error = totalChars == CharPositionFromLine(i) ? null : "*";
-            if (i == this.perLineData.Count - 1)
-            {
-                writer.WriteLine("{0}[{1}] {2} (terminal)", error, i, CharPositionFromLine(i));
-            }
-            else
-            {
-                int len = this.scintilla.DirectMessage(NativeMethods.SCI_GETLINE, new IntPtr(i)).ToInt32();
-                byte[] bytes = new byte[len];
-
-                fixed (byte* ptr = bytes)
-                    this.scintilla.DirectMessage(NativeMethods.SCI_GETLINE, new IntPtr(i), new IntPtr(ptr));
-
-                string str = this.scintilla.Encoding.GetString(bytes);
-                string containsMultibyte = "U";
-                if (this.perLineData[i].ContainsMultibyte == ContainsMultibyte.Yes)
-                    containsMultibyte = "Y";
-                else if (this.perLineData[i].ContainsMultibyte == ContainsMultibyte.No)
-                    containsMultibyte = "N";
-
-                writer.WriteLine("{0}[{1}] {2}:{3}:{4} {5}", error, i, CharPositionFromLine(i), str.Length, containsMultibyte, str.Replace("\r", "\\r").Replace("\n", "\\n"));
-                totalChars += str.Length;
-            }
-        }
-    }
-
-#endif
-
-    /// <summary>
-    /// Gets the number of CHARACTERS int a BYTE range.
-    /// </summary>
-    private int GetCharCount(int pos, int length)
-    {
-        IntPtr ptr = this.scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, new IntPtr(pos), new IntPtr(length));
-        return GetCharCount(ptr, length, this.scintilla.Encoding);
-    }
-
-    /// <summary>
-    /// Gets the number of CHARACTERS in a BYTE range.
-    /// </summary>
-    private static unsafe int GetCharCount(IntPtr text, int length, Encoding encoding)
-    {
-        if (text == IntPtr.Zero || length == 0)
-            return 0;
-
-        // Never use SCI_COUNTCHARACTERS. It counts CRLF as 1 char!
-        int count = encoding.GetCharCount((byte*)text, length);
-        return count;
-    }
-
-    /// <summary>
-    /// Provides an enumerator that iterates through the collection.
-    /// </summary>
-    /// <returns>An object that contains all <see cref="Line" /> objects within the <see cref="LineCollection" />.</returns>
-    public IEnumerator<Line> GetEnumerator()
-    {
-        int count = Count;
-        for (int i = 0; i < count; i++)
-            yield return this[i];
-
-        yield break;
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    private bool LineContainsMultibyteChar(int index)
-    {
-        PerLine perLine = this.perLineData[index];
-        if (perLine.ContainsMultibyte == ContainsMultibyte.Unkown)
-        {
-            perLine.ContainsMultibyte =
-                (this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(index)).ToInt32() == CharLineLength(index))
-                    ? ContainsMultibyte.No
-                    : ContainsMultibyte.Yes;
-
+            // Invalidate multibyte flag
+            PerLine perLine = this.perLineData[index];
+            perLine.ContainsMultibyte = ContainsMultibyte.Unkown;
             this.perLineData[index] = perLine;
         }
 
-        return perLine.ContainsMultibyte == ContainsMultibyte.Yes;
-    }
-
-    /// <summary>
-    /// Returns the line index containing the CHARACTER position.
-    /// </summary>
-    internal int LineFromCharPosition(int pos)
-    {
-        Debug.Assert(pos >= 0);
-
-        // Iterative binary search
-        // http://en.wikipedia.org/wiki/Binary_search_algorithm
-        // System.Collections.Generic.ArraySortHelper.InternalBinarySearch
-
-        int low = 0;
-        int high = Count - 1;
-
-        while (low <= high)
+        /// <summary>
+        /// Converts a BYTE offset to a CHARACTER offset.
+        /// </summary>
+        internal int ByteToCharPosition(int pos)
         {
-            int mid = low + (high - low) / 2;
-            int start = CharPositionFromLine(mid);
+            Debug.Assert(pos >= 0);
+            Debug.Assert(pos <= this.scintilla.DirectMessage(NativeMethods.SCI_GETLENGTH).ToInt32());
 
-            if (pos == start)
-                return mid;
-            else if (start < pos)
-                low = mid + 1;
+            int line = this.scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, new IntPtr(pos)).ToInt32();
+            int byteStart = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(line)).ToInt32();
+            int count = CharPositionFromLine(line) + GetCharCount(byteStart, pos - byteStart);
+
+            return count;
+        }
+
+        /// <summary>
+        /// Returns the number of CHARACTERS in a line.
+        /// </summary>
+        internal int CharLineLength(int index)
+        {
+            Debug.Assert(index >= 0);
+            Debug.Assert(index < Count);
+
+            // A line's length is calculated by subtracting its start offset from
+            // the start of the line following. We keep a terminal (faux) line at
+            // the end of the list so we can calculate the length of the last line.
+
+            if (index + 1 <= this.stepLine)
+                return this.perLineData[index + 1].Start - this.perLineData[index].Start;
+            else if (index <= this.stepLine)
+                return this.perLineData[index + 1].Start + this.stepLength - this.perLineData[index].Start;
             else
-                high = mid - 1;
+                return this.perLineData[index + 1].Start + this.stepLength - (this.perLineData[index].Start + this.stepLength);
         }
 
-        // After while exit, 'low' will point to the index where 'pos' should be
-        // inserted (if we were creating a new line start). The line containing
-        // 'pos' then would be 'low - 1'.
-        return low - 1;
-    }
-
-    /// <summary>
-    /// Tracks a new line with the given CHARACTER length.
-    /// </summary>
-    private void InsertPerLine(int index, int length = 0)
-    {
-        MoveStep(index);
-
-        PerLine data;
-        int lineStart = 0;
-
-        // Add the new line length to the existing line start
-        data = this.perLineData[index];
-        lineStart = data.Start;
-        data.Start += length;
-        this.perLineData[index] = data;
-
-        // Insert the new line
-        data = new PerLine { Start = lineStart };
-        this.perLineData.Insert(index, data);
-
-        // Move the step
-        this.stepLength += length;
-        this.stepLine++;
-    }
-
-    private void MoveStep(int line)
-    {
-        if (this.stepLength == 0)
+        /// <summary>
+        /// Returns the CHARACTER offset where the line begins.
+        /// </summary>
+        internal int CharPositionFromLine(int index)
         {
-            this.stepLine = line;
+            Debug.Assert(index >= 0);
+            Debug.Assert(index < this.perLineData.Count); // Allow query of terminal line start
+
+            int start = this.perLineData[index].Start;
+            if (index > this.stepLine)
+                start += this.stepLength;
+
+            return start;
         }
-        else if (this.stepLine < line)
+
+        internal int CharToWideBytePosition(int pos)
         {
-            PerLine data;
-            while (this.stepLine < line)
+            Debug.Assert(pos >= 0);
+            Debug.Assert(pos <= TextLength);
+
+            // Adjust to the nearest line start
+            int line = LineFromCharPosition(pos);
+            int bytePos = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(line)).ToInt32();
+            pos -= CharPositionFromLine(line);
+
+            // Optimization when the line contains NO multibyte characters
+            if (!LineContainsMultibyteChar(line))
+                return bytePos + pos;
+
+            int prevBytePos;
+            while (pos > 0)
             {
-                this.stepLine++;
-                data = this.perLineData[this.stepLine];
-                data.Start += this.stepLength;
-                this.perLineData[this.stepLine] = data;
+                // hang onto the prev byte position so we can determine if we are single or multi byte
+                prevBytePos = bytePos;
+                bytePos = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONRELATIVE, new IntPtr(bytePos), new IntPtr(1)).ToInt32();
+
+                if (bytePos - prevBytePos == 1)
+                {
+                    // if the byte position is 1, we are single byte
+                    pos--;
+                }
+                else
+                {
+                    // if the byte position > 1, we are multi byte
+                    pos -= 2;
+                }
+            }
+
+            return bytePos;
+        }
+
+        internal int CharToBytePosition(int pos)
+        {
+            Debug.Assert(pos >= 0);
+            Debug.Assert(pos <= TextLength);
+
+            // Adjust to the nearest line start
+            int line = LineFromCharPosition(pos);
+            int bytePos = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(line)).ToInt32();
+            pos -= CharPositionFromLine(line);
+
+            // Optimization when the line contains NO multibyte characters
+            if (!LineContainsMultibyteChar(line))
+                return bytePos + pos;
+
+            while (pos > 0)
+            {
+                // Move char-by-char
+                bytePos = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONRELATIVE, new IntPtr(bytePos),
+                    new IntPtr(1)).ToInt32();
+                pos--;
+            }
+
+            return bytePos;
+        }
+
+        private void DeletePerLine(int index)
+        {
+            Debug.Assert(index != 0);
+
+            MoveStep(index);
+
+            // Subtract the line length
+            this.stepLength -= CharLineLength(index);
+
+            // Remove the line
+            this.perLineData.RemoveAt(index);
+
+            // Move the step to the line before the one removed
+            this.stepLine--;
+        }
+
+#if DEBUG
+
+        /// <summary>
+        /// Dumps the line buffer to a string.
+        /// </summary>
+        /// <returns>A string representing the line buffer.</returns>
+        public string Dump()
+        {
+            using (var writer = new StringWriter())
+            {
+                this.scintilla.Lines.Dump(writer);
+                return writer.ToString();
             }
         }
-        else if (this.stepLine > line)
+
+        /// <summary>
+        /// Dumps the line buffer to the specified TextWriter.
+        /// </summary>
+        /// <param name="writer">The writer to use for dumping the line buffer.</param>
+        public unsafe void Dump(TextWriter writer)
         {
-            PerLine data;
-            while (this.stepLine > line)
+            int totalChars = 0;
+
+            for (int i = 0; i < this.perLineData.Count; i++)
             {
-                data = this.perLineData[this.stepLine];
-                data.Start -= this.stepLength;
-                this.perLineData[this.stepLine] = data;
-                this.stepLine--;
+                string error = totalChars == CharPositionFromLine(i) ? null : "*";
+                if (i == this.perLineData.Count - 1)
+                {
+                    writer.WriteLine("{0}[{1}] {2} (terminal)", error, i, CharPositionFromLine(i));
+                }
+                else
+                {
+                    int len = this.scintilla.DirectMessage(NativeMethods.SCI_GETLINE, new IntPtr(i)).ToInt32();
+                    byte[] bytes = new byte[len];
+
+                    fixed (byte* ptr = bytes)
+                        this.scintilla.DirectMessage(NativeMethods.SCI_GETLINE, new IntPtr(i), new IntPtr(ptr));
+
+                    string str = this.scintilla.Encoding.GetString(bytes);
+                    string containsMultibyte = "U";
+                    if (this.perLineData[i].ContainsMultibyte == ContainsMultibyte.Yes)
+                        containsMultibyte = "Y";
+                    else if (this.perLineData[i].ContainsMultibyte == ContainsMultibyte.No)
+                        containsMultibyte = "N";
+
+                    writer.WriteLine("{0}[{1}] {2}:{3}:{4} {5}", error, i, CharPositionFromLine(i), str.Length, containsMultibyte, str.Replace("\r", "\\r").Replace("\n", "\\n"));
+                    totalChars += str.Length;
+                }
             }
         }
-    }
 
-    internal void RebuildLineData()
-    {
-        this.stepLine = 0;
-        this.stepLength = 0;
+#endif
 
-        this.perLineData =
-        [
-            new PerLine { Start = 0 },
-            new PerLine { Start = 0 }, // Terminal
-        ];
-
-        // Fake an insert notification
-        var scn = new NativeMethods.SCNotification();
-        int adjustedLines = this.scintilla.DirectMessage(NativeMethods.SCI_GETLINECOUNT).ToInt32() - 1;
-        scn.linesAdded = new IntPtr(adjustedLines);
-        scn.position = IntPtr.Zero;
-        scn.length = this.scintilla.DirectMessage(NativeMethods.SCI_GETLENGTH);
-        scn.text = this.scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, scn.position, scn.length);
-        TrackInsertText(scn);
-    }
-
-    private void scintilla_SCNotification(object sender, SCNotificationEventArgs e)
-    {
-        NativeMethods.SCNotification scn = e.SCNotification;
-        switch (scn.nmhdr.code)
+        /// <summary>
+        /// Gets the number of CHARACTERS int a BYTE range.
+        /// </summary>
+        private int GetCharCount(int pos, int length)
         {
-            case NativeMethods.SCN_MODIFIED:
-                ScnModified(scn);
-                break;
-        }
-    }
-
-    private void ScnModified(NativeMethods.SCNotification scn)
-    {
-        if ((scn.modificationType & NativeMethods.SC_MOD_DELETETEXT) > 0)
-        {
-            TrackDeleteText(scn);
+            IntPtr ptr = this.scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, new IntPtr(pos), new IntPtr(length));
+            return GetCharCount(ptr, length, this.scintilla.Encoding);
         }
 
-        if ((scn.modificationType & NativeMethods.SC_MOD_INSERTTEXT) > 0)
+        /// <summary>
+        /// Gets the number of CHARACTERS in a BYTE range.
+        /// </summary>
+        private static unsafe int GetCharCount(IntPtr text, int length, Encoding encoding)
         {
+            if (text == IntPtr.Zero || length == 0)
+                return 0;
+
+            // Never use SCI_COUNTCHARACTERS. It counts CRLF as 1 char!
+            int count = encoding.GetCharCount((byte*)text, length);
+            return count;
+        }
+
+        /// <summary>
+        /// Provides an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An object that contains all <see cref="Line" /> objects within the <see cref="LineCollection" />.</returns>
+        public IEnumerator<Line> GetEnumerator()
+        {
+            int count = Count;
+            for (int i = 0; i < count; i++)
+                yield return this[i];
+
+            yield break;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private bool LineContainsMultibyteChar(int index)
+        {
+            PerLine perLine = this.perLineData[index];
+            if (perLine.ContainsMultibyte == ContainsMultibyte.Unkown)
+            {
+                perLine.ContainsMultibyte =
+                    (this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(index)).ToInt32() == CharLineLength(index))
+                        ? ContainsMultibyte.No
+                        : ContainsMultibyte.Yes;
+
+                this.perLineData[index] = perLine;
+            }
+
+            return perLine.ContainsMultibyte == ContainsMultibyte.Yes;
+        }
+
+        /// <summary>
+        /// Returns the line index containing the CHARACTER position.
+        /// </summary>
+        internal int LineFromCharPosition(int pos)
+        {
+            Debug.Assert(pos >= 0);
+
+            // Iterative binary search
+            // http://en.wikipedia.org/wiki/Binary_search_algorithm
+            // System.Collections.Generic.ArraySortHelper.InternalBinarySearch
+
+            int low = 0;
+            int high = Count - 1;
+
+            while (low <= high)
+            {
+                int mid = low + (high - low) / 2;
+                int start = CharPositionFromLine(mid);
+
+                if (pos == start)
+                    return mid;
+                else if (start < pos)
+                    low = mid + 1;
+                else
+                    high = mid - 1;
+            }
+
+            // After while exit, 'low' will point to the index where 'pos' should be
+            // inserted (if we were creating a new line start). The line containing
+            // 'pos' then would be 'low - 1'.
+            return low - 1;
+        }
+
+        /// <summary>
+        /// Tracks a new line with the given CHARACTER length.
+        /// </summary>
+        private void InsertPerLine(int index, int length = 0)
+        {
+            MoveStep(index);
+
+            PerLine data;
+            int lineStart = 0;
+
+            // Add the new line length to the existing line start
+            data = this.perLineData[index];
+            lineStart = data.Start;
+            data.Start += length;
+            this.perLineData[index] = data;
+
+            // Insert the new line
+            data = new PerLine { Start = lineStart };
+            this.perLineData.Insert(index, data);
+
+            // Move the step
+            this.stepLength += length;
+            this.stepLine++;
+        }
+
+        private void MoveStep(int line)
+        {
+            if (this.stepLength == 0)
+            {
+                this.stepLine = line;
+            }
+            else if (this.stepLine < line)
+            {
+                PerLine data;
+                while (this.stepLine < line)
+                {
+                    this.stepLine++;
+                    data = this.perLineData[this.stepLine];
+                    data.Start += this.stepLength;
+                    this.perLineData[this.stepLine] = data;
+                }
+            }
+            else if (this.stepLine > line)
+            {
+                PerLine data;
+                while (this.stepLine > line)
+                {
+                    data = this.perLineData[this.stepLine];
+                    data.Start -= this.stepLength;
+                    this.perLineData[this.stepLine] = data;
+                    this.stepLine--;
+                }
+            }
+        }
+
+        internal void RebuildLineData()
+        {
+            this.stepLine = 0;
+            this.stepLength = 0;
+
+            this.perLineData = new GapBuffer<PerLine>() {
+                new PerLine { Start = 0 },
+                new PerLine { Start = 0 }, // Terminal
+            };
+
+            // Fake an insert notification
+            var scn = new NativeMethods.SCNotification();
+            int adjustedLines = this.scintilla.DirectMessage(NativeMethods.SCI_GETLINECOUNT).ToInt32() - 1;
+            scn.linesAdded = new IntPtr(adjustedLines);
+            scn.position = IntPtr.Zero;
+            scn.length = this.scintilla.DirectMessage(NativeMethods.SCI_GETLENGTH);
+            scn.text = this.scintilla.DirectMessage(NativeMethods.SCI_GETRANGEPOINTER, scn.position, scn.length);
             TrackInsertText(scn);
         }
-    }
 
-    private void TrackDeleteText(NativeMethods.SCNotification scn)
-    {
-        int startLine = this.scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, scn.position).ToInt32();
-        if (scn.linesAdded == IntPtr.Zero)
+        private void scintilla_SCNotification(object sender, SCNotificationEventArgs e)
         {
-            // That was easy
-            int delta = GetCharCount(scn.text, scn.length.ToInt32(), this.scintilla.Encoding);
-            AdjustLineLength(startLine, delta * -1);
-        }
-        else
-        {
-            // Adjust the existing line
-            int lineByteStart = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(startLine)).ToInt32();
-            int lineByteLength = this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(startLine)).ToInt32();
-            AdjustLineLength(startLine, GetCharCount(lineByteStart, lineByteLength) - CharLineLength(startLine));
-
-            int linesRemoved = scn.linesAdded.ToInt32() * -1;
-            for (int i = 0; i < linesRemoved; i++)
+            NativeMethods.SCNotification scn = e.SCNotification;
+            switch (scn.nmhdr.code)
             {
-                // Deleted line
-                DeletePerLine(startLine + 1);
+                case NativeMethods.SCN_MODIFIED:
+                    ScnModified(scn);
+                    break;
             }
         }
-    }
 
-    private void TrackInsertText(NativeMethods.SCNotification scn)
-    {
-        int startLine = this.scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, scn.position).ToInt32();
-        if (scn.linesAdded == IntPtr.Zero)
+        private void ScnModified(NativeMethods.SCNotification scn)
         {
-            // That was easy
-            int delta = GetCharCount(scn.position.ToInt32(), scn.length.ToInt32());
-            AdjustLineLength(startLine, delta);
-        }
-        else
-        {
-            int lineByteStart = 0;
-            int lineByteLength = 0;
-
-            // Adjust existing line
-            lineByteStart = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(startLine)).ToInt32();
-            lineByteLength = this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(startLine)).ToInt32();
-            AdjustLineLength(startLine, GetCharCount(lineByteStart, lineByteLength) - CharLineLength(startLine));
-
-            for (int i = 1; i <= scn.linesAdded.ToInt32(); i++)
+            if ((scn.modificationType & NativeMethods.SC_MOD_DELETETEXT) > 0)
             {
-                int line = startLine + i;
+                TrackDeleteText(scn);
+            }
 
-                // Insert new line
-                lineByteStart += lineByteLength;
-                lineByteLength = this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(line)).ToInt32();
-                InsertPerLine(line, GetCharCount(lineByteStart, lineByteLength));
+            if ((scn.modificationType & NativeMethods.SC_MOD_INSERTTEXT) > 0)
+            {
+                TrackInsertText(scn);
             }
         }
-    }
 
-    #endregion Methods
-
-    #region Properties
-
-    /// <summary>
-    /// Gets a value indicating whether all the document lines are visible (not hidden).
-    /// </summary>
-    /// <returns>true if all the lines are visible; otherwise, false.</returns>
-    public bool AllLinesVisible
-    {
-        get
+        private void TrackDeleteText(NativeMethods.SCNotification scn)
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETALLLINESVISIBLE) != IntPtr.Zero;
-        }
-    }
+            int startLine = this.scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, scn.position).ToInt32();
+            if (scn.linesAdded == IntPtr.Zero)
+            {
+                // That was easy
+                int delta = GetCharCount(scn.text, scn.length.ToInt32(), this.scintilla.Encoding);
+                AdjustLineLength(startLine, delta * -1);
+            }
+            else
+            {
+                // Adjust the existing line
+                int lineByteStart = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(startLine)).ToInt32();
+                int lineByteLength = this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(startLine)).ToInt32();
+                AdjustLineLength(startLine, GetCharCount(lineByteStart, lineByteLength) - CharLineLength(startLine));
 
-    /// <summary>
-    /// Gets the number of lines.
-    /// </summary>
-    /// <returns>The number of lines in the <see cref="LineCollection" />.</returns>
-    public int Count
-    {
-        get
+                int linesRemoved = scn.linesAdded.ToInt32() * -1;
+                for (int i = 0; i < linesRemoved; i++)
+                {
+                    // Deleted line
+                    DeletePerLine(startLine + 1);
+                }
+            }
+        }
+
+        private void TrackInsertText(NativeMethods.SCNotification scn)
         {
-            // Subtract the terminal line
-            return this.perLineData.Count - 1;
+            int startLine = this.scintilla.DirectMessage(NativeMethods.SCI_LINEFROMPOSITION, scn.position).ToInt32();
+            if (scn.linesAdded == IntPtr.Zero)
+            {
+                // That was easy
+                int delta = GetCharCount(scn.position.ToInt32(), scn.length.ToInt32());
+                AdjustLineLength(startLine, delta);
+            }
+            else
+            {
+                int lineByteStart = 0;
+                int lineByteLength = 0;
+
+                // Adjust existing line
+                lineByteStart = this.scintilla.DirectMessage(NativeMethods.SCI_POSITIONFROMLINE, new IntPtr(startLine)).ToInt32();
+                lineByteLength = this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(startLine)).ToInt32();
+                AdjustLineLength(startLine, GetCharCount(lineByteStart, lineByteLength) - CharLineLength(startLine));
+
+                for (int i = 1; i <= scn.linesAdded.ToInt32(); i++)
+                {
+                    int line = startLine + i;
+
+                    // Insert new line
+                    lineByteStart += lineByteLength;
+                    lineByteLength = this.scintilla.DirectMessage(NativeMethods.SCI_LINELENGTH, new IntPtr(line)).ToInt32();
+                    InsertPerLine(line, GetCharCount(lineByteStart, lineByteLength));
+                }
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets the number of CHARACTERS in the document.
-    /// </summary>
-    internal int TextLength
-    {
-        get
-        {
-            // Where the terminal line begins
-            return CharPositionFromLine(this.perLineData.Count - 1);
-        }
-    }
+        #endregion Methods
 
-    /// <summary>
-    /// Gets the <see cref="Line" /> at the specified zero-based index.
-    /// </summary>
-    /// <param name="index">The zero-based index of the <see cref="Line" /> to get.</param>
-    /// <returns>The <see cref="Line" /> at the specified index.</returns>
-    public Line this[int index]
-    {
-        get
-        {
-            index = Helpers.Clamp(index, 0, Count - 1);
-            return new Line(this.scintilla, index);
-        }
-    }
-
-    #endregion Properties
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="LineCollection" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
-    public LineCollection(Scintilla scintilla)
-    {
-        this.scintilla = scintilla;
-        this.scintilla.SCNotification += scintilla_SCNotification;
-
-        this.perLineData =
-        [
-            new PerLine { Start = 0 },
-            new PerLine { Start = 0 }, // Terminal
-        ];
-    }
-
-    #endregion Constructors
-
-    #region Types
-
-    /// <summary>
-    /// Stuff we track for each line.
-    /// </summary>
-    private struct PerLine
-    {
-        /// <summary>
-        /// The CHARACTER position where the line begins.
-        /// </summary>
-        public int Start;
+        #region Properties
 
         /// <summary>
-        /// 1 if the line contains multibyte (Unicode) characters; -1 if not; 0 if undetermined.
+        /// Gets a value indicating whether all the document lines are visible (not hidden).
         /// </summary>
-        /// <remarks>Using an enum instead of Nullable because it uses less memory per line...</remarks>
-        public ContainsMultibyte ContainsMultibyte;
-    }
+        /// <returns>true if all the lines are visible; otherwise, false.</returns>
+        public bool AllLinesVisible
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETALLLINESVISIBLE) != IntPtr.Zero;
+            }
+        }
 
-    private enum ContainsMultibyte
-    {
-        No = -1,
-        Unkown,
-        Yes
-    }
+        /// <summary>
+        /// Gets the number of lines.
+        /// </summary>
+        /// <returns>The number of lines in the <see cref="LineCollection" />.</returns>
+        public int Count
+        {
+            get
+            {
+                // Subtract the terminal line
+                return this.perLineData.Count - 1;
+            }
+        }
 
-    #endregion Types
+        /// <summary>
+        /// Gets the number of CHARACTERS in the document.
+        /// </summary>
+        internal int TextLength
+        {
+            get
+            {
+                // Where the terminal line begins
+                return CharPositionFromLine(this.perLineData.Count - 1);
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Line" /> at the specified zero-based index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the <see cref="Line" /> to get.</param>
+        /// <returns>The <see cref="Line" /> at the specified index.</returns>
+        public Line this[int index]
+        {
+            get
+            {
+                index = Helpers.Clamp(index, 0, Count - 1);
+                return new Line(this.scintilla, index);
+            }
+        }
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LineCollection" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
+        public LineCollection(Scintilla scintilla)
+        {
+            this.scintilla = scintilla;
+            this.scintilla.SCNotification += scintilla_SCNotification;
+
+            this.perLineData = new GapBuffer<PerLine>() {
+                new PerLine { Start = 0 },
+                new PerLine { Start = 0 }, // Terminal
+            };
+        }
+
+        #endregion Constructors
+
+        #region Types
+
+        /// <summary>
+        /// Stuff we track for each line.
+        /// </summary>
+        private struct PerLine
+        {
+            /// <summary>
+            /// The CHARACTER position where the line begins.
+            /// </summary>
+            public int Start;
+
+            /// <summary>
+            /// 1 if the line contains multibyte (Unicode) characters; -1 if not; 0 if undetermined.
+            /// </summary>
+            /// <remarks>Using an enum instead of Nullable because it uses less memory per line...</remarks>
+            public ContainsMultibyte ContainsMultibyte;
+        }
+
+        private enum ContainsMultibyte
+        {
+            No = -1,
+            Unkown,
+            Yes
+        }
+
+        #endregion Types
+    }
 }

--- a/Scintilla.NET/LineEndType.cs
+++ b/Scintilla.NET/LineEndType.cs
@@ -1,23 +1,24 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Line endings types supported by lexers and allowed by a <see cref="Scintilla" /> control.
-/// </summary>
-/// <seealso cref="Scintilla.LineEndTypesSupported" />
-/// <seealso cref="Scintilla.LineEndTypesAllowed" />
-/// <seealso cref="Scintilla.LineEndTypesActive" />
-[Flags]
-public enum LineEndType
+namespace ScintillaNET
 {
     /// <summary>
-    /// ASCII line endings. Carriage Return, Line Feed pair "\r\n" (0x0D0A); Carriage Return '\r' (0x0D); Line Feed '\n' (0x0A).
+    /// Line endings types supported by lexers and allowed by a <see cref="Scintilla" /> control.
     /// </summary>
-    Default = NativeMethods.SC_LINE_END_TYPE_DEFAULT,
+    /// <seealso cref="Scintilla.LineEndTypesSupported" />
+    /// <seealso cref="Scintilla.LineEndTypesAllowed" />
+    /// <seealso cref="Scintilla.LineEndTypesActive" />
+    [Flags]
+    public enum LineEndType
+    {
+        /// <summary>
+        /// ASCII line endings. Carriage Return, Line Feed pair "\r\n" (0x0D0A); Carriage Return '\r' (0x0D); Line Feed '\n' (0x0A).
+        /// </summary>
+        Default = NativeMethods.SC_LINE_END_TYPE_DEFAULT,
 
-    /// <summary>
-    /// Unicode line endings. Next Line (0x0085); Line Separator (0x2028); Paragraph Separator (0x2029).
-    /// </summary>
-    Unicode = NativeMethods.SC_LINE_END_TYPE_UNICODE
+        /// <summary>
+        /// Unicode line endings. Next Line (0x0085); Line Separator (0x2028); Paragraph Separator (0x2029).
+        /// </summary>
+        Unicode = NativeMethods.SC_LINE_END_TYPE_UNICODE
+    }
 }

--- a/Scintilla.NET/ListCompletionMethod.cs
+++ b/Scintilla.NET/ListCompletionMethod.cs
@@ -1,33 +1,34 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Indicates how an autocompletion occurred.
-/// </summary>
-public enum ListCompletionMethod
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// A fillup character (see <see cref="Scintilla.AutoCSetFillUps" />) triggered the completion.
-    /// The character used is indicated by the <see cref="AutoCSelectionEventArgs.Char" /> property.
+    /// Indicates how an autocompletion occurred.
     /// </summary>
-    FillUp = NativeMethods.SC_AC_FILLUP,
+    public enum ListCompletionMethod
+    {
+        /// <summary>
+        /// A fillup character (see <see cref="Scintilla.AutoCSetFillUps" />) triggered the completion.
+        /// The character used is indicated by the <see cref="AutoCSelectionEventArgs.Char" /> property.
+        /// </summary>
+        FillUp = NativeMethods.SC_AC_FILLUP,
 
-    /// <summary>
-    /// A double-click triggered the completion.
-    /// </summary>
-    DoubleClick = NativeMethods.SC_AC_DOUBLECLICK,
+        /// <summary>
+        /// A double-click triggered the completion.
+        /// </summary>
+        DoubleClick = NativeMethods.SC_AC_DOUBLECLICK,
 
-    /// <summary>
-    /// A tab key or the <see cref="ScintillaNET.Command.Tab" /> command triggered the completion.
-    /// </summary>
-    Tab = NativeMethods.SC_AC_TAB,
+        /// <summary>
+        /// A tab key or the <see cref="ScintillaNET.Command.Tab" /> command triggered the completion.
+        /// </summary>
+        Tab = NativeMethods.SC_AC_TAB,
 
-    /// <summary>
-    /// A new line or <see cref="ScintillaNET.Command.NewLine" /> command triggered the completion.
-    /// </summary>
-    NewLine = NativeMethods.SC_AC_NEWLINE,
+        /// <summary>
+        /// A new line or <see cref="ScintillaNET.Command.NewLine" /> command triggered the completion.
+        /// </summary>
+        NewLine = NativeMethods.SC_AC_NEWLINE,
 
-    /// <summary>
-    /// The <see cref="Scintilla.AutoCSelect" /> method triggered the completion.
-    /// </summary>
-    Command = NativeMethods.SC_AC_COMMAND
+        /// <summary>
+        /// The <see cref="Scintilla.AutoCSelect" /> method triggered the completion.
+        /// </summary>
+        Command = NativeMethods.SC_AC_COMMAND
+    }
 }

--- a/Scintilla.NET/Loader.cs
+++ b/Scintilla.NET/Loader.cs
@@ -2,66 +2,67 @@
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace ScintillaNET;
-
-internal sealed class Loader : ILoader
+namespace ScintillaNET
 {
-    private readonly IntPtr self;
-    private readonly NativeMethods.ILoaderVTable32 loader32;
-    private readonly NativeMethods.ILoaderVTable64 loader64;
-    private readonly Encoding encoding;
-
-    public unsafe bool AddData(char[] data, int length)
+    internal sealed class Loader : ILoader
     {
-        if (data != null)
+        private readonly IntPtr self;
+        private readonly NativeMethods.ILoaderVTable32 loader32;
+        private readonly NativeMethods.ILoaderVTable64 loader64;
+        private readonly Encoding encoding;
+
+        public unsafe bool AddData(char[] data, int length)
         {
-            length = Helpers.Clamp(length, 0, data.Length);
-            byte[] bytes = Helpers.GetBytes(data, length, this.encoding, zeroTerminated: false);
-            fixed (byte* bp = bytes)
+            if (data != null)
             {
-                int status = IntPtr.Size == 4 ? this.loader32.AddData(this.self, bp, bytes.Length) : this.loader64.AddData(this.self, bp, bytes.Length);
-                if (status != NativeMethods.SC_STATUS_OK)
-                    return false;
+                length = Helpers.Clamp(length, 0, data.Length);
+                byte[] bytes = Helpers.GetBytes(data, length, this.encoding, zeroTerminated: false);
+                fixed (byte* bp = bytes)
+                {
+                    int status = IntPtr.Size == 4 ? this.loader32.AddData(this.self, bp, bytes.Length) : this.loader64.AddData(this.self, bp, bytes.Length);
+                    if (status != NativeMethods.SC_STATUS_OK)
+                        return false;
+                }
             }
+
+            return true;
         }
 
-        return true;
-    }
+        public Document ConvertToDocument()
+        {
+            IntPtr ptr = IntPtr.Size == 4 ? this.loader32.ConvertToDocument(this.self) : this.loader64.ConvertToDocument(this.self);
+            var document = new Document { Value = ptr };
+            return document;
+        }
 
-    public Document ConvertToDocument()
-    {
-        IntPtr ptr = IntPtr.Size == 4 ? this.loader32.ConvertToDocument(this.self) : this.loader64.ConvertToDocument(this.self);
-        var document = new Document { Value = ptr };
-        return document;
-    }
+        public int Release()
+        {
+            int count = IntPtr.Size == 4 ? this.loader32.Release(this.self) : this.loader64.Release(this.self);
+            return count;
+        }
 
-    public int Release()
-    {
-        int count = IntPtr.Size == 4 ? this.loader32.Release(this.self) : this.loader64.Release(this.self);
-        return count;
-    }
+        public unsafe Loader(IntPtr ptr, Encoding encoding)
+        {
+            this.self = ptr;
+            this.encoding = encoding;
 
-    public unsafe Loader(IntPtr ptr, Encoding encoding)
-    {
-        this.self = ptr;
-        this.encoding = encoding;
+            // http://stackoverflow.com/a/985820/2073621
+            // http://stackoverflow.com/a/2094715/2073621
+            // http://en.wikipedia.org/wiki/Virtual_method_table
+            // http://www.openrce.org/articles/full_view/23
+            // Because I know that I'm not going to remember all this... In C++, the first
+            // variable of an object is a pointer (v[f]ptr) to the virtual table (v[f]table)
+            // containing the addresses of each function. The first call below gets the vtable
+            // address by following the object ptr to the vptr to the vtable. The second call
+            // casts the vtable to a structure with the same memory layout so we can easily
+            // invoke each function without having to do any pointer arithmetic. Depending on the
+            // architecture, the function calling conventions can be different.
 
-        // http://stackoverflow.com/a/985820/2073621
-        // http://stackoverflow.com/a/2094715/2073621
-        // http://en.wikipedia.org/wiki/Virtual_method_table
-        // http://www.openrce.org/articles/full_view/23
-        // Because I know that I'm not going to remember all this... In C++, the first
-        // variable of an object is a pointer (v[f]ptr) to the virtual table (v[f]table)
-        // containing the addresses of each function. The first call below gets the vtable
-        // address by following the object ptr to the vptr to the vtable. The second call
-        // casts the vtable to a structure with the same memory layout so we can easily
-        // invoke each function without having to do any pointer arithmetic. Depending on the
-        // architecture, the function calling conventions can be different.
-
-        IntPtr vfptr = *(IntPtr*)ptr;
-        if (IntPtr.Size == 4)
-            this.loader32 = (NativeMethods.ILoaderVTable32)Marshal.PtrToStructure(vfptr, typeof(NativeMethods.ILoaderVTable32));
-        else
-            this.loader64 = (NativeMethods.ILoaderVTable64)Marshal.PtrToStructure(vfptr, typeof(NativeMethods.ILoaderVTable64));
+            IntPtr vfptr = *(IntPtr*)ptr;
+            if (IntPtr.Size == 4)
+                this.loader32 = (NativeMethods.ILoaderVTable32)Marshal.PtrToStructure(vfptr, typeof(NativeMethods.ILoaderVTable32));
+            else
+                this.loader64 = (NativeMethods.ILoaderVTable64)Marshal.PtrToStructure(vfptr, typeof(NativeMethods.ILoaderVTable64));
+        }
     }
 }

--- a/Scintilla.NET/Margin.cs
+++ b/Scintilla.NET/Margin.cs
@@ -1,157 +1,158 @@
 ﻿using System;
 using System.Drawing;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Represents a margin displayed on the left edge of a <see cref="Scintilla" /> control.
-/// </summary>
-public class Margin
+namespace ScintillaNET
 {
-    #region Fields
-
-    private readonly Scintilla scintilla;
-
-    #endregion Fields
-
-    #region Properties
-
     /// <summary>
-    /// Gets or sets the background color of the margin when the <see cref="Type" /> property is set to <see cref="MarginType.Color" />.
+    /// Represents a margin displayed on the left edge of a <see cref="Scintilla" /> control.
     /// </summary>
-    /// <returns>A Color object representing the margin background color. The default is Black.</returns>
-    /// <remarks>Alpha color values are ignored.</remarks>
-    public Color BackColor
+    public class Margin
     {
-        get
-        {
-            int color = this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINBACKN, new IntPtr(Index)).ToInt32();
-            return HelperMethods.FromWin32ColorOpaque(color);
-        }
-        set
-        {
-            if (value.IsEmpty)
-                value = Color.Black;
+        #region Fields
 
-            int color = HelperMethods.ToWin32ColorOpaque(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINBACKN, new IntPtr(Index), new IntPtr(color));
+        private readonly Scintilla scintilla;
+
+        #endregion Fields
+
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the background color of the margin when the <see cref="Type" /> property is set to <see cref="MarginType.Color" />.
+        /// </summary>
+        /// <returns>A Color object representing the margin background color. The default is Black.</returns>
+        /// <remarks>Alpha color values are ignored.</remarks>
+        public Color BackColor
+        {
+            get
+            {
+                int color = this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINBACKN, new IntPtr(Index)).ToInt32();
+                return HelperMethods.FromWin32ColorOpaque(color);
+            }
+            set
+            {
+                if (value.IsEmpty)
+                    value = Color.Black;
+
+                int color = HelperMethods.ToWin32ColorOpaque(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINBACKN, new IntPtr(Index), new IntPtr(color));
+            }
         }
+
+        /// <summary>
+        /// Gets or sets the mouse cursor style when over the margin.
+        /// </summary>
+        /// <returns>One of the <see cref="MarginCursor" /> enumeration values. The default is <see cref="MarginCursor.Arrow" />.</returns>
+        public MarginCursor Cursor
+        {
+            get
+            {
+                return (MarginCursor)this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINCURSORN, new IntPtr(Index));
+            }
+            set
+            {
+                int cursor = (int)value;
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINCURSORN, new IntPtr(Index), new IntPtr(cursor));
+            }
+        }
+
+        /// <summary>
+        /// Gets the zero-based margin index this object represents.
+        /// </summary>
+        /// <returns>The margin index within the <see cref="MarginCollection" />.</returns>
+        public int Index { get; private set; }
+
+        /// <summary>
+        /// Gets or sets whether the margin is sensitive to mouse clicks.
+        /// </summary>
+        /// <returns>true if the margin is sensitive to mouse clicks; otherwise, false. The default is false.</returns>
+        /// <seealso cref="Scintilla.MarginClick" />
+        public bool Sensitive
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINSENSITIVEN, new IntPtr(Index)) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr sensitive = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINSENSITIVEN, new IntPtr(Index), sensitive);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the margin type.
+        /// </summary>
+        /// <returns>One of the <see cref="MarginType" /> enumeration values. The default is <see cref="MarginType.Symbol" />.</returns>
+        public MarginType Type
+        {
+            get
+            {
+                return (MarginType)this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINTYPEN, new IntPtr(Index));
+            }
+            set
+            {
+                int type = (int)value;
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINTYPEN, new IntPtr(Index), new IntPtr(type));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the width in pixels of the margin.
+        /// </summary>
+        /// <returns>The width of the margin measured in pixels.</returns>
+        /// <remarks>Scintilla assigns various default widths.</remarks>
+        public int Width
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINWIDTHN, new IntPtr(Index)).ToInt32();
+            }
+            set
+            {
+                value = Helpers.ClampMin(value, 0);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINWIDTHN, new IntPtr(Index), new IntPtr(value));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a mask indicating which markers this margin can display.
+        /// </summary>
+        /// <returns>
+        /// An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Margin" /> indexes.
+        /// The default is 0x1FFFFFF, which is every marker except folder markers (i.e. 0 through 24).
+        /// </returns>
+        /// <remarks>
+        /// For example, the mask for marker index 10 is 1 shifted left 10 times (1 &lt;&lt; 10).
+        /// <see cref="Marker.MaskFolders" /> is a useful constant for working with just folder margin indexes.
+        /// </remarks>
+        public uint Mask
+        {
+            get
+            {
+                return unchecked((uint)this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINMASKN, new IntPtr(Index)).ToInt32());
+            }
+            set
+            {
+                int mask = unchecked((int)value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINMASKN, new IntPtr(Index), new IntPtr(mask));
+            }
+        }
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Margin" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this margin.</param>
+        /// <param name="index">The index of this margin within the <see cref="MarginCollection" /> that created it.</param>
+        public Margin(Scintilla scintilla, int index)
+        {
+            this.scintilla = scintilla;
+            Index = index;
+        }
+
+        #endregion Constructors
     }
-
-    /// <summary>
-    /// Gets or sets the mouse cursor style when over the margin.
-    /// </summary>
-    /// <returns>One of the <see cref="MarginCursor" /> enumeration values. The default is <see cref="MarginCursor.Arrow" />.</returns>
-    public MarginCursor Cursor
-    {
-        get
-        {
-            return (MarginCursor)this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINCURSORN, new IntPtr(Index));
-        }
-        set
-        {
-            int cursor = (int)value;
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINCURSORN, new IntPtr(Index), new IntPtr(cursor));
-        }
-    }
-
-    /// <summary>
-    /// Gets the zero-based margin index this object represents.
-    /// </summary>
-    /// <returns>The margin index within the <see cref="MarginCollection" />.</returns>
-    public int Index { get; private set; }
-
-    /// <summary>
-    /// Gets or sets whether the margin is sensitive to mouse clicks.
-    /// </summary>
-    /// <returns>true if the margin is sensitive to mouse clicks; otherwise, false. The default is false.</returns>
-    /// <seealso cref="Scintilla.MarginClick" />
-    public bool Sensitive
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINSENSITIVEN, new IntPtr(Index)) != IntPtr.Zero;
-        }
-        set
-        {
-            IntPtr sensitive = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINSENSITIVEN, new IntPtr(Index), sensitive);
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the margin type.
-    /// </summary>
-    /// <returns>One of the <see cref="MarginType" /> enumeration values. The default is <see cref="MarginType.Symbol" />.</returns>
-    public MarginType Type
-    {
-        get
-        {
-            return (MarginType)this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINTYPEN, new IntPtr(Index));
-        }
-        set
-        {
-            int type = (int)value;
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINTYPEN, new IntPtr(Index), new IntPtr(type));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the width in pixels of the margin.
-    /// </summary>
-    /// <returns>The width of the margin measured in pixels.</returns>
-    /// <remarks>Scintilla assigns various default widths.</remarks>
-    public int Width
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINWIDTHN, new IntPtr(Index)).ToInt32();
-        }
-        set
-        {
-            value = Helpers.ClampMin(value, 0);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINWIDTHN, new IntPtr(Index), new IntPtr(value));
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets a mask indicating which markers this margin can display.
-    /// </summary>
-    /// <returns>
-    /// An unsigned 32-bit value with each bit cooresponding to one of the 32 zero-based <see cref="Margin" /> indexes.
-    /// The default is 0x1FFFFFF, which is every marker except folder markers (i.e. 0 through 24).
-    /// </returns>
-    /// <remarks>
-    /// For example, the mask for marker index 10 is 1 shifted left 10 times (1 &lt;&lt; 10).
-    /// <see cref="Marker.MaskFolders" /> is a useful constant for working with just folder margin indexes.
-    /// </remarks>
-    public uint Mask
-    {
-        get
-        {
-            return unchecked((uint)this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINMASKN, new IntPtr(Index)).ToInt32());
-        }
-        set
-        {
-            int mask = unchecked((int)value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINMASKN, new IntPtr(Index), new IntPtr(mask));
-        }
-    }
-
-    #endregion Properties
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Margin" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this margin.</param>
-    /// <param name="index">The index of this margin within the <see cref="MarginCollection" /> that created it.</param>
-    public Margin(Scintilla scintilla, int index)
-    {
-        this.scintilla = scintilla;
-        Index = index;
-    }
-
-    #endregion Constructors
 }

--- a/Scintilla.NET/MarginClickEventArgs.cs
+++ b/Scintilla.NET/MarginClickEventArgs.cs
@@ -1,55 +1,56 @@
 ﻿using System;
 using System.Windows.Forms;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.MarginClick" /> event.
-/// </summary>
-public class MarginClickEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private int? position;
-
     /// <summary>
-    /// Gets the margin clicked.
+    /// Provides data for the <see cref="Scintilla.MarginClick" /> event.
     /// </summary>
-    /// <returns>The zero-based index of the clicked margin.</returns>
-    public int Margin { get; private set; }
-
-    /// <summary>
-    /// Gets the modifier keys (SHIFT, CTRL, ALT) held down when the margin was clicked.
-    /// </summary>
-    /// <returns>A bitwise combination of the Keys enumeration indicating the modifier keys.</returns>
-    public Keys Modifiers { get; private set; }
-
-    /// <summary>
-    /// Gets the zero-based document position where the line ajacent to the clicked margin starts.
-    /// </summary>
-    /// <returns>The zero-based character position within the document of the start of the line adjacent to the margin clicked.</returns>
-    public int Position
+    public class MarginClickEventArgs : EventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private int? position;
+
+        /// <summary>
+        /// Gets the margin clicked.
+        /// </summary>
+        /// <returns>The zero-based index of the clicked margin.</returns>
+        public int Margin { get; private set; }
+
+        /// <summary>
+        /// Gets the modifier keys (SHIFT, CTRL, ALT) held down when the margin was clicked.
+        /// </summary>
+        /// <returns>A bitwise combination of the Keys enumeration indicating the modifier keys.</returns>
+        public Keys Modifiers { get; private set; }
+
+        /// <summary>
+        /// Gets the zero-based document position where the line ajacent to the clicked margin starts.
+        /// </summary>
+        /// <returns>The zero-based character position within the document of the start of the line adjacent to the margin clicked.</returns>
+        public int Position
         {
-            this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+            get
+            {
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
-            return (int)this.position;
+                return (int)this.position;
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MarginClickEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="modifiers">The modifier keys that where held down at the time of the margin click.</param>
-    /// <param name="bytePosition">The zero-based byte position within the document where the line adjacent to the clicked margin starts.</param>
-    /// <param name="margin">The zero-based index of the clicked margin.</param>
-    public MarginClickEventArgs(Scintilla scintilla, Keys modifiers, int bytePosition, int margin)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
-        Modifiers = modifiers;
-        Margin = margin;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarginClickEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="modifiers">The modifier keys that where held down at the time of the margin click.</param>
+        /// <param name="bytePosition">The zero-based byte position within the document where the line adjacent to the clicked margin starts.</param>
+        /// <param name="margin">The zero-based index of the clicked margin.</param>
+        public MarginClickEventArgs(Scintilla scintilla, Keys modifiers, int bytePosition, int margin)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+            Modifiers = modifiers;
+            Margin = margin;
+        }
     }
 }

--- a/Scintilla.NET/MarginCollection.cs
+++ b/Scintilla.NET/MarginCollection.cs
@@ -3,163 +3,164 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// An immutable collection of margins in a <see cref="Scintilla" /> control.
-/// </summary>
-public class MarginCollection : IEnumerable<Margin>
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-
     /// <summary>
-    /// Removes all text displayed in every <see cref="MarginType.Text" /> and <see cref="MarginType.RightText" /> margins.
+    /// An immutable collection of margins in a <see cref="Scintilla" /> control.
     /// </summary>
-    public void ClearAllText()
+    public class MarginCollection : IEnumerable<Margin>
     {
-        this.scintilla.DirectMessage(NativeMethods.SCI_MARGINTEXTCLEARALL);
-    }
+        private readonly Scintilla scintilla;
 
-    /// <summary>
-    /// Provides an enumerator that iterates through the collection.
-    /// </summary>
-    /// <returns>An object that contains all <see cref="Margin" /> objects within the <see cref="MarginCollection" />.</returns>
-    public IEnumerator<Margin> GetEnumerator()
-    {
-        int count = Count;
-        for (int i = 0; i < count; i++)
-            yield return this[i];
+        /// <summary>
+        /// Removes all text displayed in every <see cref="MarginType.Text" /> and <see cref="MarginType.RightText" /> margins.
+        /// </summary>
+        public void ClearAllText()
+        {
+            this.scintilla.DirectMessage(NativeMethods.SCI_MARGINTEXTCLEARALL);
+        }
 
-        yield break;
-    }
+        /// <summary>
+        /// Provides an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An object that contains all <see cref="Margin" /> objects within the <see cref="MarginCollection" />.</returns>
+        public IEnumerator<Margin> GetEnumerator()
+        {
+            int count = Count;
+            for (int i = 0; i < count; i++)
+                yield return this[i];
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+            yield break;
+        }
 
-    /// <summary>
-    /// Gets or sets the number of margins in the <see cref="MarginCollection" />.
-    /// </summary>
-    /// <returns>The number of margins in the collection. The default is 5.</returns>
-    [DefaultValue(NativeMethods.SC_MAX_MARGIN + 1)]
-    [Description("The maximum number of margins.")]
-    public int Capacity
-    {
-        get
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINS).ToInt32();
+            return GetEnumerator();
         }
-        set
-        {
-            value = Helpers.ClampMin(value, 0);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINS, new IntPtr(value));
-        }
-    }
 
-    /// <summary>
-    /// Gets the number of margins in the <see cref="MarginCollection" />.
-    /// </summary>
-    /// <returns>The number of margins in the collection.</returns>
-    /// <remarks>This property is kept for convenience. The return value will always be equal to <see cref="Capacity" />.</remarks>
-    /// <seealso cref="Capacity" />
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int Count
-    {
-        get
+        /// <summary>
+        /// Gets or sets the number of margins in the <see cref="MarginCollection" />.
+        /// </summary>
+        /// <returns>The number of margins in the collection. The default is 5.</returns>
+        [DefaultValue(NativeMethods.SC_MAX_MARGIN + 1)]
+        [Description("The maximum number of margins.")]
+        public int Capacity
         {
-            return Capacity;
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINS).ToInt32();
+            }
+            set
+            {
+                value = Helpers.ClampMin(value, 0);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINS, new IntPtr(value));
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets or sets the width in pixels of the left margin padding.
-    /// </summary>
-    /// <returns>The left margin padding measured in pixels. The default is 1.</returns>
-    [DefaultValue(1)]
-    [Description("The left margin padding in pixels.")]
-    public int Left
-    {
-        get
+        /// <summary>
+        /// Gets the number of margins in the <see cref="MarginCollection" />.
+        /// </summary>
+        /// <returns>The number of margins in the collection.</returns>
+        /// <remarks>This property is kept for convenience. The return value will always be equal to <see cref="Capacity" />.</remarks>
+        /// <seealso cref="Capacity" />
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int Count
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINLEFT).ToInt32();
+            get
+            {
+                return Capacity;
+            }
         }
-        set
-        {
-            value = Helpers.ClampMin(value, 0);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINLEFT, IntPtr.Zero, new IntPtr(value));
-        }
-    }
 
-    // TODO Why is this commented out?
-    /*
-    /// <summary>
-    /// Gets or sets the margin options.
-    /// </summary>
-    /// <returns>
-    /// A <see cref="ScintillaNET.MarginOptions" /> that represents the margin options.
-    /// The default is <see cref="ScintillaNET.MarginOptions.None" />.
-    /// </returns>
-    [DefaultValue(MarginOptions.None)]
-    [Description("Margin options flags.")]
-    [TypeConverter(typeof(FlagsEnumTypeConverter.FlagsEnumConverter))]
-    public MarginOptions Options
-    {
-        get
+        /// <summary>
+        /// Gets or sets the width in pixels of the left margin padding.
+        /// </summary>
+        /// <returns>The left margin padding measured in pixels. The default is 1.</returns>
+        [DefaultValue(1)]
+        [Description("The left margin padding in pixels.")]
+        public int Left
         {
-            return (MarginOptions)scintilla.DirectMessage(NativeMethods.SCI_GETMARGINOPTIONS);
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINLEFT).ToInt32();
+            }
+            set
+            {
+                value = Helpers.ClampMin(value, 0);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINLEFT, IntPtr.Zero, new IntPtr(value));
+            }
         }
-        set
-        {
-            var options = (int)value;
-            scintilla.DirectMessage(NativeMethods.SCI_SETMARGINOPTIONS, new IntPtr(options));
-        }
-    }
-    */
 
-    /// <summary>
-    /// Gets or sets the width in pixels of the right margin padding.
-    /// </summary>
-    /// <returns>The right margin padding measured in pixels. The default is 1.</returns>
-    [DefaultValue(1)]
-    [Description("The right margin padding in pixels.")]
-    public int Right
-    {
-        get
+        // TODO Why is this commented out?
+        /*
+        /// <summary>
+        /// Gets or sets the margin options.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="ScintillaNET.MarginOptions" /> that represents the margin options.
+        /// The default is <see cref="ScintillaNET.MarginOptions.None" />.
+        /// </returns>
+        [DefaultValue(MarginOptions.None)]
+        [Description("Margin options flags.")]
+        [TypeConverter(typeof(FlagsEnumTypeConverter.FlagsEnumConverter))]
+        public MarginOptions Options
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINRIGHT).ToInt32();
+            get
+            {
+                return (MarginOptions)scintilla.DirectMessage(NativeMethods.SCI_GETMARGINOPTIONS);
+            }
+            set
+            {
+                var options = (int)value;
+                scintilla.DirectMessage(NativeMethods.SCI_SETMARGINOPTIONS, new IntPtr(options));
+            }
         }
-        set
-        {
-            value = Helpers.ClampMin(value, 0);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINRIGHT, IntPtr.Zero, new IntPtr(value));
-        }
-    }
+        */
 
-    /// <summary>
-    /// Gets a <see cref="Margin" /> object at the specified index.
-    /// </summary>
-    /// <param name="index">The margin index.</param>
-    /// <returns>An object representing the margin at the specified <paramref name="index" />.</returns>
-    /// <remarks>By convention margin 0 is used for line numbers and the two following for symbols.</remarks>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public Margin this[int index]
-    {
-        get
+        /// <summary>
+        /// Gets or sets the width in pixels of the right margin padding.
+        /// </summary>
+        /// <returns>The right margin padding measured in pixels. The default is 1.</returns>
+        [DefaultValue(1)]
+        [Description("The right margin padding in pixels.")]
+        public int Right
         {
-            index = Helpers.Clamp(index, 0, Count - 1);
-            return new Margin(this.scintilla, index);
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETMARGINRIGHT).ToInt32();
+            }
+            set
+            {
+                value = Helpers.ClampMin(value, 0);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETMARGINRIGHT, IntPtr.Zero, new IntPtr(value));
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MarginCollection" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
-    public MarginCollection(Scintilla scintilla)
-    {
-        this.scintilla = scintilla;
+        /// <summary>
+        /// Gets a <see cref="Margin" /> object at the specified index.
+        /// </summary>
+        /// <param name="index">The margin index.</param>
+        /// <returns>An object representing the margin at the specified <paramref name="index" />.</returns>
+        /// <remarks>By convention margin 0 is used for line numbers and the two following for symbols.</remarks>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public Margin this[int index]
+        {
+            get
+            {
+                index = Helpers.Clamp(index, 0, Count - 1);
+                return new Margin(this.scintilla, index);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarginCollection" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
+        public MarginCollection(Scintilla scintilla)
+        {
+            this.scintilla = scintilla;
+        }
     }
 }

--- a/Scintilla.NET/MarginCursor.cs
+++ b/Scintilla.NET/MarginCursor.cs
@@ -1,17 +1,18 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The display of a cursor when over a margin.
-/// </summary>
-public enum MarginCursor
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// A normal arrow.
+    /// The display of a cursor when over a margin.
     /// </summary>
-    Arrow = NativeMethods.SC_CURSORARROW,
+    public enum MarginCursor
+    {
+        /// <summary>
+        /// A normal arrow.
+        /// </summary>
+        Arrow = NativeMethods.SC_CURSORARROW,
 
-    /// <summary>
-    /// A reversed arrow.
-    /// </summary>
-    ReverseArrow = NativeMethods.SC_CURSORREVERSEARROW
+        /// <summary>
+        /// A reversed arrow.
+        /// </summary>
+        ReverseArrow = NativeMethods.SC_CURSORREVERSEARROW
+    }
 }

--- a/Scintilla.NET/MarginOptions.cs
+++ b/Scintilla.NET/MarginOptions.cs
@@ -1,21 +1,22 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Flags used to define margin options.
-/// </summary>
-/// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
-[Flags]
-public enum MarginOptions
+namespace ScintillaNET
 {
     /// <summary>
-    /// No options. This is the default.
+    /// Flags used to define margin options.
     /// </summary>
-    None = NativeMethods.SC_MARGINOPTION_NONE,
+    /// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
+    [Flags]
+    public enum MarginOptions
+    {
+        /// <summary>
+        /// No options. This is the default.
+        /// </summary>
+        None = NativeMethods.SC_MARGINOPTION_NONE,
 
-    /// <summary>
-    /// Lines selected by clicking on the margin will select only the subline of wrapped text.
-    /// </summary>
-    SublineSelect = NativeMethods.SC_MARGINOPTION_SUBLINESELECT
+        /// <summary>
+        /// Lines selected by clicking on the margin will select only the subline of wrapped text.
+        /// </summary>
+        SublineSelect = NativeMethods.SC_MARGINOPTION_SUBLINESELECT
+    }
 }

--- a/Scintilla.NET/MarginType.cs
+++ b/Scintilla.NET/MarginType.cs
@@ -1,42 +1,43 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The behavior and appearance of a margin.
-/// </summary>
-public enum MarginType
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Margin can display symbols.
+    /// The behavior and appearance of a margin.
     /// </summary>
-    Symbol = NativeMethods.SC_MARGIN_SYMBOL,
+    public enum MarginType
+    {
+        /// <summary>
+        /// Margin can display symbols.
+        /// </summary>
+        Symbol = NativeMethods.SC_MARGIN_SYMBOL,
 
-    /// <summary>
-    /// Margin displays line numbers.
-    /// </summary>
-    Number = NativeMethods.SC_MARGIN_NUMBER,
+        /// <summary>
+        /// Margin displays line numbers.
+        /// </summary>
+        Number = NativeMethods.SC_MARGIN_NUMBER,
 
-    /// <summary>
-    /// Margin can display symbols and has a background color equivalent to <see cref="Style.Default" /> background color.
-    /// </summary>
-    BackColor = NativeMethods.SC_MARGIN_BACK,
+        /// <summary>
+        /// Margin can display symbols and has a background color equivalent to <see cref="Style.Default" /> background color.
+        /// </summary>
+        BackColor = NativeMethods.SC_MARGIN_BACK,
 
-    /// <summary>
-    /// Margin can display symbols and has a background color equivalent to <see cref="Style.Default"/> foreground color.
-    /// </summary>
-    ForeColor = NativeMethods.SC_MARGIN_FORE,
+        /// <summary>
+        /// Margin can display symbols and has a background color equivalent to <see cref="Style.Default"/> foreground color.
+        /// </summary>
+        ForeColor = NativeMethods.SC_MARGIN_FORE,
 
-    /// <summary>
-    /// Margin can display application defined text.
-    /// </summary>
-    Text = NativeMethods.SC_MARGIN_TEXT,
+        /// <summary>
+        /// Margin can display application defined text.
+        /// </summary>
+        Text = NativeMethods.SC_MARGIN_TEXT,
 
-    /// <summary>
-    /// Margin can display application defined text right-justified.
-    /// </summary>
-    RightText = NativeMethods.SC_MARGIN_RTEXT,
+        /// <summary>
+        /// Margin can display application defined text right-justified.
+        /// </summary>
+        RightText = NativeMethods.SC_MARGIN_RTEXT,
 
-    /// <summary>
-    /// Margin can display symbols and has a background color specified using the <see cref="Margin.BackColor" /> property.
-    /// </summary>
-    Color = NativeMethods.SC_MARGIN_COLOUR
+        /// <summary>
+        /// Margin can display symbols and has a background color specified using the <see cref="Margin.BackColor" /> property.
+        /// </summary>
+        Color = NativeMethods.SC_MARGIN_COLOUR
+    }
 }

--- a/Scintilla.NET/Marker.cs
+++ b/Scintilla.NET/Marker.cs
@@ -1,184 +1,185 @@
 ﻿using System;
 using System.Drawing;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Represents a margin marker in a <see cref="Scintilla" /> control.
-/// </summary>
-public class Marker
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-
     /// <summary>
-    /// An unsigned 32-bit mask of all <see cref="Margin" /> indexes where each bit cooresponds to a margin index.
+    /// Represents a margin marker in a <see cref="Scintilla" /> control.
     /// </summary>
-    public const uint MaskAll = unchecked((uint)-1);
-
-    /// <summary>
-    /// An unsigned 32-bit mask of history <see cref="Margin" /> indexes (21 through 24) where each bit cooresponds to a margin index.
-    /// </summary>
-    /// <seealso cref="Margin.Mask" />
-    public const uint MaskHistory = (1 << HistoryRevertedToOrigin) | (1 << HistorySaved) | (1 << HistoryModified) | (1 << HistoryRevertedToModified);
-
-    /// <summary>
-    /// A change was made to this line and saved but then reverted to its original state.
-    /// </summary>
-    public const int HistoryRevertedToOrigin = NativeMethods.SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN;
-
-    /// <summary>
-    /// This line was modified and saved.
-    /// </summary>
-    public const int HistorySaved = NativeMethods.SC_MARKNUM_HISTORY_SAVED;
-
-    /// <summary>
-    /// This line was modified but not yet saved.
-    /// </summary>
-    public const int HistoryModified = NativeMethods.SC_MARKNUM_HISTORY_MODIFIED;
-
-    /// <summary>
-    /// A change was made to this line and saved but then reverted but not to its original state.
-    /// </summary>
-    public const int HistoryRevertedToModified = NativeMethods.SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED;
-
-    /// <summary>
-    /// An unsigned 32-bit mask of folder <see cref="Margin" /> indexes (25 through 31) where each bit cooresponds to a margin index.
-    /// </summary>
-    /// <seealso cref="Margin.Mask" />
-    public const uint MaskFolders = NativeMethods.SC_MASK_FOLDERS;
-
-    /// <summary>
-    /// Folder end marker index. This marker is typically configured to display the <see cref="MarkerSymbol.BoxPlusConnected" /> symbol.
-    /// </summary>
-    public const int FolderEnd = NativeMethods.SC_MARKNUM_FOLDEREND;
-
-    /// <summary>
-    /// Folder open marker index. This marker is typically configured to display the <see cref="MarkerSymbol.BoxMinusConnected" /> symbol.
-    /// </summary>
-    public const int FolderOpenMid = NativeMethods.SC_MARKNUM_FOLDEROPENMID;
-
-    /// <summary>
-    /// Folder mid tail marker index. This marker is typically configured to display the <see cref="MarkerSymbol.TCorner" /> symbol.
-    /// </summary>
-    public const int FolderMidTail = NativeMethods.SC_MARKNUM_FOLDERMIDTAIL;
-
-    /// <summary>
-    /// Folder tail marker index. This marker is typically configured to display the <see cref="MarkerSymbol.LCorner" /> symbol.
-    /// </summary>
-    public const int FolderTail = NativeMethods.SC_MARKNUM_FOLDERTAIL;
-
-    /// <summary>
-    /// Folder sub marker index. This marker is typically configured to display the <see cref="MarkerSymbol.VLine" /> symbol.
-    /// </summary>
-    public const int FolderSub = NativeMethods.SC_MARKNUM_FOLDERSUB;
-
-    /// <summary>
-    /// Folder marker index. This marker is typically configured to display the <see cref="MarkerSymbol.BoxPlus" /> symbol.
-    /// </summary>
-    public const int Folder = NativeMethods.SC_MARKNUM_FOLDER;
-
-    /// <summary>
-    /// Folder open marker index. This marker is typically configured to display the <see cref="MarkerSymbol.BoxMinus" /> symbol.
-    /// </summary>
-    public const int FolderOpen = NativeMethods.SC_MARKNUM_FOLDEROPEN;
-
-    /// <summary>
-    /// Sets the marker symbol to a custom image.
-    /// </summary>
-    /// <param name="image">The Bitmap to use as a marker symbol.</param>
-    /// <remarks>Calling this method will also update the <see cref="Symbol" /> property to <see cref="MarkerSymbol.RgbaImage" />.</remarks>
-    public unsafe void DefineRgbaImage(Bitmap image)
+    public class Marker
     {
-        if (image == null)
-            return;
+        private readonly Scintilla scintilla;
 
-        this.scintilla.DirectMessage(NativeMethods.SCI_RGBAIMAGESETWIDTH, new IntPtr(image.Width));
-        this.scintilla.DirectMessage(NativeMethods.SCI_RGBAIMAGESETHEIGHT, new IntPtr(image.Height));
+        /// <summary>
+        /// An unsigned 32-bit mask of all <see cref="Margin" /> indexes where each bit cooresponds to a margin index.
+        /// </summary>
+        public const uint MaskAll = unchecked((uint)-1);
 
-        byte[] bytes = Helpers.BitmapToArgb(image);
-        fixed (byte* bp = bytes)
-            this.scintilla.DirectMessage(NativeMethods.SCI_MARKERDEFINERGBAIMAGE, new IntPtr(Index), new IntPtr(bp));
-    }
+        /// <summary>
+        /// An unsigned 32-bit mask of history <see cref="Margin" /> indexes (21 through 24) where each bit cooresponds to a margin index.
+        /// </summary>
+        /// <seealso cref="Margin.Mask" />
+        public const uint MaskHistory = (1 << HistoryRevertedToOrigin) | (1 << HistorySaved) | (1 << HistoryModified) | (1 << HistoryRevertedToModified);
 
-    /// <summary>
-    /// Removes this marker from all lines.
-    /// </summary>
-    public void DeleteAll()
-    {
-        this.scintilla.MarkerDeleteAll(Index);
-    }
+        /// <summary>
+        /// A change was made to this line and saved but then reverted to its original state.
+        /// </summary>
+        public const int HistoryRevertedToOrigin = NativeMethods.SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN;
 
-    /// <summary>
-    /// Sets the foreground alpha transparency for markers that are drawn in the content area.
-    /// </summary>
-    /// <param name="alpha">The alpha transparency ranging from 0 (completely transparent) to 255 (no transparency).</param>
-    /// <remarks>See the remarks on the <see cref="SetBackColor" /> method for a full explanation of when a marker can be drawn in the content area.</remarks>
-    /// <seealso cref="SetBackColor" />
-    public void SetAlpha(int alpha)
-    {
-        alpha = Helpers.Clamp(alpha, 0, 255);
-        this.scintilla.DirectMessage(NativeMethods.SCI_MARKERSETALPHA, new IntPtr(Index), new IntPtr(alpha));
-    }
+        /// <summary>
+        /// This line was modified and saved.
+        /// </summary>
+        public const int HistorySaved = NativeMethods.SC_MARKNUM_HISTORY_SAVED;
 
-    /// <summary>
-    /// Sets the background color of the marker.
-    /// </summary>
-    /// <param name="color">The <see cref="Marker" /> background Color. The default is White.</param>
-    /// <remarks>
-    /// The background color of the whole line will be drawn in the <paramref name="color" /> specified when the marker is not visible
-    /// because it is hidden by a <see cref="Margin.Mask" /> or the <see cref="Margin.Width" /> is zero.
-    /// </remarks>
-    /// <seealso cref="SetAlpha" />
-    public void SetBackColor(Color color)
-    {
-        int colour = HelperMethods.ToWin32Color(color);
-        this.scintilla.DirectMessage(NativeMethods.SCI_MARKERSETBACKTRANSLUCENT, new IntPtr(Index), new IntPtr(colour));
-    }
+        /// <summary>
+        /// This line was modified but not yet saved.
+        /// </summary>
+        public const int HistoryModified = NativeMethods.SC_MARKNUM_HISTORY_MODIFIED;
 
-    /// <summary>
-    /// Sets the foreground color of the marker.
-    /// </summary>
-    /// <param name="color">The <see cref="Marker" /> foreground Color. The default is Black.</param>
-    public void SetForeColor(Color color)
-    {
-        int colour = HelperMethods.ToWin32Color(color);
-        this.scintilla.DirectMessage(NativeMethods.SCI_MARKERSETFORETRANSLUCENT, new IntPtr(Index), new IntPtr(colour));
-    }
+        /// <summary>
+        /// A change was made to this line and saved but then reverted but not to its original state.
+        /// </summary>
+        public const int HistoryRevertedToModified = NativeMethods.SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED;
 
-    /// <summary>
-    /// Gets the zero-based marker index this object represents.
-    /// </summary>
-    /// <returns>The marker index within the <see cref="MarkerCollection" />.</returns>
-    public int Index { get; private set; }
+        /// <summary>
+        /// An unsigned 32-bit mask of folder <see cref="Margin" /> indexes (25 through 31) where each bit cooresponds to a margin index.
+        /// </summary>
+        /// <seealso cref="Margin.Mask" />
+        public const uint MaskFolders = NativeMethods.SC_MASK_FOLDERS;
 
-    /// <summary>
-    /// Gets or sets the marker symbol.
-    /// </summary>
-    /// <returns>
-    /// One of the <see cref="ScintillaNET.MarkerSymbol" /> enumeration values.
-    /// The default is <see cref="ScintillaNET.MarkerSymbol.Circle" />.
-    /// </returns>
-    public MarkerSymbol Symbol
-    {
-        get
+        /// <summary>
+        /// Folder end marker index. This marker is typically configured to display the <see cref="MarkerSymbol.BoxPlusConnected" /> symbol.
+        /// </summary>
+        public const int FolderEnd = NativeMethods.SC_MARKNUM_FOLDEREND;
+
+        /// <summary>
+        /// Folder open marker index. This marker is typically configured to display the <see cref="MarkerSymbol.BoxMinusConnected" /> symbol.
+        /// </summary>
+        public const int FolderOpenMid = NativeMethods.SC_MARKNUM_FOLDEROPENMID;
+
+        /// <summary>
+        /// Folder mid tail marker index. This marker is typically configured to display the <see cref="MarkerSymbol.TCorner" /> symbol.
+        /// </summary>
+        public const int FolderMidTail = NativeMethods.SC_MARKNUM_FOLDERMIDTAIL;
+
+        /// <summary>
+        /// Folder tail marker index. This marker is typically configured to display the <see cref="MarkerSymbol.LCorner" /> symbol.
+        /// </summary>
+        public const int FolderTail = NativeMethods.SC_MARKNUM_FOLDERTAIL;
+
+        /// <summary>
+        /// Folder sub marker index. This marker is typically configured to display the <see cref="MarkerSymbol.VLine" /> symbol.
+        /// </summary>
+        public const int FolderSub = NativeMethods.SC_MARKNUM_FOLDERSUB;
+
+        /// <summary>
+        /// Folder marker index. This marker is typically configured to display the <see cref="MarkerSymbol.BoxPlus" /> symbol.
+        /// </summary>
+        public const int Folder = NativeMethods.SC_MARKNUM_FOLDER;
+
+        /// <summary>
+        /// Folder open marker index. This marker is typically configured to display the <see cref="MarkerSymbol.BoxMinus" /> symbol.
+        /// </summary>
+        public const int FolderOpen = NativeMethods.SC_MARKNUM_FOLDEROPEN;
+
+        /// <summary>
+        /// Sets the marker symbol to a custom image.
+        /// </summary>
+        /// <param name="image">The Bitmap to use as a marker symbol.</param>
+        /// <remarks>Calling this method will also update the <see cref="Symbol" /> property to <see cref="MarkerSymbol.RgbaImage" />.</remarks>
+        public unsafe void DefineRgbaImage(Bitmap image)
         {
-            return (MarkerSymbol)this.scintilla.DirectMessage(NativeMethods.SCI_MARKERSYMBOLDEFINED, new IntPtr(Index));
-        }
-        set
-        {
-            int markerSymbol = (int)value;
-            this.scintilla.DirectMessage(NativeMethods.SCI_MARKERDEFINE, new IntPtr(Index), new IntPtr(markerSymbol));
-        }
-    }
+            if (image == null)
+                return;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Marker" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this marker.</param>
-    /// <param name="index">The index of this style within the <see cref="MarkerCollection" /> that created it.</param>
-    public Marker(Scintilla scintilla, int index)
-    {
-        this.scintilla = scintilla;
-        Index = index;
+            this.scintilla.DirectMessage(NativeMethods.SCI_RGBAIMAGESETWIDTH, new IntPtr(image.Width));
+            this.scintilla.DirectMessage(NativeMethods.SCI_RGBAIMAGESETHEIGHT, new IntPtr(image.Height));
+
+            byte[] bytes = Helpers.BitmapToArgb(image);
+            fixed (byte* bp = bytes)
+                this.scintilla.DirectMessage(NativeMethods.SCI_MARKERDEFINERGBAIMAGE, new IntPtr(Index), new IntPtr(bp));
+        }
+
+        /// <summary>
+        /// Removes this marker from all lines.
+        /// </summary>
+        public void DeleteAll()
+        {
+            this.scintilla.MarkerDeleteAll(Index);
+        }
+
+        /// <summary>
+        /// Sets the foreground alpha transparency for markers that are drawn in the content area.
+        /// </summary>
+        /// <param name="alpha">The alpha transparency ranging from 0 (completely transparent) to 255 (no transparency).</param>
+        /// <remarks>See the remarks on the <see cref="SetBackColor" /> method for a full explanation of when a marker can be drawn in the content area.</remarks>
+        /// <seealso cref="SetBackColor" />
+        public void SetAlpha(int alpha)
+        {
+            alpha = Helpers.Clamp(alpha, 0, 255);
+            this.scintilla.DirectMessage(NativeMethods.SCI_MARKERSETALPHA, new IntPtr(Index), new IntPtr(alpha));
+        }
+
+        /// <summary>
+        /// Sets the background color of the marker.
+        /// </summary>
+        /// <param name="color">The <see cref="Marker" /> background Color. The default is White.</param>
+        /// <remarks>
+        /// The background color of the whole line will be drawn in the <paramref name="color" /> specified when the marker is not visible
+        /// because it is hidden by a <see cref="Margin.Mask" /> or the <see cref="Margin.Width" /> is zero.
+        /// </remarks>
+        /// <seealso cref="SetAlpha" />
+        public void SetBackColor(Color color)
+        {
+            int colour = HelperMethods.ToWin32Color(color);
+            this.scintilla.DirectMessage(NativeMethods.SCI_MARKERSETBACKTRANSLUCENT, new IntPtr(Index), new IntPtr(colour));
+        }
+
+        /// <summary>
+        /// Sets the foreground color of the marker.
+        /// </summary>
+        /// <param name="color">The <see cref="Marker" /> foreground Color. The default is Black.</param>
+        public void SetForeColor(Color color)
+        {
+            int colour = HelperMethods.ToWin32Color(color);
+            this.scintilla.DirectMessage(NativeMethods.SCI_MARKERSETFORETRANSLUCENT, new IntPtr(Index), new IntPtr(colour));
+        }
+
+        /// <summary>
+        /// Gets the zero-based marker index this object represents.
+        /// </summary>
+        /// <returns>The marker index within the <see cref="MarkerCollection" />.</returns>
+        public int Index { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the marker symbol.
+        /// </summary>
+        /// <returns>
+        /// One of the <see cref="ScintillaNET.MarkerSymbol" /> enumeration values.
+        /// The default is <see cref="ScintillaNET.MarkerSymbol.Circle" />.
+        /// </returns>
+        public MarkerSymbol Symbol
+        {
+            get
+            {
+                return (MarkerSymbol)this.scintilla.DirectMessage(NativeMethods.SCI_MARKERSYMBOLDEFINED, new IntPtr(Index));
+            }
+            set
+            {
+                int markerSymbol = (int)value;
+                this.scintilla.DirectMessage(NativeMethods.SCI_MARKERDEFINE, new IntPtr(Index), new IntPtr(markerSymbol));
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Marker" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this marker.</param>
+        /// <param name="index">The index of this style within the <see cref="MarkerCollection" /> that created it.</param>
+        public Marker(Scintilla scintilla, int index)
+        {
+            this.scintilla = scintilla;
+            Index = index;
+        }
     }
 }

--- a/Scintilla.NET/MarkerCollection.cs
+++ b/Scintilla.NET/MarkerCollection.cs
@@ -1,66 +1,67 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// An immutable collection of markers in a <see cref="Scintilla" /> control.
-/// </summary>
-public class MarkerCollection : IEnumerable<Marker>
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-
     /// <summary>
-    /// Provides an enumerator that iterates through the collection.
+    /// An immutable collection of markers in a <see cref="Scintilla" /> control.
     /// </summary>
-    /// <returns>An object for enumerating all <see cref="Marker" /> objects within the <see cref="MarkerCollection" />.</returns>
-    public IEnumerator<Marker> GetEnumerator()
+    public class MarkerCollection : IEnumerable<Marker>
     {
-        int count = Count;
-        for (int i = 0; i < count; i++)
-            yield return this[i];
+        private readonly Scintilla scintilla;
 
-        yield break;
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    /// <summary>
-    /// Gets the number of markers in the <see cref="MarkerCollection" />.
-    /// </summary>
-    /// <returns>This property always returns 32.</returns>
-    public int Count
-    {
-        get
+        /// <summary>
+        /// Provides an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An object for enumerating all <see cref="Marker" /> objects within the <see cref="MarkerCollection" />.</returns>
+        public IEnumerator<Marker> GetEnumerator()
         {
-            return NativeMethods.MARKER_MAX + 1;
-        }
-    }
+            int count = Count;
+            for (int i = 0; i < count; i++)
+                yield return this[i];
 
-    /// <summary>
-    /// Gets a <see cref="Marker" /> object at the specified index.
-    /// </summary>
-    /// <param name="index">The marker index.</param>
-    /// <returns>An object representing the marker at the specified <paramref name="index" />.</returns>
-    /// <remarks>Markers 25 through 31 are used by Scintilla for folding.</remarks>
-    public Marker this[int index]
-    {
-        get
+            yield break;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            index = Helpers.Clamp(index, 0, Count - 1);
-            return new Marker(this.scintilla, index);
+            return GetEnumerator();
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MarkerCollection" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
-    public MarkerCollection(Scintilla scintilla)
-    {
-        this.scintilla = scintilla;
+        /// <summary>
+        /// Gets the number of markers in the <see cref="MarkerCollection" />.
+        /// </summary>
+        /// <returns>This property always returns 32.</returns>
+        public int Count
+        {
+            get
+            {
+                return NativeMethods.MARKER_MAX + 1;
+            }
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Marker" /> object at the specified index.
+        /// </summary>
+        /// <param name="index">The marker index.</param>
+        /// <returns>An object representing the marker at the specified <paramref name="index" />.</returns>
+        /// <remarks>Markers 25 through 31 are used by Scintilla for folding.</remarks>
+        public Marker this[int index]
+        {
+            get
+            {
+                index = Helpers.Clamp(index, 0, Count - 1);
+                return new Marker(this.scintilla, index);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkerCollection" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
+        public MarkerCollection(Scintilla scintilla)
+        {
+            this.scintilla = scintilla;
+        }
     }
 }

--- a/Scintilla.NET/MarkerHandle.cs
+++ b/Scintilla.NET/MarkerHandle.cs
@@ -1,61 +1,62 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// A <see cref="Marker" /> handle.
-/// </summary>
-/// <remarks>
-/// This is an opaque type, meaning it can be used by a <see cref="Scintilla" /> control but
-/// otherwise has no public members of its own.
-/// </remarks>
-public struct MarkerHandle
+namespace ScintillaNET
 {
-    internal IntPtr Value;
-
     /// <summary>
-    /// A read-only field that represents an uninitialized handle.
+    /// A <see cref="Marker" /> handle.
     /// </summary>
-    public static readonly MarkerHandle Zero;
-
-    /// <summary>
-    /// Returns a value indicating whether this instance is equal to a specified object.
-    /// </summary>
-    /// <param name="obj">An object to compare with this instance or null.</param>
-    /// <returns>true if <paramref name="obj" /> is an instance of <see cref="MarkerHandle" /> and equals the value of this instance; otherwise, false.</returns>
-    public override bool Equals(object obj)
+    /// <remarks>
+    /// This is an opaque type, meaning it can be used by a <see cref="Scintilla" /> control but
+    /// otherwise has no public members of its own.
+    /// </remarks>
+    public struct MarkerHandle
     {
-        return obj is IntPtr && this.Value == ((MarkerHandle)obj).Value;
-    }
+        internal IntPtr Value;
 
-    /// <summary>
-    /// Returns the hash code for this instance.
-    /// </summary>
-    /// <returns>A 32-bit signed integer hash code.</returns>
-    public override int GetHashCode()
-    {
-        return this.Value.GetHashCode();
-    }
+        /// <summary>
+        /// A read-only field that represents an uninitialized handle.
+        /// </summary>
+        public static readonly MarkerHandle Zero;
 
-    /// <summary>
-    /// Determines whether two specified instances of <see cref="MarkerHandle" /> are equal.
-    /// </summary>
-    /// <param name="a">The first handle to compare.</param>
-    /// <param name="b">The second handle to compare.</param>
-    /// <returns>true if <paramref name="a" /> equals <paramref name="b" />; otherwise, false.</returns>
-    public static bool operator ==(MarkerHandle a, MarkerHandle b)
-    {
-        return a.Value == b.Value;
-    }
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this instance or null.</param>
+        /// <returns>true if <paramref name="obj" /> is an instance of <see cref="MarkerHandle" /> and equals the value of this instance; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return obj is IntPtr && this.Value == ((MarkerHandle)obj).Value;
+        }
 
-    /// <summary>
-    /// Determines whether two specified instances of <see cref="MarkerHandle" /> are not equal.
-    /// </summary>
-    /// <param name="a">The first handle to compare.</param>
-    /// <param name="b">The second handle to compare.</param>
-    /// <returns>true if <paramref name="a" /> does not equal <paramref name="b" />; otherwise, false.</returns>
-    public static bool operator !=(MarkerHandle a, MarkerHandle b)
-    {
-        return a.Value != b.Value;
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return this.Value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MarkerHandle" /> are equal.
+        /// </summary>
+        /// <param name="a">The first handle to compare.</param>
+        /// <param name="b">The second handle to compare.</param>
+        /// <returns>true if <paramref name="a" /> equals <paramref name="b" />; otherwise, false.</returns>
+        public static bool operator ==(MarkerHandle a, MarkerHandle b)
+        {
+            return a.Value == b.Value;
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MarkerHandle" /> are not equal.
+        /// </summary>
+        /// <param name="a">The first handle to compare.</param>
+        /// <param name="b">The second handle to compare.</param>
+        /// <returns>true if <paramref name="a" /> does not equal <paramref name="b" />; otherwise, false.</returns>
+        public static bool operator !=(MarkerHandle a, MarkerHandle b)
+        {
+            return a.Value != b.Value;
+        }
     }
 }

--- a/Scintilla.NET/MarkerSymbol.cs
+++ b/Scintilla.NET/MarkerSymbol.cs
@@ -1,176 +1,177 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The symbol displayed by a <see cref="Marker" />
-/// </summary>
-public enum MarkerSymbol
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// A circle. This symbol is typically used to indicate a breakpoint.
+    /// The symbol displayed by a <see cref="Marker" />
     /// </summary>
-    Circle = NativeMethods.SC_MARK_CIRCLE,
+    public enum MarkerSymbol
+    {
+        /// <summary>
+        /// A circle. This symbol is typically used to indicate a breakpoint.
+        /// </summary>
+        Circle = NativeMethods.SC_MARK_CIRCLE,
 
-    /// <summary>
-    /// A rectangel with rounded edges.
-    /// </summary>
-    RoundRect = NativeMethods.SC_MARK_ROUNDRECT,
+        /// <summary>
+        /// A rectangel with rounded edges.
+        /// </summary>
+        RoundRect = NativeMethods.SC_MARK_ROUNDRECT,
 
-    /// <summary>
-    /// An arrow (triangle) pointing right.
-    /// </summary>
-    Arrow = NativeMethods.SC_MARK_ARROW,
+        /// <summary>
+        /// An arrow (triangle) pointing right.
+        /// </summary>
+        Arrow = NativeMethods.SC_MARK_ARROW,
 
-    /// <summary>
-    /// A rectangle that is wider than it is tall.
-    /// </summary>
-    SmallRect = NativeMethods.SC_MARK_SMALLRECT,
+        /// <summary>
+        /// A rectangle that is wider than it is tall.
+        /// </summary>
+        SmallRect = NativeMethods.SC_MARK_SMALLRECT,
 
-    /// <summary>
-    /// An arrow and tail pointing right. This symbol is typically used to indicate the current line of execution.
-    /// </summary>
-    ShortArrow = NativeMethods.SC_MARK_SHORTARROW,
+        /// <summary>
+        /// An arrow and tail pointing right. This symbol is typically used to indicate the current line of execution.
+        /// </summary>
+        ShortArrow = NativeMethods.SC_MARK_SHORTARROW,
 
-    /// <summary>
-    /// An invisible symbol useful for tracking the movement of lines.
-    /// </summary>
-    Empty = NativeMethods.SC_MARK_EMPTY,
+        /// <summary>
+        /// An invisible symbol useful for tracking the movement of lines.
+        /// </summary>
+        Empty = NativeMethods.SC_MARK_EMPTY,
 
-    /// <summary>
-    /// An arrow (triangle) pointing down.
-    /// </summary>
-    ArrowDown = NativeMethods.SC_MARK_ARROWDOWN,
+        /// <summary>
+        /// An arrow (triangle) pointing down.
+        /// </summary>
+        ArrowDown = NativeMethods.SC_MARK_ARROWDOWN,
 
-    /// <summary>
-    /// A minus (-) symbol.
-    /// </summary>
-    Minus = NativeMethods.SC_MARK_MINUS,
+        /// <summary>
+        /// A minus (-) symbol.
+        /// </summary>
+        Minus = NativeMethods.SC_MARK_MINUS,
 
-    /// <summary>
-    /// A plus (+) symbol.
-    /// </summary>
-    Plus = NativeMethods.SC_MARK_PLUS,
+        /// <summary>
+        /// A plus (+) symbol.
+        /// </summary>
+        Plus = NativeMethods.SC_MARK_PLUS,
 
-    /// <summary>
-    /// A thin vertical line. This symbol is typically used on the middle line of an expanded fold block.
-    /// </summary>
-    VLine = NativeMethods.SC_MARK_VLINE,
+        /// <summary>
+        /// A thin vertical line. This symbol is typically used on the middle line of an expanded fold block.
+        /// </summary>
+        VLine = NativeMethods.SC_MARK_VLINE,
 
-    /// <summary>
-    /// A thin 'L' shaped line. This symbol is typically used on the last line of an expanded fold block.
-    /// </summary>
-    LCorner = NativeMethods.SC_MARK_LCORNER,
+        /// <summary>
+        /// A thin 'L' shaped line. This symbol is typically used on the last line of an expanded fold block.
+        /// </summary>
+        LCorner = NativeMethods.SC_MARK_LCORNER,
 
-    /// <summary>
-    /// A thin 't' shaped line. This symbol is typically used on the last line of an expanded nested fold block.
-    /// </summary>
-    TCorner = NativeMethods.SC_MARK_TCORNER,
+        /// <summary>
+        /// A thin 't' shaped line. This symbol is typically used on the last line of an expanded nested fold block.
+        /// </summary>
+        TCorner = NativeMethods.SC_MARK_TCORNER,
 
-    /// <summary>
-    /// A plus (+) symbol with surrounding box. This symbol is typically used on the first line of a collapsed fold block.
-    /// </summary>
-    BoxPlus = NativeMethods.SC_MARK_BOXPLUS,
+        /// <summary>
+        /// A plus (+) symbol with surrounding box. This symbol is typically used on the first line of a collapsed fold block.
+        /// </summary>
+        BoxPlus = NativeMethods.SC_MARK_BOXPLUS,
 
-    /// <summary>
-    /// A plus (+) symbol with surrounding box and thin vertical line. This symbol is typically used on the first line of a collapsed nested fold block.
-    /// </summary>
-    BoxPlusConnected = NativeMethods.SC_MARK_BOXPLUSCONNECTED,
+        /// <summary>
+        /// A plus (+) symbol with surrounding box and thin vertical line. This symbol is typically used on the first line of a collapsed nested fold block.
+        /// </summary>
+        BoxPlusConnected = NativeMethods.SC_MARK_BOXPLUSCONNECTED,
 
-    /// <summary>
-    /// A minus (-) symbol with surrounding box. This symbol is typically used on the first line of an expanded fold block.
-    /// </summary>
-    BoxMinus = NativeMethods.SC_MARK_BOXMINUS,
+        /// <summary>
+        /// A minus (-) symbol with surrounding box. This symbol is typically used on the first line of an expanded fold block.
+        /// </summary>
+        BoxMinus = NativeMethods.SC_MARK_BOXMINUS,
 
-    /// <summary>
-    /// A minus (-) symbol with surrounding box and thin vertical line. This symbol is typically used on the first line of an expanded nested fold block.
-    /// </summary>
-    BoxMinusConnected = NativeMethods.SC_MARK_BOXMINUSCONNECTED,
+        /// <summary>
+        /// A minus (-) symbol with surrounding box and thin vertical line. This symbol is typically used on the first line of an expanded nested fold block.
+        /// </summary>
+        BoxMinusConnected = NativeMethods.SC_MARK_BOXMINUSCONNECTED,
 
-    /// <summary>
-    /// Similar to a <see cref="LCorner" />, but curved.
-    /// </summary>
-    LCornerCurve = NativeMethods.SC_MARK_LCORNERCURVE,
+        /// <summary>
+        /// Similar to a <see cref="LCorner" />, but curved.
+        /// </summary>
+        LCornerCurve = NativeMethods.SC_MARK_LCORNERCURVE,
 
-    /// <summary>
-    /// Similar to a <see cref="TCorner" />, but curved.
-    /// </summary>
-    TCornerCurve = NativeMethods.SC_MARK_TCORNERCURVE,
+        /// <summary>
+        /// Similar to a <see cref="TCorner" />, but curved.
+        /// </summary>
+        TCornerCurve = NativeMethods.SC_MARK_TCORNERCURVE,
 
-    /// <summary>
-    /// Similar to a <see cref="BoxPlus" /> but surrounded by a circle.
-    /// </summary>
-    CirclePlus = NativeMethods.SC_MARK_CIRCLEPLUS,
+        /// <summary>
+        /// Similar to a <see cref="BoxPlus" /> but surrounded by a circle.
+        /// </summary>
+        CirclePlus = NativeMethods.SC_MARK_CIRCLEPLUS,
 
-    /// <summary>
-    /// Similar to a <see cref="BoxPlusConnected" />, but surrounded by a circle.
-    /// </summary>
-    CirclePlusConnected = NativeMethods.SC_MARK_CIRCLEPLUSCONNECTED,
+        /// <summary>
+        /// Similar to a <see cref="BoxPlusConnected" />, but surrounded by a circle.
+        /// </summary>
+        CirclePlusConnected = NativeMethods.SC_MARK_CIRCLEPLUSCONNECTED,
 
-    /// <summary>
-    /// Similar to a <see cref="BoxMinus" />, but surrounded by a circle.
-    /// </summary>
-    CircleMinus = NativeMethods.SC_MARK_CIRCLEMINUS,
+        /// <summary>
+        /// Similar to a <see cref="BoxMinus" />, but surrounded by a circle.
+        /// </summary>
+        CircleMinus = NativeMethods.SC_MARK_CIRCLEMINUS,
 
-    /// <summary>
-    /// Similar to a <see cref="BoxMinusConnected" />, but surrounded by a circle.
-    /// </summary>
-    CircleMinusConnected = NativeMethods.SC_MARK_CIRCLEMINUSCONNECTED,
+        /// <summary>
+        /// Similar to a <see cref="BoxMinusConnected" />, but surrounded by a circle.
+        /// </summary>
+        CircleMinusConnected = NativeMethods.SC_MARK_CIRCLEMINUSCONNECTED,
 
-    /// <summary>
-    /// A special marker that displays no symbol but will affect the background color of the line.
-    /// </summary>
-    Background = NativeMethods.SC_MARK_BACKGROUND,
+        /// <summary>
+        /// A special marker that displays no symbol but will affect the background color of the line.
+        /// </summary>
+        Background = NativeMethods.SC_MARK_BACKGROUND,
 
-    /// <summary>
-    /// Three dots (ellipsis).
-    /// </summary>
-    DotDotDot = NativeMethods.SC_MARK_DOTDOTDOT,
+        /// <summary>
+        /// Three dots (ellipsis).
+        /// </summary>
+        DotDotDot = NativeMethods.SC_MARK_DOTDOTDOT,
 
-    /// <summary>
-    /// Three bracket style arrows.
-    /// </summary>
-    Arrows = NativeMethods.SC_MARK_ARROWS,
+        /// <summary>
+        /// Three bracket style arrows.
+        /// </summary>
+        Arrows = NativeMethods.SC_MARK_ARROWS,
 
-    // PixMap = NativeMethods.SC_MARK_PIXMAP,
+        // PixMap = NativeMethods.SC_MARK_PIXMAP,
 
-    /// <summary>
-    /// A rectangle occupying the entire marker space.
-    /// </summary>
-    FullRect = NativeMethods.SC_MARK_FULLRECT,
+        /// <summary>
+        /// A rectangle occupying the entire marker space.
+        /// </summary>
+        FullRect = NativeMethods.SC_MARK_FULLRECT,
 
-    /// <summary>
-    /// A rectangle occupying only the left edge of the marker space.
-    /// </summary>
-    LeftRect = NativeMethods.SC_MARK_LEFTRECT,
+        /// <summary>
+        /// A rectangle occupying only the left edge of the marker space.
+        /// </summary>
+        LeftRect = NativeMethods.SC_MARK_LEFTRECT,
 
-    /// <summary>
-    /// A special marker left available to plugins.
-    /// </summary>
-    Available = NativeMethods.SC_MARK_AVAILABLE,
+        /// <summary>
+        /// A special marker left available to plugins.
+        /// </summary>
+        Available = NativeMethods.SC_MARK_AVAILABLE,
 
-    /// <summary>
-    /// A special marker that displays no symbol but will underline the current line text.
-    /// </summary>
-    Underline = NativeMethods.SC_MARK_UNDERLINE,
+        /// <summary>
+        /// A special marker that displays no symbol but will underline the current line text.
+        /// </summary>
+        Underline = NativeMethods.SC_MARK_UNDERLINE,
 
-    /// <summary>
-    /// A user-defined image. Images can be set using the <see cref="Marker.DefineRgbaImage" /> method.
-    /// </summary>
-    RgbaImage = NativeMethods.SC_MARK_RGBAIMAGE,
+        /// <summary>
+        /// A user-defined image. Images can be set using the <see cref="Marker.DefineRgbaImage" /> method.
+        /// </summary>
+        RgbaImage = NativeMethods.SC_MARK_RGBAIMAGE,
 
-    /// <summary>
-    /// A left-rotated bookmark.
-    /// </summary>
-    Bookmark = NativeMethods.SC_MARK_BOOKMARK,
+        /// <summary>
+        /// A left-rotated bookmark.
+        /// </summary>
+        Bookmark = NativeMethods.SC_MARK_BOOKMARK,
 
-    /// <summary>
-    /// A bookmark.
-    /// </summary>
-    VerticalBookmark = NativeMethods.SC_MARK_VERTICALBOOKMARK,
+        /// <summary>
+        /// A bookmark.
+        /// </summary>
+        VerticalBookmark = NativeMethods.SC_MARK_VERTICALBOOKMARK,
 
-    /// <summary>
-    /// A slim  rectangular vertical bar.
-    /// </summary>
-    Bar = NativeMethods.SC_MARK_BAR,
+        /// <summary>
+        /// A slim  rectangular vertical bar.
+        /// </summary>
+        Bar = NativeMethods.SC_MARK_BAR,
 
-    // Character = NativeMethods.SC_MARK_CHARACTER
+        // Character = NativeMethods.SC_MARK_CHARACTER
+    }
 }

--- a/Scintilla.NET/ModificationEventArgs.cs
+++ b/Scintilla.NET/ModificationEventArgs.cs
@@ -1,54 +1,55 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.Insert" /> and <see cref="Scintilla.Delete" /> events.
-/// </summary>
-public class ModificationEventArgs : BeforeModificationEventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private readonly int byteLength;
-    private readonly IntPtr textPtr;
-
     /// <summary>
-    /// Gets the number of lines added or removed.
+    /// Provides data for the <see cref="Scintilla.Insert" /> and <see cref="Scintilla.Delete" /> events.
     /// </summary>
-    /// <returns>The number of lines added to the document when text is inserted, or the number of lines removed from the document when text is deleted.</returns>
-    /// <remarks>When lines are deleted the return value will be negative.</remarks>
-    public int LinesAdded { get; private set; }
-
-    /// <summary>
-    /// Gets the text that was inserted or deleted.
-    /// </summary>
-    /// <returns>The text inserted or deleted from the document.</returns>
-    public override unsafe string Text
+    public class ModificationEventArgs : BeforeModificationEventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private readonly int byteLength;
+        private readonly IntPtr textPtr;
+
+        /// <summary>
+        /// Gets the number of lines added or removed.
+        /// </summary>
+        /// <returns>The number of lines added to the document when text is inserted, or the number of lines removed from the document when text is deleted.</returns>
+        /// <remarks>When lines are deleted the return value will be negative.</remarks>
+        public int LinesAdded { get; private set; }
+
+        /// <summary>
+        /// Gets the text that was inserted or deleted.
+        /// </summary>
+        /// <returns>The text inserted or deleted from the document.</returns>
+        public override unsafe string Text
         {
-            CachedText ??= Helpers.GetString(this.textPtr, this.byteLength, this.scintilla.Encoding);
+            get
+            {
+                CachedText = CachedText ?? Helpers.GetString(this.textPtr, this.byteLength, this.scintilla.Encoding);
 
-            return CachedText;
+                return CachedText;
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ModificationEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="source">The source of the modification.</param>
-    /// <param name="bytePosition">The zero-based byte position within the document where text was modified.</param>
-    /// <param name="byteLength">The length in bytes of the inserted or deleted text.</param>
-    /// <param name="text">>A pointer to the text inserted or deleted.</param>
-    /// <param name="linesAdded">The number of lines added or removed (delta).</param>
-    public ModificationEventArgs(Scintilla scintilla, ModificationSource source, int bytePosition, int byteLength, IntPtr text, int linesAdded) : base(scintilla, source, bytePosition, byteLength, text)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
-        this.byteLength = byteLength;
-        this.textPtr = text;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModificationEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="source">The source of the modification.</param>
+        /// <param name="bytePosition">The zero-based byte position within the document where text was modified.</param>
+        /// <param name="byteLength">The length in bytes of the inserted or deleted text.</param>
+        /// <param name="text">>A pointer to the text inserted or deleted.</param>
+        /// <param name="linesAdded">The number of lines added or removed (delta).</param>
+        public ModificationEventArgs(Scintilla scintilla, ModificationSource source, int bytePosition, int byteLength, IntPtr text, int linesAdded) : base(scintilla, source, bytePosition, byteLength, text)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+            this.byteLength = byteLength;
+            this.textPtr = text;
 
-        LinesAdded = linesAdded;
+            LinesAdded = linesAdded;
+        }
     }
 }

--- a/Scintilla.NET/ModificationSource.cs
+++ b/Scintilla.NET/ModificationSource.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The source of a modification
-/// </summary>
-public enum ModificationSource
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Modification is the result of a user operation.
+    /// The source of a modification
     /// </summary>
-    User = NativeMethods.SC_PERFORMED_USER,
+    public enum ModificationSource
+    {
+        /// <summary>
+        /// Modification is the result of a user operation.
+        /// </summary>
+        User = NativeMethods.SC_PERFORMED_USER,
 
-    /// <summary>
-    /// Modification is the result of an undo operation.
-    /// </summary>
-    Undo = NativeMethods.SC_PERFORMED_UNDO,
+        /// <summary>
+        /// Modification is the result of an undo operation.
+        /// </summary>
+        Undo = NativeMethods.SC_PERFORMED_UNDO,
 
-    /// <summary>
-    /// Modification is the result of a redo operation.
-    /// </summary>
-    Redo = NativeMethods.SC_PERFORMED_REDO
+        /// <summary>
+        /// Modification is the result of a redo operation.
+        /// </summary>
+        Redo = NativeMethods.SC_PERFORMED_REDO
+    }
 }

--- a/Scintilla.NET/MultiPaste.cs
+++ b/Scintilla.NET/MultiPaste.cs
@@ -1,17 +1,18 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Specifies the behavior of pasting into multiple selections.
-/// </summary>
-public enum MultiPaste
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Pasting into multiple selections only pastes to the main selection. This is the default.
+    /// Specifies the behavior of pasting into multiple selections.
     /// </summary>
-    Once = NativeMethods.SC_MULTIPASTE_ONCE,
+    public enum MultiPaste
+    {
+        /// <summary>
+        /// Pasting into multiple selections only pastes to the main selection. This is the default.
+        /// </summary>
+        Once = NativeMethods.SC_MULTIPASTE_ONCE,
 
-    /// <summary>
-    /// Pasting into multiple selections pastes into each selection.
-    /// </summary>
-    Each = NativeMethods.SC_MULTIPASTE_EACH
+        /// <summary>
+        /// Pasting into multiple selections pastes into each selection.
+        /// </summary>
+        Each = NativeMethods.SC_MULTIPASTE_EACH
+    }
 }

--- a/Scintilla.NET/NativeMemoryStream.cs
+++ b/Scintilla.NET/NativeMemoryStream.cs
@@ -2,149 +2,150 @@
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Like an UnmanagedMemoryStream execpt it can grow.
-/// </summary>
-internal sealed unsafe class NativeMemoryStream : Stream
+namespace ScintillaNET
 {
-    #region Fields
-
-    private int capacity;
-    private int position;
-    private int length;
-
-    #endregion Fields
-
-    #region Methods
-
-    protected override void Dispose(bool disposing)
+    /// <summary>
+    /// Like an UnmanagedMemoryStream execpt it can grow.
+    /// </summary>
+    internal sealed unsafe class NativeMemoryStream : Stream
     {
-        if (FreeOnDispose && Pointer != IntPtr.Zero)
+        #region Fields
+
+        private int capacity;
+        private int position;
+        private int length;
+
+        #endregion Fields
+
+        #region Methods
+
+        protected override void Dispose(bool disposing)
         {
-            Marshal.FreeHGlobal(Pointer);
-            Pointer = IntPtr.Zero;
+            if (FreeOnDispose && Pointer != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(Pointer);
+                Pointer = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
         }
 
-        base.Dispose(disposing);
-    }
-
-    public override void Flush()
-    {
-        // NOP
-    }
-
-    public override int Read(byte[] buffer, int offset, int count)
-    {
-        throw new NotImplementedException();
-    }
-
-    public override long Seek(long offset, SeekOrigin origin)
-    {
-        switch (origin)
+        public override void Flush()
         {
-            case SeekOrigin.Begin:
-                this.position = (int)offset;
-                break;
-
-            default:
-                throw new NotImplementedException();
+            // NOP
         }
 
-        return this.position;
-    }
-
-    public override void SetLength(long value)
-    {
-        throw new NotImplementedException();
-    }
-
-    public override void Write(byte[] buffer, int offset, int count)
-    {
-        if (this.position + count > this.capacity)
-        {
-            // Realloc buffer
-            int minCapacity = this.position + count;
-            int newCapacity = this.capacity * 2;
-            if (newCapacity < minCapacity)
-                newCapacity = minCapacity;
-
-            IntPtr newPtr = Marshal.AllocHGlobal(newCapacity);
-            NativeMethods.MoveMemory(newPtr, Pointer, this.length);
-            Marshal.FreeHGlobal(Pointer);
-
-            Pointer = newPtr;
-            this.capacity = newCapacity;
-        }
-
-        Marshal.Copy(buffer, offset, (IntPtr)((long)Pointer + this.position), count);
-        this.position += count;
-        this.length = Math.Max(this.length, this.position);
-    }
-
-    #endregion Methods
-
-    #region Properties
-
-    public override bool CanRead
-    {
-        get { throw new NotImplementedException(); }
-    }
-
-    public override bool CanSeek
-    {
-        get
-        {
-            return true;
-        }
-    }
-
-    public override bool CanWrite
-    {
-        get
-        {
-            return true;
-        }
-    }
-
-    public bool FreeOnDispose { get; set; }
-
-    public override long Length
-    {
-        get
-        {
-            return this.length;
-        }
-    }
-
-    public IntPtr Pointer { get; private set; }
-
-    public override long Position
-    {
-        get
-        {
-            return this.position;
-        }
-        set
+        public override int Read(byte[] buffer, int offset, int count)
         {
             throw new NotImplementedException();
         }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    this.position = (int)offset;
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            return this.position;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (this.position + count > this.capacity)
+            {
+                // Realloc buffer
+                int minCapacity = this.position + count;
+                int newCapacity = this.capacity * 2;
+                if (newCapacity < minCapacity)
+                    newCapacity = minCapacity;
+
+                IntPtr newPtr = Marshal.AllocHGlobal(newCapacity);
+                NativeMethods.MoveMemory(newPtr, Pointer, this.length);
+                Marshal.FreeHGlobal(Pointer);
+
+                Pointer = newPtr;
+                this.capacity = newCapacity;
+            }
+
+            Marshal.Copy(buffer, offset, (IntPtr)((long)Pointer + this.position), count);
+            this.position += count;
+            this.length = Math.Max(this.length, this.position);
+        }
+
+        #endregion Methods
+
+        #region Properties
+
+        public override bool CanRead
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override bool CanSeek
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public bool FreeOnDispose { get; set; }
+
+        public override long Length
+        {
+            get
+            {
+                return this.length;
+            }
+        }
+
+        public IntPtr Pointer { get; private set; }
+
+        public override long Position
+        {
+            get
+            {
+                return this.position;
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        #endregion Properties
+
+        #region Constructors
+
+        public NativeMemoryStream(int capacity)
+        {
+            if (capacity < 4)
+                capacity = 4;
+
+            this.capacity = capacity;
+            Pointer = Marshal.AllocHGlobal(capacity);
+            FreeOnDispose = true;
+        }
+
+        #endregion Constructors
     }
-
-    #endregion Properties
-
-    #region Constructors
-
-    public NativeMemoryStream(int capacity)
-    {
-        if (capacity < 4)
-            capacity = 4;
-
-        this.capacity = capacity;
-        Pointer = Marshal.AllocHGlobal(capacity);
-        FreeOnDispose = true;
-    }
-
-    #endregion Constructors
 }

--- a/Scintilla.NET/NativeMethods.cs
+++ b/Scintilla.NET/NativeMethods.cs
@@ -2,1228 +2,1228 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
-namespace ScintillaNET;
-
+namespace ScintillaNET
+{
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-public static class NativeMethods
-{
-    #region Constants
-
-    private const string DLL_NAME_GDI32 = "gdi32.dll";
-    private const string DLL_NAME_KERNEL32 = "kernel32.dll";
-    private const string DLL_NAME_OLE32 = "ole32.dll";
-    private const string DLL_NAME_USER32 = "user32.dll";
-
-    public const int INVALID_POSITION = -1;
-
-    // Autocompletions
-    public const int SC_AC_FILLUP = 1;
-    public const int SC_AC_DOUBLECLICK = 2;
-    public const int SC_AC_TAB = 3;
-    public const int SC_AC_NEWLINE = 4;
-    public const int SC_AC_COMMAND = 5;
-
-    // Annotations
-    public const int ANNOTATION_HIDDEN = 0;
-    public const int ANNOTATION_STANDARD = 1;
-    public const int ANNOTATION_BOXED = 2;
-    public const int ANNOTATION_INDENTED = 3;
-
-    // Clipboard formats
-    public const string CF_HTML = "HTML Format";
-
-    // Idle styling
-    public const int SC_IDLESTYLING_NONE = 0;
-    public const int SC_IDLESTYLING_TOVISIBLE = 1;
-    public const int SC_IDLESTYLING_AFTERVISIBLE = 2;
-    public const int SC_IDLESTYLING_ALL = 3;
-
-    // Indentation 
-    public const int SC_IV_NONE = 0;
-    public const int SC_IV_REAL = 1;
-    public const int SC_IV_LOOKFORWARD = 2;
-    public const int SC_IV_LOOKBOTH = 3;
-
-    // Keys
-    public const int SCMOD_NORM = 0;
-    public const int SCMOD_SHIFT = 1;
-    public const int SCMOD_CTRL = 2;
-    public const int SCMOD_ALT = 4;
-    public const int SCMOD_SUPER = 8;
-    public const int SCMOD_META = 16;
-
-    public const int SCI_NORM = 0;
-    public const int SCI_SHIFT = SCMOD_SHIFT;
-    public const int SCI_CTRL = SCMOD_CTRL;
-    public const int SCI_ALT = SCMOD_ALT;
-    public const int SCI_META = SCMOD_META;
-    public const int SCI_CSHIFT = SCI_CTRL | SCI_SHIFT;
-    public const int SCI_ASHIFT = SCI_ALT | SCI_SHIFT;
-
-    // Caret policy flags
-    public const int CARET_SLOP = 0x01;
-    public const int CARET_STRICT = 0x04;
-    public const int CARET_JUMPS = 0x10;
-    public const int CARET_EVEN = 0x08;
-
-    // Caret styles
-    public const int CARETSTYLE_INVISIBLE = 0;
-    public const int CARETSTYLE_LINE = 1;
-    public const int CARETSTYLE_BLOCK = 2;
-
-    // Line edges
-    public const int EDGE_NONE = 0;
-    public const int EDGE_LINE = 1;
-    public const int EDGE_BACKGROUND = 2;
-    public const int EDGE_MULTILINE = 3;
-
-    // Message-only window
-    public const int HWND_MESSAGE = -3;
-
-    // Indicator styles
-    public const int INDIC_PLAIN = 0;
-    public const int INDIC_SQUIGGLE = 1;
-    public const int INDIC_TT = 2;
-    public const int INDIC_DIAGONAL = 3;
-    public const int INDIC_STRIKE = 4;
-    public const int INDIC_HIDDEN = 5;
-    public const int INDIC_BOX = 6;
-    public const int INDIC_ROUNDBOX = 7;
-    public const int INDIC_STRAIGHTBOX = 8;
-    public const int INDIC_DASH = 9;
-    public const int INDIC_DOTS = 10;
-    public const int INDIC_SQUIGGLELOW = 11;
-    public const int INDIC_DOTBOX = 12;
-    public const int INDIC_SQUIGGLEPIXMAP = 13;
-    public const int INDIC_COMPOSITIONTHICK = 14;
-    public const int INDIC_COMPOSITIONTHIN = 15;
-    public const int INDIC_FULLBOX = 16;
-    public const int INDIC_TEXTFORE = 17;
-    public const int INDIC_POINT = 18;
-    public const int INDIC_POINTCHARACTER = 19;
-    public const int INDIC_GRADIENT = 20;
-    public const int INDIC_GRADIENTCENTRE = 21;
-    public const int INDIC_POINT_TOP = 22;
-
-    [Obsolete("Use INDICATOR_CONTAINER instead.")]
-    public const int INDIC_CONTAINER = 8;
-    [Obsolete("Use INDICATOR_MAX instead.")]
-    public const int INDIC_MAX = 31;
-
-    // Indicators
-    public const int INDICATOR_CONTAINER = 8;
-    public const int INDICATOR_IME = 32;
-    public const int INDICATOR_IME_MAX = 35;
-    public const int INDICATOR_HISTORY_REVERTED_TO_ORIGIN_INSERTION = 36;
-    public const int INDICATOR_HISTORY_REVERTED_TO_ORIGIN_DELETION = 37;
-    public const int INDICATOR_HISTORY_SAVED_INSERTION = 38;
-    public const int INDICATOR_HISTORY_SAVED_DELETION = 39;
-    public const int INDICATOR_HISTORY_MODIFIED_INSERTION = 40;
-    public const int INDICATOR_HISTORY_MODIFIED_DELETION = 41;
-    public const int INDICATOR_HISTORY_REVERTED_TO_MODIFIED_INSERTION = 42;
-    public const int INDICATOR_HISTORY_REVERTED_TO_MODIFIED_DELETION = 43;
-    public const int INDICATOR_MAX = 43;
-
-    // Phases
-    public const int SC_PHASES_ONE = 0;
-    public const int SC_PHASES_TWO = 1;
-    public const int SC_PHASES_MULTIPLE = 2;
-
-    // Indicator flags
-    public const int SC_INDICFLAG_VALUEFORE = 1;
-    public const int SC_INDICVALUEBIT = 0x1000000;
-    public const int SC_INDICVALUEMASK = 0xFFFFFF;
-
-    // public const int INDIC0_MASK = 0x20;
-    // public const int INDIC1_MASK = 0x40;
-    // public const int INDIC2_MASK = 0x80;
-    // public const int INDICS_MASK = 0xE0;
-
-    public const int KEYWORDSET_MAX = 8;
-
-    // Alpha ranges
-    public const int SC_ALPHA_TRANSPARENT = 0;
-    public const int SC_ALPHA_OPAQUE = 255;
-    public const int SC_ALPHA_NOALPHA = 256;
-
-    // Automatic folding
-    public const int SC_AUTOMATICFOLD_SHOW = 0x0001;
-    public const int SC_AUTOMATICFOLD_CLICK = 0x0002;
-    public const int SC_AUTOMATICFOLD_CHANGE = 0x0004;
-
-    // Caret sticky behavior
-    public const int SC_CARETSTICKY_OFF = 0;
-    public const int SC_CARETSTICKY_ON = 1;
-    public const int SC_CARETSTICKY_WHITESPACE = 2;
-
-    // Encodings
-    public const int SC_CP_UTF8 = 65001;
-
-    // Cursors
-    public const int SC_CURSORNORMAL = -1;
-    public const int SC_CURSORARROW = 2;
-    public const int SC_CURSORWAIT = 4;
-    public const int SC_CURSORREVERSEARROW = 7;
-
-    // Font quality
-    public const int SC_EFF_QUALITY_DEFAULT = 0;
-    public const int SC_EFF_QUALITY_NON_ANTIALIASED = 1;
-    public const int SC_EFF_QUALITY_ANTIALIASED = 2;
-    public const int SC_EFF_QUALITY_LCD_OPTIMIZED = 3;
-
-    // End-of-line
-    public const int SC_EOL_CRLF = 0;
-    public const int SC_EOL_CR = 1;
-    public const int SC_EOL_LF = 2;
-
-    // Fold action
-    public const int SC_FOLDACTION_CONTRACT = 0;
-    public const int SC_FOLDACTION_EXPAND = 1;
-    public const int SC_FOLDACTION_TOGGLE = 2;
-
-    // Fold level
-    public const int SC_FOLDLEVELBASE = 0x400;
-    public const int SC_FOLDLEVELWHITEFLAG = 0x1000;
-    public const int SC_FOLDLEVELHEADERFLAG = 0x2000;
-    public const int SC_FOLDLEVELNUMBERMASK = 0x0FFF;
-
-    // Fold flags
-    public const int SC_FOLDFLAG_LINEBEFORE_EXPANDED = 0x0002;
-    public const int SC_FOLDFLAG_LINEBEFORE_CONTRACTED = 0x0004;
-    public const int SC_FOLDFLAG_LINEAFTER_EXPANDED = 0x0008;
-    public const int SC_FOLDFLAG_LINEAFTER_CONTRACTED = 0x0010;
-    public const int SC_FOLDFLAG_LEVELNUMBERS = 0x0040;
-    public const int SC_FOLDFLAG_LINESTATE = 0x0080;
-
-    // Fold display text
-    public const int SC_FOLDDISPLAYTEXT_HIDDEN = 0;
-    public const int SC_FOLDDISPLAYTEXT_STANDARD = 1;
-    public const int SC_FOLDDISPLAYTEXT_BOXED = 2;
-
-    // Line end type
-    public const int SC_LINE_END_TYPE_DEFAULT = 0;
-    public const int SC_LINE_END_TYPE_UNICODE = 1;
-
-    //Line layers
-    public const int SC_LAYER_BASE = 0;
-    public const int SC_LAYER_UNDER_TEXT = 1;
-    public const int SC_LAYER_OVER_TEXT = 2;
-
-    // Margins
-    public const int SC_MAX_MARGIN = 4;
-
-    public const int SC_MARGIN_SYMBOL = 0;
-    public const int SC_MARGIN_NUMBER = 1;
-    public const int SC_MARGIN_BACK = 2;
-    public const int SC_MARGIN_FORE = 3;
-    public const int SC_MARGIN_TEXT = 4;
-    public const int SC_MARGIN_RTEXT = 5;
-    public const int SC_MARGIN_COLOUR = 6;
-
-    public const int SC_MARGINOPTION_NONE = 0;
-    public const int SC_MARGINOPTION_SUBLINESELECT = 1;
-
-    // Markers
-    public const int MARKER_MAX = 31;
-    public const int SC_MARK_CIRCLE = 0;
-    public const int SC_MARK_ROUNDRECT = 1;
-    public const int SC_MARK_ARROW = 2;
-    public const int SC_MARK_SMALLRECT = 3;
-    public const int SC_MARK_SHORTARROW = 4;
-    public const int SC_MARK_EMPTY = 5;
-    public const int SC_MARK_ARROWDOWN = 6;
-    public const int SC_MARK_MINUS = 7;
-    public const int SC_MARK_PLUS = 8;
-    public const int SC_MARK_VLINE = 9;
-    public const int SC_MARK_LCORNER = 10;
-    public const int SC_MARK_TCORNER = 11;
-    public const int SC_MARK_BOXPLUS = 12;
-    public const int SC_MARK_BOXPLUSCONNECTED = 13;
-    public const int SC_MARK_BOXMINUS = 14;
-    public const int SC_MARK_BOXMINUSCONNECTED = 15;
-    public const int SC_MARK_LCORNERCURVE = 16;
-    public const int SC_MARK_TCORNERCURVE = 17;
-    public const int SC_MARK_CIRCLEPLUS = 18;
-    public const int SC_MARK_CIRCLEPLUSCONNECTED = 19;
-    public const int SC_MARK_CIRCLEMINUS = 20;
-    public const int SC_MARK_CIRCLEMINUSCONNECTED = 21;
-    public const int SC_MARK_BACKGROUND = 22;
-    public const int SC_MARK_DOTDOTDOT = 23;
-    public const int SC_MARK_ARROWS = 24;
-    public const int SC_MARK_PIXMAP = 25;
-    public const int SC_MARK_FULLRECT = 26;
-    public const int SC_MARK_LEFTRECT = 27;
-    public const int SC_MARK_AVAILABLE = 28;
-    public const int SC_MARK_UNDERLINE = 29;
-    public const int SC_MARK_RGBAIMAGE = 30;
-    public const int SC_MARK_BOOKMARK = 31;
-    public const int SC_MARK_VERTICALBOOKMARK = 32;
-    public const int SC_MARK_BAR = 33;
-    public const int SC_MARK_CHARACTER = 10000;
-    public const int SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN = 21;
-    public const int SC_MARKNUM_HISTORY_SAVED = 22;
-    public const int SC_MARKNUM_HISTORY_MODIFIED = 23;
-    public const int SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED = 24;
-    public const int SC_MARKNUM_FOLDEREND = 25;
-    public const int SC_MARKNUM_FOLDEROPENMID = 26;
-    public const int SC_MARKNUM_FOLDERMIDTAIL = 27;
-    public const int SC_MARKNUM_FOLDERTAIL = 28;
-    public const int SC_MARKNUM_FOLDERSUB = 29;
-    public const int SC_MARKNUM_FOLDER = 30;
-    public const int SC_MARKNUM_FOLDEROPEN = 31;
-    public const uint SC_MASK_FOLDERS = 0xFE000000;
-
-    public const int SC_MULTIPASTE_ONCE = 0;
-    public const int SC_MULTIPASTE_EACH = 1;
-
-    public const int SC_ORDER_PRESORTED = 0;
-    public const int SC_ORDER_PERFORMSORT = 1;
-    public const int SC_ORDER_CUSTOM = 2;
-
-    // Update notification reasons
-    public const int SC_UPDATE_CONTENT = 0x01;
-    public const int SC_UPDATE_SELECTION = 0x02;
-    public const int SC_UPDATE_V_SCROLL = 0x04;
-    public const int SC_UPDATE_H_SCROLL = 0x08;
-
-    // Modified notification types
-    public const int SC_MOD_INSERTTEXT = 0x1;
-    public const int SC_MOD_DELETETEXT = 0x2;
-    public const int SC_MOD_BEFOREINSERT = 0x400;
-    public const int SC_MOD_BEFOREDELETE = 0x800;
-    public const int SC_MOD_CHANGEANNOTATION = 0x20000;
-    public const int SC_MOD_INSERTCHECK = 0x100000;
-
-    // Modified flags
-    public const int SC_PERFORMED_USER = 0x10;
-    public const int SC_PERFORMED_UNDO = 0x20;
-    public const int SC_PERFORMED_REDO = 0x40;
-
-    // Status codes
-    public const int SC_STATUS_OK = 0;
-    public const int SC_STATUS_FAILURE = 1;
-    public const int SC_STATUS_BADALLOC = 2;
-    public const int SC_STATUS_WARN_START = 1000;
-    public const int SC_STATUS_WARN_REGEX = 1001;
-
-    // Dwell
-    public const int SC_TIME_FOREVER = 10000000;
-
-    // Property types
-    public const int SC_TYPE_BOOLEAN = 0;
-    public const int SC_TYPE_INTEGER = 1;
-    public const int SC_TYPE_STRING = 2;
-
-    // Search flags
-    public const int SCFIND_NONE = 0x0;
-    public const int SCFIND_WHOLEWORD = 0x2;
-    public const int SCFIND_MATCHCASE = 0x4;
-    public const int SCFIND_WORDSTART = 0x00100000;
-    public const int SCFIND_REGEXP = 0x00200000;
-    public const int SCFIND_POSIX = 0x00400000;
-    public const int SCFIND_CXX11REGEX = 0x00800000;
-
-    // Element colors
-    public const int SC_ELEMENT_LIST = 0;
-    public const int SC_ELEMENT_LIST_BACK = 1;
-    public const int SC_ELEMENT_LIST_SELECTED = 2;
-    public const int SC_ELEMENT_LIST_SELECTED_BACK = 3;
-    public const int SC_ELEMENT_SELECTION_TEXT = 10;
-    public const int SC_ELEMENT_SELECTION_BACK = 11;
-    public const int SC_ELEMENT_SELECTION_ADDITIONAL_TEXT = 12;
-    public const int SC_ELEMENT_SELECTION_ADDITIONAL_BACK = 13;
-    public const int SC_ELEMENT_SELECTION_SECONDARY_TEXT = 14;
-    public const int SC_ELEMENT_SELECTION_SECONDARY_BACK = 15;
-    public const int SC_ELEMENT_SELECTION_INACTIVE_TEXT = 16;
-    public const int SC_ELEMENT_SELECTION_INACTIVE_BACK = 17;
-    public const int SC_ELEMENT_SELECTION_INACTIVE_ADDITIONAL_TEXT = 18;
-    public const int SC_ELEMENT_SELECTION_INACTIVE_ADDITIONAL_BACK = 19;
-    public const int SC_ELEMENT_CARET = 40;
-    public const int SC_ELEMENT_CARET_ADDITIONAL = 41;
-    public const int SC_ELEMENT_CARET_LINE_BACK = 50;
-    public const int SC_ELEMENT_WHITE_SPACE = 60;
-    public const int SC_ELEMENT_WHITE_SPACE_BACK = 61;
-    public const int SC_ELEMENT_HOT_SPOT_ACTIVE = 70;
-    public const int SC_ELEMENT_HOT_SPOT_ACTIVE_BACK = 71;
-    public const int SC_ELEMENT_FOLD_LINE = 80;
-    public const int SC_ELEMENT_HIDDEN_LINE = 81;
-
-    // Change history
-    public const int SC_CHANGE_HISTORY_DISABLED = 0;
-    public const int SC_CHANGE_HISTORY_ENABLED = 1;
-    public const int SC_CHANGE_HISTORY_MARKERS = 2;
-    public const int SC_CHANGE_HISTORY_INDICATORS = 4;
-
-    // Functions
-    public const int SCI_START = 2000;
-    public const int SCI_OPTIONAL_START = 3000;
-    public const int SCI_LEXER_START = 4000;
-    public const int SCI_ADDTEXT = 2001;
-    public const int SCI_ADDSTYLEDTEXT = 2002;
-    public const int SCI_INSERTTEXT = 2003;
-    public const int SCI_CHANGEINSERTION = 2672;
-    public const int SCI_CLEARALL = 2004;
-    public const int SCI_DELETERANGE = 2645;
-    public const int SCI_CLEARDOCUMENTSTYLE = 2005;
-    public const int SCI_GETLENGTH = 2006;
-    public const int SCI_GETCHARAT = 2007;
-    public const int SCI_GETCURRENTPOS = 2008;
-    public const int SCI_GETANCHOR = 2009;
-    public const int SCI_GETSTYLEAT = 2010;
-    public const int SCI_REDO = 2011;
-    public const int SCI_SETUNDOCOLLECTION = 2012;
-    public const int SCI_SELECTALL = 2013;
-    public const int SCI_SETSAVEPOINT = 2014;
-    public const int SCI_GETSTYLEDTEXT = 2015;
-    public const int SCI_CANREDO = 2016;
-    public const int SCI_MARKERLINEFROMHANDLE = 2017;
-    public const int SCI_MARKERDELETEHANDLE = 2018;
-    public const int SCI_GETUNDOCOLLECTION = 2019;
-    public const int SCI_GETVIEWWS = 2020;
-    public const int SCI_SETVIEWWS = 2021;
-    public const int SCI_POSITIONFROMPOINT = 2022;
-    public const int SCI_POSITIONFROMPOINTCLOSE = 2023;
-    public const int SCI_GOTOLINE = 2024;
-    public const int SCI_GOTOPOS = 2025;
-    public const int SCI_SETANCHOR = 2026;
-    public const int SCI_GETCURLINE = 2027;
-    public const int SCI_GETENDSTYLED = 2028;
-    public const int SCI_CONVERTEOLS = 2029;
-    public const int SCI_GETEOLMODE = 2030;
-    public const int SCI_SETEOLMODE = 2031;
-    public const int SCI_STARTSTYLING = 2032;
-    public const int SCI_SETSTYLING = 2033;
-    public const int SCI_GETBUFFEREDDRAW = 2034;
-    public const int SCI_SETBUFFEREDDRAW = 2035;
-    public const int SCI_SETTABWIDTH = 2036;
-    public const int SCI_GETTABWIDTH = 2121;
-    public const int SCI_CLEARTABSTOPS = 2675;
-    public const int SCI_ADDTABSTOP = 2676;
-    public const int SCI_GETNEXTTABSTOP = 2677;
-    public const int SCI_SETCODEPAGE = 2037;
-    public const int SCI_MARKERDEFINE = 2040;
-    public const int SCI_MARKERSETFORE = 2041;
-    public const int SCI_MARKERSETBACK = 2042;
-    public const int SCI_MARKERSETFORETRANSLUCENT = 2294;
-    public const int SCI_MARKERSETBACKTRANSLUCENT = 2295;
-    public const int SCI_MARKERSETBACKSELECTED = 2292;
-    public const int SCI_MARKERENABLEHIGHLIGHT = 2293;
-    public const int SCI_MARKERADD = 2043;
-    public const int SCI_MARKERDELETE = 2044;
-    public const int SCI_MARKERDELETEALL = 2045;
-    public const int SCI_MARKERGET = 2046;
-    public const int SCI_MARKERNEXT = 2047;
-    public const int SCI_MARKERPREVIOUS = 2048;
-    public const int SCI_MARKERDEFINEPIXMAP = 2049;
-    public const int SCI_MARKERADDSET = 2466;
-    public const int SCI_MARKERSETALPHA = 2476;
-    public const int SCI_SETMARGINTYPEN = 2240;
-    public const int SCI_GETMARGINTYPEN = 2241;
-    public const int SCI_SETMARGINWIDTHN = 2242;
-    public const int SCI_GETMARGINWIDTHN = 2243;
-    public const int SCI_SETMARGINMASKN = 2244;
-    public const int SCI_GETMARGINMASKN = 2245;
-    public const int SCI_SETMARGINSENSITIVEN = 2246;
-    public const int SCI_GETMARGINSENSITIVEN = 2247;
-    public const int SCI_SETMARGINCURSORN = 2248;
-    public const int SCI_GETMARGINCURSORN = 2249;
-    public const int SCI_SETMARGINBACKN = 2250;
-    public const int SCI_GETMARGINBACKN = 2251;
-    public const int SCI_SETMARGINS = 2252;
-    public const int SCI_GETMARGINS = 2253;
-    public const int SCI_STYLECLEARALL = 2050;
-    public const int SCI_STYLESETFORE = 2051;
-    public const int SCI_STYLESETBACK = 2052;
-    public const int SCI_STYLESETBOLD = 2053;
-    public const int SCI_STYLESETITALIC = 2054;
-    public const int SCI_STYLESETSIZE = 2055;
-    public const int SCI_STYLESETFONT = 2056;
-    public const int SCI_STYLESETEOLFILLED = 2057;
-    public const int SCI_STYLERESETDEFAULT = 2058;
-    public const int SCI_STYLESETUNDERLINE = 2059;
-    public const int SCI_STYLEGETFORE = 2481;
-    public const int SCI_STYLEGETBACK = 2482;
-    public const int SCI_STYLEGETBOLD = 2483;
-    public const int SCI_STYLEGETITALIC = 2484;
-    public const int SCI_STYLEGETSIZE = 2485;
-    public const int SCI_STYLEGETFONT = 2486;
-    public const int SCI_STYLEGETEOLFILLED = 2487;
-    public const int SCI_STYLEGETUNDERLINE = 2488;
-    public const int SCI_STYLEGETCASE = 2489;
-    public const int SCI_STYLEGETCHARACTERSET = 2490;
-    public const int SCI_STYLEGETVISIBLE = 2491;
-    public const int SCI_STYLEGETCHANGEABLE = 2492;
-    public const int SCI_STYLEGETHOTSPOT = 2493;
-    public const int SCI_STYLESETCASE = 2060;
-    public const int SCI_STYLESETSIZEFRACTIONAL = 2061;
-    public const int SCI_STYLEGETSIZEFRACTIONAL = 2062;
-    public const int SCI_STYLESETWEIGHT = 2063;
-    public const int SCI_STYLEGETWEIGHT = 2064;
-    public const int SCI_STYLESETCHARACTERSET = 2066;
-    public const int SCI_STYLESETHOTSPOT = 2409;
-    public const int SCI_SETSELFORE = 2067;
-    public const int SCI_SETSELBACK = 2068;
-    public const int SCI_GETSELALPHA = 2477;
-    public const int SCI_SETSELALPHA = 2478;
-    public const int SCI_GETSELEOLFILLED = 2479;
-    public const int SCI_SETSELEOLFILLED = 2480;
-    public const int SCI_SETCARETFORE = 2069;
-    public const int SCI_ASSIGNCMDKEY = 2070;
-    public const int SCI_CLEARCMDKEY = 2071;
-    public const int SCI_CLEARALLCMDKEYS = 2072;
-    public const int SCI_SETSTYLINGEX = 2073;
-    public const int SCI_STYLESETVISIBLE = 2074;
-    public const int SCI_GETCARETPERIOD = 2075;
-    public const int SCI_SETCARETPERIOD = 2076;
-    public const int SCI_SETWORDCHARS = 2077;
-    public const int SCI_GETWORDCHARS = 2646;
-    public const int SCI_BEGINUNDOACTION = 2078;
-    public const int SCI_ENDUNDOACTION = 2079;
-    public const int SCI_INDICSETSTYLE = 2080;
-    public const int SCI_INDICGETSTYLE = 2081;
-    public const int SCI_INDICSETFORE = 2082;
-    public const int SCI_INDICGETFORE = 2083;
-    public const int SCI_INDICSETUNDER = 2510;
-    public const int SCI_INDICGETUNDER = 2511;
-    public const int SCI_INDICSETHOVERSTYLE = 2680;
-    public const int SCI_INDICGETHOVERSTYLE = 2681;
-    public const int SCI_INDICSETHOVERFORE = 2682;
-    public const int SCI_INDICGETHOVERFORE = 2683;
-    public const int SCI_INDICSETFLAGS = 2684;
-    public const int SCI_INDICGETFLAGS = 2685;
-    public const int SCI_SETWHITESPACEFORE = 2084;
-    public const int SCI_SETWHITESPACEBACK = 2085;
-    public const int SCI_SETWHITESPACESIZE = 2086;
-    public const int SCI_GETWHITESPACESIZE = 2087;
-    // public const int SCI_SETSTYLEBITS = 2090;
-    // public const int SCI_GETSTYLEBITS = 2091;
-    public const int SCI_SETLINESTATE = 2092;
-    public const int SCI_GETLINESTATE = 2093;
-    public const int SCI_GETMAXLINESTATE = 2094;
-    public const int SCI_GETCARETLINEVISIBLE = 2095;
-    public const int SCI_SETCARETLINEVISIBLE = 2096;
-    public const int SCI_GETCARETLINEBACK = 2097;
-    public const int SCI_SETCARETLINEBACK = 2098;
-    public const int SCI_STYLESETCHANGEABLE = 2099;
-    public const int SCI_AUTOCSHOW = 2100;
-    public const int SCI_AUTOCCANCEL = 2101;
-    public const int SCI_AUTOCACTIVE = 2102;
-    public const int SCI_AUTOCPOSSTART = 2103;
-    public const int SCI_AUTOCCOMPLETE = 2104;
-    public const int SCI_AUTOCSTOPS = 2105;
-    public const int SCI_AUTOCSETSEPARATOR = 2106;
-    public const int SCI_AUTOCGETSEPARATOR = 2107;
-    public const int SCI_AUTOCSELECT = 2108;
-    public const int SCI_AUTOCSETCANCELATSTART = 2110;
-    public const int SCI_AUTOCGETCANCELATSTART = 2111;
-    public const int SCI_AUTOCSETFILLUPS = 2112;
-    public const int SCI_AUTOCSETCHOOSESINGLE = 2113;
-    public const int SCI_AUTOCGETCHOOSESINGLE = 2114;
-    public const int SCI_AUTOCSETIGNORECASE = 2115;
-    public const int SCI_AUTOCGETIGNORECASE = 2116;
-    public const int SCI_USERLISTSHOW = 2117;
-    public const int SCI_AUTOCSETAUTOHIDE = 2118;
-    public const int SCI_AUTOCGETAUTOHIDE = 2119;
-    public const int SCI_AUTOCSETDROPRESTOFWORD = 2270;
-    public const int SCI_AUTOCGETDROPRESTOFWORD = 2271;
-    public const int SCI_REGISTERIMAGE = 2405;
-    public const int SCI_CLEARREGISTEREDIMAGES = 2408;
-    public const int SCI_AUTOCGETTYPESEPARATOR = 2285;
-    public const int SCI_AUTOCSETTYPESEPARATOR = 2286;
-    public const int SCI_AUTOCSETMAXWIDTH = 2208;
-    public const int SCI_AUTOCGETMAXWIDTH = 2209;
-    public const int SCI_AUTOCSETMAXHEIGHT = 2210;
-    public const int SCI_AUTOCGETMAXHEIGHT = 2211;
-    public const int SCI_SETINDENT = 2122;
-    public const int SCI_GETINDENT = 2123;
-    public const int SCI_SETUSETABS = 2124;
-    public const int SCI_GETUSETABS = 2125;
-    public const int SCI_SETLINEINDENTATION = 2126;
-    public const int SCI_GETLINEINDENTATION = 2127;
-    public const int SCI_GETLINEINDENTPOSITION = 2128;
-    public const int SCI_GETCOLUMN = 2129;
-    public const int SCI_COUNTCHARACTERS = 2633;
-    public const int SCI_SETHSCROLLBAR = 2130;
-    public const int SCI_GETHSCROLLBAR = 2131;
-    public const int SCI_SETINDENTATIONGUIDES = 2132;
-    public const int SCI_GETINDENTATIONGUIDES = 2133;
-    public const int SCI_SETHIGHLIGHTGUIDE = 2134;
-    public const int SCI_GETHIGHLIGHTGUIDE = 2135;
-    public const int SCI_GETLINEENDPOSITION = 2136;
-    public const int SCI_GETCODEPAGE = 2137;
-    public const int SCI_GETCARETFORE = 2138;
-    public const int SCI_GETREADONLY = 2140;
-    public const int SCI_SETCURRENTPOS = 2141;
-    public const int SCI_SETSELECTIONSTART = 2142;
-    public const int SCI_GETSELECTIONSTART = 2143;
-    public const int SCI_SETSELECTIONEND = 2144;
-    public const int SCI_GETSELECTIONEND = 2145;
-    public const int SCI_SETEMPTYSELECTION = 2556;
-    public const int SCI_SETPRINTMAGNIFICATION = 2146;
-    public const int SCI_GETPRINTMAGNIFICATION = 2147;
-    public const int SCI_SETPRINTCOLOURMODE = 2148;
-    public const int SCI_GETPRINTCOLOURMODE = 2149;
-    public const int SCI_FINDTEXT = 2150;
-    public const int SCI_FORMATRANGE = 2151;
-    public const int SCI_GETFIRSTVISIBLELINE = 2152;
-    public const int SCI_GETLINE = 2153;
-    public const int SCI_GETLINECOUNT = 2154;
-    public const int SCI_SETMARGINLEFT = 2155;
-    public const int SCI_GETMARGINLEFT = 2156;
-    public const int SCI_SETMARGINRIGHT = 2157;
-    public const int SCI_GETMARGINRIGHT = 2158;
-    public const int SCI_GETMODIFY = 2159;
-    public const int SCI_SETSEL = 2160;
-    public const int SCI_GETSELTEXT = 2161;
-    public const int SCI_GETTEXTRANGE = 2162;
-    public const int SCI_HIDESELECTION = 2163;
-    public const int SCI_POINTXFROMPOSITION = 2164;
-    public const int SCI_POINTYFROMPOSITION = 2165;
-    public const int SCI_LINEFROMPOSITION = 2166;
-    public const int SCI_POSITIONFROMLINE = 2167;
-    public const int SCI_LINESCROLL = 2168;
-    public const int SCI_SCROLLCARET = 2169;
-    public const int SCI_SCROLLRANGE = 2569;
-    public const int SCI_REPLACESEL = 2170;
-    public const int SCI_SETREADONLY = 2171;
-    public const int SCI_NULL = 2172;
-    public const int SCI_CANPASTE = 2173;
-    public const int SCI_CANUNDO = 2174;
-    public const int SCI_EMPTYUNDOBUFFER = 2175;
-    public const int SCI_UNDO = 2176;
-    public const int SCI_CUT = 2177;
-    public const int SCI_COPY = 2178;
-    public const int SCI_PASTE = 2179;
-    public const int SCI_CLEAR = 2180;
-    public const int SCI_SETTEXT = 2181;
-    public const int SCI_GETTEXT = 2182;
-    public const int SCI_GETTEXTLENGTH = 2183;
-    public const int SCI_GETDIRECTFUNCTION = 2184;
-    public const int SCI_GETDIRECTPOINTER = 2185;
-    public const int SCI_SETOVERTYPE = 2186;
-    public const int SCI_GETOVERTYPE = 2187;
-    public const int SCI_SETCARETWIDTH = 2188;
-    public const int SCI_GETCARETWIDTH = 2189;
-    public const int SCI_SETTARGETSTART = 2190;
-    public const int SCI_GETTARGETSTART = 2191;
-    public const int SCI_SETTARGETEND = 2192;
-    public const int SCI_GETTARGETEND = 2193;
-    public const int SCI_REPLACETARGET = 2194;
-    public const int SCI_REPLACETARGETRE = 2195;
-    public const int SCI_FINDTEXTFULL = 2196;
-    public const int SCI_SEARCHINTARGET = 2197;
-    public const int SCI_SETSEARCHFLAGS = 2198;
-    public const int SCI_GETSEARCHFLAGS = 2199;
-    public const int SCI_CALLTIPSHOW = 2200;
-    public const int SCI_CALLTIPCANCEL = 2201;
-    public const int SCI_CALLTIPACTIVE = 2202;
-    public const int SCI_CALLTIPPOSSTART = 2203;
-    public const int SCI_CALLTIPSETPOSSTART = 2214;
-    public const int SCI_CALLTIPSETHLT = 2204;
-    public const int SCI_CALLTIPSETBACK = 2205;
-    public const int SCI_CALLTIPSETFORE = 2206;
-    public const int SCI_CALLTIPSETFOREHLT = 2207;
-    public const int SCI_CALLTIPUSESTYLE = 2212;
-    public const int SCI_CALLTIPSETPOSITION = 2213;
-    public const int SCI_VISIBLEFROMDOCLINE = 2220;
-    public const int SCI_DOCLINEFROMVISIBLE = 2221;
-    public const int SCI_WRAPCOUNT = 2235;
-    public const int SCI_SETFOLDLEVEL = 2222;
-    public const int SCI_GETFOLDLEVEL = 2223;
-    public const int SCI_GETLASTCHILD = 2224;
-    public const int SCI_GETFOLDPARENT = 2225;
-    public const int SCI_SHOWLINES = 2226;
-    public const int SCI_HIDELINES = 2227;
-    public const int SCI_GETLINEVISIBLE = 2228;
-    public const int SCI_GETALLLINESVISIBLE = 2236;
-    public const int SCI_SETFOLDEXPANDED = 2229;
-    public const int SCI_GETFOLDEXPANDED = 2230;
-    public const int SCI_TOGGLEFOLD = 2231;
-    public const int SCI_FOLDLINE = 2237;
-    public const int SCI_FOLDCHILDREN = 2238;
-    public const int SCI_EXPANDCHILDREN = 2239;
-    public const int SCI_FOLDALL = 2662;
-    public const int SCI_ENSUREVISIBLE = 2232;
-    public const int SCI_SETAUTOMATICFOLD = 2663;
-    public const int SCI_GETAUTOMATICFOLD = 2664;
-    public const int SCI_SETFOLDFLAGS = 2233;
-    public const int SCI_ENSUREVISIBLEENFORCEPOLICY = 2234;
-    public const int SCI_SETTABINDENTS = 2260;
-    public const int SCI_GETTABINDENTS = 2261;
-    public const int SCI_SETBACKSPACEUNINDENTS = 2262;
-    public const int SCI_GETBACKSPACEUNINDENTS = 2263;
-    public const int SCI_SETMOUSEDWELLTIME = 2264;
-    public const int SCI_GETMOUSEDWELLTIME = 2265;
-    public const int SCI_WORDSTARTPOSITION = 2266;
-    public const int SCI_WORDENDPOSITION = 2267;
-    public const int SCI_ISRANGEWORD = 2691;
-    public const int SCI_SETWRAPMODE = 2268;
-    public const int SCI_GETWRAPMODE = 2269;
-    public const int SCI_SETWRAPVISUALFLAGS = 2460;
-    public const int SCI_GETWRAPVISUALFLAGS = 2461;
-    public const int SCI_SETWRAPVISUALFLAGSLOCATION = 2462;
-    public const int SCI_GETWRAPVISUALFLAGSLOCATION = 2463;
-    public const int SCI_SETWRAPSTARTINDENT = 2464;
-    public const int SCI_GETWRAPSTARTINDENT = 2465;
-    public const int SCI_SETWRAPINDENTMODE = 2472;
-    public const int SCI_GETWRAPINDENTMODE = 2473;
-    public const int SCI_SETLAYOUTCACHE = 2272;
-    public const int SCI_GETLAYOUTCACHE = 2273;
-    public const int SCI_SETSCROLLWIDTH = 2274;
-    public const int SCI_GETSCROLLWIDTH = 2275;
-    public const int SCI_SETSCROLLWIDTHTRACKING = 2516;
-    public const int SCI_GETSCROLLWIDTHTRACKING = 2517;
-    public const int SCI_TEXTWIDTH = 2276;
-    public const int SCI_SETENDATLASTLINE = 2277;
-    public const int SCI_GETENDATLASTLINE = 2278;
-    public const int SCI_TEXTHEIGHT = 2279;
-    public const int SCI_SETVSCROLLBAR = 2280;
-    public const int SCI_GETVSCROLLBAR = 2281;
-    public const int SCI_APPENDTEXT = 2282;
-    public const int SCI_GETTWOPHASEDRAW = 2283;
-    public const int SCI_SETTWOPHASEDRAW = 2284;
-    public const int SCI_GETPHASESDRAW = 2673;
-    public const int SCI_SETPHASESDRAW = 2674;
-    public const int SCI_SETFONTQUALITY = 2611;
-    public const int SCI_GETFONTQUALITY = 2612;
-    public const int SCI_SETFIRSTVISIBLELINE = 2613;
-    public const int SCI_SETMULTIPASTE = 2614;
-    public const int SCI_GETMULTIPASTE = 2615;
-    public const int SCI_GETTAG = 2616;
-    public const int SCI_TARGETFROMSELECTION = 2287;
-    public const int SCI_TARGETWHOLEDOCUMENT = 2690;
-    public const int SCI_LINESJOIN = 2288;
-    public const int SCI_LINESSPLIT = 2289;
-    public const int SCI_SETFOLDMARGINCOLOUR = 2290;
-    public const int SCI_SETFOLDMARGINHICOLOUR = 2291;
-    public const int SCI_LINEDOWN = 2300;
-    public const int SCI_LINEDOWNEXTEND = 2301;
-    public const int SCI_LINEUP = 2302;
-    public const int SCI_LINEUPEXTEND = 2303;
-    public const int SCI_CHARLEFT = 2304;
-    public const int SCI_CHARLEFTEXTEND = 2305;
-    public const int SCI_CHARRIGHT = 2306;
-    public const int SCI_CHARRIGHTEXTEND = 2307;
-    public const int SCI_WORDLEFT = 2308;
-    public const int SCI_WORDLEFTEXTEND = 2309;
-    public const int SCI_WORDRIGHT = 2310;
-    public const int SCI_WORDRIGHTEXTEND = 2311;
-    public const int SCI_HOME = 2312;
-    public const int SCI_HOMEEXTEND = 2313;
-    public const int SCI_LINEEND = 2314;
-    public const int SCI_LINEENDEXTEND = 2315;
-    public const int SCI_DOCUMENTSTART = 2316;
-    public const int SCI_DOCUMENTSTARTEXTEND = 2317;
-    public const int SCI_DOCUMENTEND = 2318;
-    public const int SCI_DOCUMENTENDEXTEND = 2319;
-    public const int SCI_PAGEUP = 2320;
-    public const int SCI_PAGEUPEXTEND = 2321;
-    public const int SCI_PAGEDOWN = 2322;
-    public const int SCI_PAGEDOWNEXTEND = 2323;
-    public const int SCI_EDITTOGGLEOVERTYPE = 2324;
-    public const int SCI_CANCEL = 2325;
-    public const int SCI_DELETEBACK = 2326;
-    public const int SCI_TAB = 2327;
-    public const int SCI_BACKTAB = 2328;
-    public const int SCI_NEWLINE = 2329;
-    public const int SCI_FORMFEED = 2330;
-    public const int SCI_VCHOME = 2331;
-    public const int SCI_VCHOMEEXTEND = 2332;
-    public const int SCI_ZOOMIN = 2333;
-    public const int SCI_ZOOMOUT = 2334;
-    public const int SCI_DELWORDLEFT = 2335;
-    public const int SCI_DELWORDRIGHT = 2336;
-    public const int SCI_DELWORDRIGHTEND = 2518;
-    public const int SCI_LINECUT = 2337;
-    public const int SCI_LINEDELETE = 2338;
-    public const int SCI_LINETRANSPOSE = 2339;
-    public const int SCI_LINEDUPLICATE = 2404;
-    public const int SCI_LOWERCASE = 2340;
-    public const int SCI_UPPERCASE = 2341;
-    public const int SCI_LINESCROLLDOWN = 2342;
-    public const int SCI_LINESCROLLUP = 2343;
-    public const int SCI_DELETEBACKNOTLINE = 2344;
-    public const int SCI_HOMEDISPLAY = 2345;
-    public const int SCI_HOMEDISPLAYEXTEND = 2346;
-    public const int SCI_LINEENDDISPLAY = 2347;
-    public const int SCI_LINEENDDISPLAYEXTEND = 2348;
-    public const int SCI_HOMEWRAP = 2349;
-    public const int SCI_LINEREVERSE = 2354;
-    public const int SCI_HOMEWRAPEXTEND = 2450;
-    public const int SCI_LINEENDWRAP = 2451;
-    public const int SCI_LINEENDWRAPEXTEND = 2452;
-    public const int SCI_VCHOMEWRAP = 2453;
-    public const int SCI_VCHOMEWRAPEXTEND = 2454;
-    public const int SCI_LINECOPY = 2455;
-    public const int SCI_MOVECARETINSIDEVIEW = 2401;
-    public const int SCI_LINELENGTH = 2350;
-    public const int SCI_BRACEHIGHLIGHT = 2351;
-    public const int SCI_BRACEHIGHLIGHTINDICATOR = 2498;
-    public const int SCI_BRACEBADLIGHT = 2352;
-    public const int SCI_BRACEBADLIGHTINDICATOR = 2499;
-    public const int SCI_BRACEMATCH = 2353;
-    public const int SCI_GETVIEWEOL = 2355;
-    public const int SCI_SETVIEWEOL = 2356;
-    public const int SCI_GETDOCPOINTER = 2357;
-    public const int SCI_SETDOCPOINTER = 2358;
-    public const int SCI_SETMODEVENTMASK = 2359;
-    public const int SCI_GETEDGECOLUMN = 2360;
-    public const int SCI_SETEDGECOLUMN = 2361;
-    public const int SCI_GETEDGEMODE = 2362;
-    public const int SCI_SETEDGEMODE = 2363;
-    public const int SCI_GETEDGECOLOUR = 2364;
-    public const int SCI_SETEDGECOLOUR = 2365;
-    public const int SCI_SEARCHANCHOR = 2366;
-    public const int SCI_SEARCHNEXT = 2367;
-    public const int SCI_SEARCHPREV = 2368;
-    public const int SCI_LINESONSCREEN = 2370;
-    public const int SCI_USEPOPUP = 2371;
-    public const int SCI_SELECTIONISRECTANGLE = 2372;
-    public const int SCI_SETZOOM = 2373;
-    public const int SCI_GETZOOM = 2374;
-    public const int SCI_CREATEDOCUMENT = 2375;
-    public const int SCI_ADDREFDOCUMENT = 2376;
-    public const int SCI_RELEASEDOCUMENT = 2377;
-    public const int SCI_GETMODEVENTMASK = 2378;
-    public const int SCI_SETFOCUS = 2380;
-    public const int SCI_GETFOCUS = 2381;
-    public const int SCI_SETSTATUS = 2382;
-    public const int SCI_GETSTATUS = 2383;
-    public const int SCI_SETMOUSEDOWNCAPTURES = 2384;
-    public const int SCI_GETMOUSEDOWNCAPTURES = 2385;
-    public const int SCI_SETCURSOR = 2386;
-    public const int SCI_GETCURSOR = 2387;
-    public const int SCI_SETCONTROLCHARSYMBOL = 2388;
-    public const int SCI_GETCONTROLCHARSYMBOL = 2389;
-    public const int SCI_WORDPARTLEFT = 2390;
-    public const int SCI_WORDPARTLEFTEXTEND = 2391;
-    public const int SCI_WORDPARTRIGHT = 2392;
-    public const int SCI_WORDPARTRIGHTEXTEND = 2393;
-    public const int SCI_SETVISIBLEPOLICY = 2394;
-    public const int SCI_DELLINELEFT = 2395;
-    public const int SCI_DELLINERIGHT = 2396;
-    public const int SCI_SETXOFFSET = 2397;
-    public const int SCI_GETXOFFSET = 2398;
-    public const int SCI_CHOOSECARETX = 2399;
-    public const int SCI_GRABFOCUS = 2400;
-    public const int SCI_SETXCARETPOLICY = 2402;
-    public const int SCI_SETYCARETPOLICY = 2403;
-    public const int SCI_SETPRINTWRAPMODE = 2406;
-    public const int SCI_GETPRINTWRAPMODE = 2407;
-    public const int SCI_SETHOTSPOTACTIVEFORE = 2410;
-    public const int SCI_GETHOTSPOTACTIVEFORE = 2494;
-    public const int SCI_SETHOTSPOTACTIVEBACK = 2411;
-    public const int SCI_GETHOTSPOTACTIVEBACK = 2495;
-    public const int SCI_SETHOTSPOTACTIVEUNDERLINE = 2412;
-    public const int SCI_GETHOTSPOTACTIVEUNDERLINE = 2496;
-    public const int SCI_SETHOTSPOTSINGLELINE = 2421;
-    public const int SCI_GETHOTSPOTSINGLELINE = 2497;
-    public const int SCI_PARADOWN = 2413;
-    public const int SCI_PARADOWNEXTEND = 2414;
-    public const int SCI_PARAUP = 2415;
-    public const int SCI_PARAUPEXTEND = 2416;
-    // public const int SCI_POSITIONBEFORE = 2417; // Bad, bad, bad. Don't use these...
-    // public const int SCI_POSITIONAFTER = 2418;  // they treat \r\n as one character.
-    public const int SCI_POSITIONRELATIVE = 2670;
-    public const int SCI_COPYRANGE = 2419;
-    public const int SCI_COPYTEXT = 2420;
-    public const int SCI_SETSELECTIONMODE = 2422;
-    public const int SCI_GETSELECTIONMODE = 2423;
-    public const int SCI_GETLINESELSTARTPOSITION = 2424;
-    public const int SCI_GETLINESELENDPOSITION = 2425;
-    public const int SCI_LINEDOWNRECTEXTEND = 2426;
-    public const int SCI_LINEUPRECTEXTEND = 2427;
-    public const int SCI_CHARLEFTRECTEXTEND = 2428;
-    public const int SCI_CHARRIGHTRECTEXTEND = 2429;
-    public const int SCI_HOMERECTEXTEND = 2430;
-    public const int SCI_VCHOMERECTEXTEND = 2431;
-    public const int SCI_LINEENDRECTEXTEND = 2432;
-    public const int SCI_PAGEUPRECTEXTEND = 2433;
-    public const int SCI_PAGEDOWNRECTEXTEND = 2434;
-    public const int SCI_STUTTEREDPAGEUP = 2435;
-    public const int SCI_STUTTEREDPAGEUPEXTEND = 2436;
-    public const int SCI_STUTTEREDPAGEDOWN = 2437;
-    public const int SCI_STUTTEREDPAGEDOWNEXTEND = 2438;
-    public const int SCI_WORDLEFTEND = 2439;
-    public const int SCI_WORDLEFTENDEXTEND = 2440;
-    public const int SCI_WORDRIGHTEND = 2441;
-    public const int SCI_WORDRIGHTENDEXTEND = 2442;
-    public const int SCI_SETWHITESPACECHARS = 2443;
-    public const int SCI_GETWHITESPACECHARS = 2647;
-    public const int SCI_SETPUNCTUATIONCHARS = 2648;
-    public const int SCI_GETPUNCTUATIONCHARS = 2649;
-    public const int SCI_SETCHARSDEFAULT = 2444;
-    public const int SCI_AUTOCGETCURRENT = 2445;
-    public const int SCI_AUTOCGETCURRENTTEXT = 2610;
-    public const int SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR = 2634;
-    public const int SCI_AUTOCGETCASEINSENSITIVEBEHAVIOUR = 2635;
-    public const int SCI_AUTOCSETMULTI = 2636;
-    public const int SCI_AUTOCGETMULTI = 2637;
-    public const int SCI_AUTOCSETORDER = 2660;
-    public const int SCI_AUTOCGETORDER = 2661;
-    public const int SCI_ALLOCATE = 2446;
-    public const int SCI_TARGETASUTF8 = 2447;
-    public const int SCI_SETLENGTHFORENCODE = 2448;
-    public const int SCI_ENCODEDFROMUTF8 = 2449;
-    public const int SCI_FINDCOLUMN = 2456;
-    public const int SCI_GETCARETSTICKY = 2457;
-    public const int SCI_SETCARETSTICKY = 2458;
-    public const int SCI_TOGGLECARETSTICKY = 2459;
-    public const int SCI_SETPASTECONVERTENDINGS = 2467;
-    public const int SCI_GETPASTECONVERTENDINGS = 2468;
-    public const int SCI_SELECTIONDUPLICATE = 2469;
-    public const int SCI_SETCARETLINEBACKALPHA = 2470;
-    public const int SCI_GETCARETLINEBACKALPHA = 2471;
-    public const int SCI_SETCARETSTYLE = 2512;
-    public const int SCI_GETCARETSTYLE = 2513;
-    public const int SCI_SETINDICATORCURRENT = 2500;
-    public const int SCI_GETINDICATORCURRENT = 2501;
-    public const int SCI_SETINDICATORVALUE = 2502;
-    public const int SCI_GETINDICATORVALUE = 2503;
-    public const int SCI_INDICATORFILLRANGE = 2504;
-    public const int SCI_INDICATORCLEARRANGE = 2505;
-    public const int SCI_INDICATORALLONFOR = 2506;
-    public const int SCI_INDICATORVALUEAT = 2507;
-    public const int SCI_INDICATORSTART = 2508;
-    public const int SCI_INDICATOREND = 2509;
-    public const int SCI_SETPOSITIONCACHE = 2514;
-    public const int SCI_GETPOSITIONCACHE = 2515;
-    public const int SCI_COPYALLOWLINE = 2519;
-    public const int SCI_GETCHARACTERPOINTER = 2520;
-    public const int SCI_GETRANGEPOINTER = 2643;
-    public const int SCI_GETGAPPOSITION = 2644;
-    public const int SCI_INDICSETALPHA = 2523;
-    public const int SCI_INDICGETALPHA = 2524;
-    public const int SCI_INDICSETOUTLINEALPHA = 2558;
-    public const int SCI_INDICGETOUTLINEALPHA = 2559;
-    public const int SCI_SETEXTRAASCENT = 2525;
-    public const int SCI_GETEXTRAASCENT = 2526;
-    public const int SCI_SETEXTRADESCENT = 2527;
-    public const int SCI_GETEXTRADESCENT = 2528;
-    public const int SCI_MARKERSYMBOLDEFINED = 2529;
-    public const int SCI_MARGINSETTEXT = 2530;
-    public const int SCI_MARGINGETTEXT = 2531;
-    public const int SCI_MARGINSETSTYLE = 2532;
-    public const int SCI_MARGINGETSTYLE = 2533;
-    public const int SCI_MARGINSETSTYLES = 2534;
-    public const int SCI_MARGINGETSTYLES = 2535;
-    public const int SCI_MARGINTEXTCLEARALL = 2536;
-    public const int SCI_MARGINSETSTYLEOFFSET = 2537;
-    public const int SCI_MARGINGETSTYLEOFFSET = 2538;
-    public const int SCI_SETMARGINOPTIONS = 2539;
-    public const int SCI_GETMARGINOPTIONS = 2557;
-    public const int SCI_ANNOTATIONSETTEXT = 2540;
-    public const int SCI_ANNOTATIONGETTEXT = 2541;
-    public const int SCI_ANNOTATIONSETSTYLE = 2542;
-    public const int SCI_ANNOTATIONGETSTYLE = 2543;
-    public const int SCI_ANNOTATIONSETSTYLES = 2544;
-    public const int SCI_ANNOTATIONGETSTYLES = 2545;
-    public const int SCI_ANNOTATIONGETLINES = 2546;
-    public const int SCI_ANNOTATIONCLEARALL = 2547;
-    public const int SCI_ANNOTATIONSETVISIBLE = 2548;
-    public const int SCI_ANNOTATIONGETVISIBLE = 2549;
-    public const int SCI_ANNOTATIONSETSTYLEOFFSET = 2550;
-    public const int SCI_ANNOTATIONGETSTYLEOFFSET = 2551;
-    public const int SCI_RELEASEALLEXTENDEDSTYLES = 2552;
-    public const int SCI_ALLOCATEEXTENDEDSTYLES = 2553;
-    public const int SCI_ADDUNDOACTION = 2560;
-    public const int SCI_CHARPOSITIONFROMPOINT = 2561;
-    public const int SCI_CHARPOSITIONFROMPOINTCLOSE = 2562;
-    public const int SCI_SETMOUSESELECTIONRECTANGULARSWITCH = 2668;
-    public const int SCI_GETMOUSESELECTIONRECTANGULARSWITCH = 2669;
-    public const int SCI_SETMULTIPLESELECTION = 2563;
-    public const int SCI_GETMULTIPLESELECTION = 2564;
-    public const int SCI_SETADDITIONALSELECTIONTYPING = 2565;
-    public const int SCI_GETADDITIONALSELECTIONTYPING = 2566;
-    public const int SCI_SETADDITIONALCARETSBLINK = 2567;
-    public const int SCI_GETADDITIONALCARETSBLINK = 2568;
-    public const int SCI_SETADDITIONALCARETSVISIBLE = 2608;
-    public const int SCI_GETADDITIONALCARETSVISIBLE = 2609;
-    public const int SCI_GETTABDRAWMODE = 2698;
-    public const int SCI_SETTABDRAWMODE = 2699;
-    public const int SCI_GETSELECTIONS = 2570;
-    public const int SCI_GETSELECTIONEMPTY = 2650;
-    public const int SCI_CLEARSELECTIONS = 2571;
-    public const int SCI_SETSELECTION = 2572;
-    public const int SCI_ADDSELECTION = 2573;
-    public const int SCI_DROPSELECTIONN = 2671;
-    public const int SCI_SETMAINSELECTION = 2574;
-    public const int SCI_GETMAINSELECTION = 2575;
-    public const int SCI_SETSELECTIONNCARET = 2576;
-    public const int SCI_GETSELECTIONNCARET = 2577;
-    public const int SCI_SETSELECTIONNANCHOR = 2578;
-    public const int SCI_GETSELECTIONNANCHOR = 2579;
-    public const int SCI_SETSELECTIONNCARETVIRTUALSPACE = 2580;
-    public const int SCI_GETSELECTIONNCARETVIRTUALSPACE = 2581;
-    public const int SCI_SETSELECTIONNANCHORVIRTUALSPACE = 2582;
-    public const int SCI_GETSELECTIONNANCHORVIRTUALSPACE = 2583;
-    public const int SCI_SETSELECTIONNSTART = 2584;
-    public const int SCI_GETSELECTIONNSTART = 2585;
-    public const int SCI_SETSELECTIONNEND = 2586;
-    public const int SCI_GETSELECTIONNEND = 2587;
-    public const int SCI_SETRECTANGULARSELECTIONCARET = 2588;
-    public const int SCI_GETRECTANGULARSELECTIONCARET = 2589;
-    public const int SCI_SETRECTANGULARSELECTIONANCHOR = 2590;
-    public const int SCI_GETRECTANGULARSELECTIONANCHOR = 2591;
-    public const int SCI_SETRECTANGULARSELECTIONCARETVIRTUALSPACE = 2592;
-    public const int SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE = 2593;
-    public const int SCI_SETRECTANGULARSELECTIONANCHORVIRTUALSPACE = 2594;
-    public const int SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE = 2595;
-    public const int SCI_SETVIRTUALSPACEOPTIONS = 2596;
-    public const int SCI_GETVIRTUALSPACEOPTIONS = 2597;
-    public const int SCI_SETRECTANGULARSELECTIONMODIFIER = 2598;
-    public const int SCI_GETRECTANGULARSELECTIONMODIFIER = 2599;
-    public const int SCI_SETADDITIONALSELFORE = 2600;
-    public const int SCI_SETADDITIONALSELBACK = 2601;
-    public const int SCI_SETADDITIONALSELALPHA = 2602;
-    public const int SCI_GETADDITIONALSELALPHA = 2603;
-    public const int SCI_SETADDITIONALCARETFORE = 2604;
-    public const int SCI_GETADDITIONALCARETFORE = 2605;
-    public const int SCI_ROTATESELECTION = 2606;
-    public const int SCI_SWAPMAINANCHORCARET = 2607;
-    public const int SCI_MULTIPLESELECTADDNEXT = 2688;
-    public const int SCI_MULTIPLESELECTADDEACH = 2689;
-    public const int SCI_CHANGELEXERSTATE = 2617;
-    public const int SCI_CONTRACTEDFOLDNEXT = 2618;
-    public const int SCI_VERTICALCENTRECARET = 2619;
-    public const int SCI_MOVESELECTEDLINESUP = 2620;
-    public const int SCI_MOVESELECTEDLINESDOWN = 2621;
-    public const int SCI_SETIDENTIFIER = 2622;
-    public const int SCI_GETIDENTIFIER = 2623;
-    public const int SCI_RGBAIMAGESETWIDTH = 2624;
-    public const int SCI_RGBAIMAGESETHEIGHT = 2625;
-    public const int SCI_RGBAIMAGESETSCALE = 2651;
-    public const int SCI_MARKERDEFINERGBAIMAGE = 2626;
-    public const int SCI_REGISTERRGBAIMAGE = 2627;
-    public const int SCI_SCROLLTOSTART = 2628;
-    public const int SCI_SCROLLTOEND = 2629;
-    public const int SCI_SETTECHNOLOGY = 2630;
-    public const int SCI_GETTECHNOLOGY = 2631;
-    public const int SCI_CREATELOADER = 2632;
-    public const int SCI_FINDINDICATORSHOW = 2640;
-    public const int SCI_FINDINDICATORFLASH = 2641;
-    public const int SCI_FINDINDICATORHIDE = 2642;
-    public const int SCI_VCHOMEDISPLAY = 2652;
-    public const int SCI_VCHOMEDISPLAYEXTEND = 2653;
-    public const int SCI_GETCARETLINEVISIBLEALWAYS = 2654;
-    public const int SCI_SETCARETLINEVISIBLEALWAYS = 2655;
-    public const int SCI_SETLINEENDTYPESALLOWED = 2656;
-    public const int SCI_GETLINEENDTYPESALLOWED = 2657;
-    public const int SCI_GETLINEENDTYPESACTIVE = 2658;
-    public const int SCI_SETREPRESENTATION = 2665;
-    public const int SCI_GETREPRESENTATION = 2666;
-    public const int SCI_CLEARREPRESENTATION = 2667;
-    public const int SCI_SETTARGETRANGE = 2686;
-    public const int SCI_GETTARGETTEXT = 2687;
-    public const int SCI_SETIDLESTYLING = 2692;
-    public const int SCI_GETIDLESTYLING = 2693;
-    public const int SCI_MULTIEDGEADDLINE = 2694;
-    public const int SCI_MULTIEDGECLEARALL = 2695;
-    public const int SCI_SETMOUSEWHEELCAPTURES = 2696;
-    public const int SCI_GETMOUSEWHEELCAPTURES = 2697;
-    public const int SCI_TOGGLEFOLDSHOWTEXT = 2700;
-    public const int SCI_FOLDDISPLAYTEXTSETSTYLE = 2701;
-    public const int SCI_GETCARETLINEFRAME = 2704;
-    public const int SCI_SETCARETLINEFRAME = 2705;
-    public const int SCI_SETELEMENTCOLOUR = 2753;
-    public const int SCI_GETELEMENTCOLOUR = 2754;
-    public const int SCI_RESETELEMENTCOLOUR = 2755;
-    public const int SCI_GETELEMENTISSET = 2756;
-    public const int SCI_GETELEMENTALLOWSTRANSLUCENT = 2757;
-    public const int SCI_GETELEMENTBASECOLOUR = 2758;
-    public const int SCI_GETSELECTIONLAYER = 2762;
-    public const int SCI_SETSELECTIONLAYER = 2763;
-    public const int SCI_GETCARETLINELAYER = 2764;
-    public const int SCI_SETCARETLINELAYER = 2765;
-    public const int SCI_SETCHANGEHISTORY = 2780;
-    public const int SCI_GETCHANGEHISTORY = 2781;
-    public const int SCI_STARTRECORD = 3001;
-    public const int SCI_STOPRECORD = 3002;
-    public const int SCI_SETLEXER = 4001;
-    public const int SCI_GETLEXER = 4002;
-    public const int SCI_COLOURISE = 4003;
-    public const int SCI_SETPROPERTY = 4004;
-    public const int SCI_SETKEYWORDS = 4005;
-    public const int SCI_SETLEXERLANGUAGE = 4006;
-    public const int SCI_LOADLEXERLIBRARY = 4007;
-    public const int SCI_GETPROPERTY = 4008;
-    public const int SCI_GETPROPERTYEXPANDED = 4009;
-    public const int SCI_GETPROPERTYINT = 4010;
-    // public const int SCI_GETSTYLEBITSNEEDED = 4011;
-    public const int SCI_GETLEXERLANGUAGE = 4012;
-    public const int SCI_PRIVATELEXERCALL = 4013;
-    public const int SCI_PROPERTYNAMES = 4014;
-    public const int SCI_PROPERTYTYPE = 4015;
-    public const int SCI_DESCRIBEPROPERTY = 4016;
-    public const int SCI_DESCRIBEKEYWORDSETS = 4017;
-    public const int SCI_GETLINEENDTYPESSUPPORTED = 4018;
-    public const int SCI_ALLOCATESUBSTYLES = 4020;
-    public const int SCI_GETSUBSTYLESSTART = 4021;
-    public const int SCI_GETSUBSTYLESLENGTH = 4022;
-    public const int SCI_GETSTYLEFROMSUBSTYLE = 4027;
-    public const int SCI_GETPRIMARYSTYLEFROMSTYLE = 4028;
-    public const int SCI_FREESUBSTYLES = 4023;
-    public const int SCI_SETIDENTIFIERS = 4024;
-    public const int SCI_DISTANCETOSECONDARYSTYLES = 4025;
-    public const int SCI_GETSUBSTYLEBASES = 4026;
-    // public const int SCI_SETUSEPALETTE = 2039;
-    // public const int SCI_GETUSEPALETTE = 2139;
-    public const int SC_BIDIRECTIONAL_DISABLED = 0;
-    public const int SC_BIDIRECTIONAL_L2R = 1;
-    public const int SC_BIDIRECTIONAL_R2L = 2;
-    public const int SCI_GETBIDIRECTIONAL = 2708;
-    public const int SCI_SETBIDIRECTIONAL = 2709;
-    public const int SCI_SETILEXER = 4033;
-
-    // Keys
-    public const int SCK_DOWN = 300;
-    public const int SCK_UP = 301;
-    public const int SCK_LEFT = 302;
-    public const int SCK_RIGHT = 303;
-    public const int SCK_HOME = 304;
-    public const int SCK_END = 305;
-    public const int SCK_PRIOR = 306;
-    public const int SCK_NEXT = 307;
-    public const int SCK_DELETE = 308;
-    public const int SCK_INSERT = 309;
-    public const int SCK_ESCAPE = 7;
-    public const int SCK_BACK = 8;
-    public const int SCK_TAB = 9;
-    public const int SCK_RETURN = 13;
-    public const int SCK_ADD = 310;
-    public const int SCK_SUBTRACT = 311;
-    public const int SCK_DIVIDE = 312;
-    public const int SCK_WIN = 313;
-    public const int SCK_RWIN = 314;
-    public const int SCK_MENU = 315;
-
-    // Notifications
-    public const int SCN_STYLENEEDED = 2000;
-    public const int SCN_CHARADDED = 2001;
-    public const int SCN_SAVEPOINTREACHED = 2002;
-    public const int SCN_SAVEPOINTLEFT = 2003;
-    public const int SCN_MODIFYATTEMPTRO = 2004;
-    public const int SCN_KEY = 2005;
-    public const int SCN_DOUBLECLICK = 2006;
-    public const int SCN_UPDATEUI = 2007;
-    public const int SCN_MODIFIED = 2008;
-    public const int SCN_MACRORECORD = 2009;
-    public const int SCN_MARGINCLICK = 2010;
-    public const int SCN_NEEDSHOWN = 2011;
-    public const int SCN_PAINTED = 2013;
-    public const int SCN_USERLISTSELECTION = 2014;
-    public const int SCN_URIDROPPED = 2015;
-    public const int SCN_DWELLSTART = 2016;
-    public const int SCN_DWELLEND = 2017;
-    public const int SCN_ZOOM = 2018;
-    public const int SCN_HOTSPOTCLICK = 2019;
-    public const int SCN_HOTSPOTDOUBLECLICK = 2020;
-    public const int SCN_CALLTIPCLICK = 2021;
-    public const int SCN_AUTOCSELECTION = 2022;
-    public const int SCN_INDICATORCLICK = 2023;
-    public const int SCN_INDICATORRELEASE = 2024;
-    public const int SCN_AUTOCCANCELLED = 2025;
-    public const int SCN_AUTOCCHARDELETED = 2026;
-    public const int SCN_HOTSPOTRELEASECLICK = 2027;
-    public const int SCN_FOCUSIN = 2028;
-    public const int SCN_FOCUSOUT = 2029;
-    public const int SCN_AUTOCCOMPLETED = 2030;
-    public const int SCN_MARGINRIGHTCLICK = 2031;
-    public const int SCN_AUTOCSELECTIONCHANGE = 2032;
-
-    // Popup
-    public const int SC_POPUP_NEVER = 0;
-    public const int SC_POPUP_ALL = 1;
-    public const int SC_POPUP_TEXT = 2;
-
-    // Line wrapping
-    public const int SC_WRAP_NONE = 0;
-    public const int SC_WRAP_WORD = 1;
-    public const int SC_WRAP_CHAR = 2;
-    public const int SC_WRAP_WHITESPACE = 3;
-
-    public const int SC_WRAPVISUALFLAG_NONE = 0x0000;
-    public const int SC_WRAPVISUALFLAG_END = 0x0001;
-    public const int SC_WRAPVISUALFLAG_START = 0x0002;
-    public const int SC_WRAPVISUALFLAG_MARGIN = 0x0004;
-
-    public const int SC_WRAPVISUALFLAGLOC_DEFAULT = 0x0000;
-    public const int SC_WRAPVISUALFLAGLOC_END_BY_TEXT = 0x0001;
-    public const int SC_WRAPVISUALFLAGLOC_START_BY_TEXT = 0x0002;
-
-    public const int SC_WRAPINDENT_FIXED = 0;
-    public const int SC_WRAPINDENT_SAME = 1;
-    public const int SC_WRAPINDENT_INDENT = 2;
-
-    // Virtual space
-    public const int SCVS_NONE = 0;
-    public const int SCVS_RECTANGULARSELECTION = 1;
-    public const int SCVS_USERACCESSIBLE = 2;
-    public const int SCVS_NOWRAPLINESTART = 4;
-
-    // Styles constants
-    public const int STYLE_DEFAULT = 32;
-    public const int STYLE_LINENUMBER = 33;
-    public const int STYLE_BRACELIGHT = 34;
-    public const int STYLE_BRACEBAD = 35;
-    public const int STYLE_CONTROLCHAR = 36;
-    public const int STYLE_INDENTGUIDE = 37;
-    public const int STYLE_CALLTIP = 38;
-    public const int STYLE_FOLDDISPLAYTEXT = 39;
-    public const int STYLE_LASTPREDEFINED = 39;
-    public const int STYLE_MAX = 255;
-
-    public const int SC_FONT_SIZE_MULTIPLIER = 100;
-    public const int SC_CASE_MIXED = 0;
-    public const int SC_CASE_UPPER = 1;
-    public const int SC_CASE_LOWER = 2;
-    public const int SC_CASE_CAMEL = 3;
-
-    // Technology
-    public const int SC_TECHNOLOGY_DEFAULT = 0;
-    public const int SC_TECHNOLOGY_DIRECTWRITE = 1;
-    public const int SC_TECHNOLOGY_DIRECTWRITERETAIN = 2;
-    public const int SC_TECHNOLOGY_DIRECTWRITEDC = 3;
-
-    // Tab draw
-    public const int SCTD_LONGARROW = 0;
-    public const int SCTD_STRIKEOUT = 1;
-
-    // Undo
-    public const int UNDO_MAY_COALESCE = 1;
-
-    // Whitespace
-    public const int SCWS_INVISIBLE = 0;
-    public const int SCWS_VISIBLEALWAYS = 1;
-    public const int SCWS_VISIBLEAFTERINDENT = 2;
-    public const int SCWS_VISIBLEONLYININDENT = 3;
-
-    // Window messages
-    public const int WM_CREATE = 0x0001;
-    public const int WM_DESTROY = 0x0002;
-    public const int WM_SETCURSOR = 0x0020;
-    public const int WM_NOTIFY = 0x004E;
-    public const int WM_NCPAINT = 0x0085;
-    public const int WM_LBUTTONDBLCLK = 0x0203;
-    public const int WM_RBUTTONDBLCLK = 0x0206;
-    public const int WM_MBUTTONDBLCLK = 0x0209;
-    public const int WM_XBUTTONDBLCLK = 0x020D;
-    public const int WM_USER = 0x0400;
-    public const int WM_REFLECT = WM_USER + 0x1C00;
-
-    // Window styles
-    public const int WS_BORDER = 0x00800000;
-    public const int WS_EX_CLIENTEDGE = 0x00000200;
-
-    public const int RGN_AND = 1;
-
-    #endregion Constants
-
-    #region Lexer Constants
-
-    // Map the constant language names
-    public static readonly Dictionary<int, string> NameConstantMap = new() {
+    public static class NativeMethods
+    {
+        #region Constants
+
+        private const string DLL_NAME_GDI32 = "gdi32.dll";
+        private const string DLL_NAME_KERNEL32 = "kernel32.dll";
+        private const string DLL_NAME_OLE32 = "ole32.dll";
+        private const string DLL_NAME_USER32 = "user32.dll";
+
+        public const int INVALID_POSITION = -1;
+
+        // Autocompletions
+        public const int SC_AC_FILLUP = 1;
+        public const int SC_AC_DOUBLECLICK = 2;
+        public const int SC_AC_TAB = 3;
+        public const int SC_AC_NEWLINE = 4;
+        public const int SC_AC_COMMAND = 5;
+
+        // Annotations
+        public const int ANNOTATION_HIDDEN = 0;
+        public const int ANNOTATION_STANDARD = 1;
+        public const int ANNOTATION_BOXED = 2;
+        public const int ANNOTATION_INDENTED = 3;
+
+        // Clipboard formats
+        public const string CF_HTML = "HTML Format";
+
+        // Idle styling
+        public const int SC_IDLESTYLING_NONE = 0;
+        public const int SC_IDLESTYLING_TOVISIBLE = 1;
+        public const int SC_IDLESTYLING_AFTERVISIBLE = 2;
+        public const int SC_IDLESTYLING_ALL = 3;
+
+        // Indentation 
+        public const int SC_IV_NONE = 0;
+        public const int SC_IV_REAL = 1;
+        public const int SC_IV_LOOKFORWARD = 2;
+        public const int SC_IV_LOOKBOTH = 3;
+
+        // Keys
+        public const int SCMOD_NORM = 0;
+        public const int SCMOD_SHIFT = 1;
+        public const int SCMOD_CTRL = 2;
+        public const int SCMOD_ALT = 4;
+        public const int SCMOD_SUPER = 8;
+        public const int SCMOD_META = 16;
+
+        public const int SCI_NORM = 0;
+        public const int SCI_SHIFT = SCMOD_SHIFT;
+        public const int SCI_CTRL = SCMOD_CTRL;
+        public const int SCI_ALT = SCMOD_ALT;
+        public const int SCI_META = SCMOD_META;
+        public const int SCI_CSHIFT = SCI_CTRL | SCI_SHIFT;
+        public const int SCI_ASHIFT = SCI_ALT | SCI_SHIFT;
+
+        // Caret policy flags
+        public const int CARET_SLOP = 0x01;
+        public const int CARET_STRICT = 0x04;
+        public const int CARET_JUMPS = 0x10;
+        public const int CARET_EVEN = 0x08;
+
+        // Caret styles
+        public const int CARETSTYLE_INVISIBLE = 0;
+        public const int CARETSTYLE_LINE = 1;
+        public const int CARETSTYLE_BLOCK = 2;
+
+        // Line edges
+        public const int EDGE_NONE = 0;
+        public const int EDGE_LINE = 1;
+        public const int EDGE_BACKGROUND = 2;
+        public const int EDGE_MULTILINE = 3;
+
+        // Message-only window
+        public const int HWND_MESSAGE = -3;
+
+        // Indicator styles
+        public const int INDIC_PLAIN = 0;
+        public const int INDIC_SQUIGGLE = 1;
+        public const int INDIC_TT = 2;
+        public const int INDIC_DIAGONAL = 3;
+        public const int INDIC_STRIKE = 4;
+        public const int INDIC_HIDDEN = 5;
+        public const int INDIC_BOX = 6;
+        public const int INDIC_ROUNDBOX = 7;
+        public const int INDIC_STRAIGHTBOX = 8;
+        public const int INDIC_DASH = 9;
+        public const int INDIC_DOTS = 10;
+        public const int INDIC_SQUIGGLELOW = 11;
+        public const int INDIC_DOTBOX = 12;
+        public const int INDIC_SQUIGGLEPIXMAP = 13;
+        public const int INDIC_COMPOSITIONTHICK = 14;
+        public const int INDIC_COMPOSITIONTHIN = 15;
+        public const int INDIC_FULLBOX = 16;
+        public const int INDIC_TEXTFORE = 17;
+        public const int INDIC_POINT = 18;
+        public const int INDIC_POINTCHARACTER = 19;
+        public const int INDIC_GRADIENT = 20;
+        public const int INDIC_GRADIENTCENTRE = 21;
+        public const int INDIC_POINT_TOP = 22;
+
+        [Obsolete("Use INDICATOR_CONTAINER instead.")]
+        public const int INDIC_CONTAINER = 8;
+        [Obsolete("Use INDICATOR_MAX instead.")]
+        public const int INDIC_MAX = 31;
+
+        // Indicators
+        public const int INDICATOR_CONTAINER = 8;
+        public const int INDICATOR_IME = 32;
+        public const int INDICATOR_IME_MAX = 35;
+        public const int INDICATOR_HISTORY_REVERTED_TO_ORIGIN_INSERTION = 36;
+        public const int INDICATOR_HISTORY_REVERTED_TO_ORIGIN_DELETION = 37;
+        public const int INDICATOR_HISTORY_SAVED_INSERTION = 38;
+        public const int INDICATOR_HISTORY_SAVED_DELETION = 39;
+        public const int INDICATOR_HISTORY_MODIFIED_INSERTION = 40;
+        public const int INDICATOR_HISTORY_MODIFIED_DELETION = 41;
+        public const int INDICATOR_HISTORY_REVERTED_TO_MODIFIED_INSERTION = 42;
+        public const int INDICATOR_HISTORY_REVERTED_TO_MODIFIED_DELETION = 43;
+        public const int INDICATOR_MAX = 43;
+
+        // Phases
+        public const int SC_PHASES_ONE = 0;
+        public const int SC_PHASES_TWO = 1;
+        public const int SC_PHASES_MULTIPLE = 2;
+
+        // Indicator flags
+        public const int SC_INDICFLAG_VALUEFORE = 1;
+        public const int SC_INDICVALUEBIT = 0x1000000;
+        public const int SC_INDICVALUEMASK = 0xFFFFFF;
+
+        // public const int INDIC0_MASK = 0x20;
+        // public const int INDIC1_MASK = 0x40;
+        // public const int INDIC2_MASK = 0x80;
+        // public const int INDICS_MASK = 0xE0;
+
+        public const int KEYWORDSET_MAX = 8;
+
+        // Alpha ranges
+        public const int SC_ALPHA_TRANSPARENT = 0;
+        public const int SC_ALPHA_OPAQUE = 255;
+        public const int SC_ALPHA_NOALPHA = 256;
+
+        // Automatic folding
+        public const int SC_AUTOMATICFOLD_SHOW = 0x0001;
+        public const int SC_AUTOMATICFOLD_CLICK = 0x0002;
+        public const int SC_AUTOMATICFOLD_CHANGE = 0x0004;
+
+        // Caret sticky behavior
+        public const int SC_CARETSTICKY_OFF = 0;
+        public const int SC_CARETSTICKY_ON = 1;
+        public const int SC_CARETSTICKY_WHITESPACE = 2;
+
+        // Encodings
+        public const int SC_CP_UTF8 = 65001;
+
+        // Cursors
+        public const int SC_CURSORNORMAL = -1;
+        public const int SC_CURSORARROW = 2;
+        public const int SC_CURSORWAIT = 4;
+        public const int SC_CURSORREVERSEARROW = 7;
+
+        // Font quality
+        public const int SC_EFF_QUALITY_DEFAULT = 0;
+        public const int SC_EFF_QUALITY_NON_ANTIALIASED = 1;
+        public const int SC_EFF_QUALITY_ANTIALIASED = 2;
+        public const int SC_EFF_QUALITY_LCD_OPTIMIZED = 3;
+
+        // End-of-line
+        public const int SC_EOL_CRLF = 0;
+        public const int SC_EOL_CR = 1;
+        public const int SC_EOL_LF = 2;
+
+        // Fold action
+        public const int SC_FOLDACTION_CONTRACT = 0;
+        public const int SC_FOLDACTION_EXPAND = 1;
+        public const int SC_FOLDACTION_TOGGLE = 2;
+
+        // Fold level
+        public const int SC_FOLDLEVELBASE = 0x400;
+        public const int SC_FOLDLEVELWHITEFLAG = 0x1000;
+        public const int SC_FOLDLEVELHEADERFLAG = 0x2000;
+        public const int SC_FOLDLEVELNUMBERMASK = 0x0FFF;
+
+        // Fold flags
+        public const int SC_FOLDFLAG_LINEBEFORE_EXPANDED = 0x0002;
+        public const int SC_FOLDFLAG_LINEBEFORE_CONTRACTED = 0x0004;
+        public const int SC_FOLDFLAG_LINEAFTER_EXPANDED = 0x0008;
+        public const int SC_FOLDFLAG_LINEAFTER_CONTRACTED = 0x0010;
+        public const int SC_FOLDFLAG_LEVELNUMBERS = 0x0040;
+        public const int SC_FOLDFLAG_LINESTATE = 0x0080;
+
+        // Fold display text
+        public const int SC_FOLDDISPLAYTEXT_HIDDEN = 0;
+        public const int SC_FOLDDISPLAYTEXT_STANDARD = 1;
+        public const int SC_FOLDDISPLAYTEXT_BOXED = 2;
+
+        // Line end type
+        public const int SC_LINE_END_TYPE_DEFAULT = 0;
+        public const int SC_LINE_END_TYPE_UNICODE = 1;
+
+        //Line layers
+        public const int SC_LAYER_BASE = 0;
+        public const int SC_LAYER_UNDER_TEXT = 1;
+        public const int SC_LAYER_OVER_TEXT = 2;
+
+        // Margins
+        public const int SC_MAX_MARGIN = 4;
+
+        public const int SC_MARGIN_SYMBOL = 0;
+        public const int SC_MARGIN_NUMBER = 1;
+        public const int SC_MARGIN_BACK = 2;
+        public const int SC_MARGIN_FORE = 3;
+        public const int SC_MARGIN_TEXT = 4;
+        public const int SC_MARGIN_RTEXT = 5;
+        public const int SC_MARGIN_COLOUR = 6;
+
+        public const int SC_MARGINOPTION_NONE = 0;
+        public const int SC_MARGINOPTION_SUBLINESELECT = 1;
+
+        // Markers
+        public const int MARKER_MAX = 31;
+        public const int SC_MARK_CIRCLE = 0;
+        public const int SC_MARK_ROUNDRECT = 1;
+        public const int SC_MARK_ARROW = 2;
+        public const int SC_MARK_SMALLRECT = 3;
+        public const int SC_MARK_SHORTARROW = 4;
+        public const int SC_MARK_EMPTY = 5;
+        public const int SC_MARK_ARROWDOWN = 6;
+        public const int SC_MARK_MINUS = 7;
+        public const int SC_MARK_PLUS = 8;
+        public const int SC_MARK_VLINE = 9;
+        public const int SC_MARK_LCORNER = 10;
+        public const int SC_MARK_TCORNER = 11;
+        public const int SC_MARK_BOXPLUS = 12;
+        public const int SC_MARK_BOXPLUSCONNECTED = 13;
+        public const int SC_MARK_BOXMINUS = 14;
+        public const int SC_MARK_BOXMINUSCONNECTED = 15;
+        public const int SC_MARK_LCORNERCURVE = 16;
+        public const int SC_MARK_TCORNERCURVE = 17;
+        public const int SC_MARK_CIRCLEPLUS = 18;
+        public const int SC_MARK_CIRCLEPLUSCONNECTED = 19;
+        public const int SC_MARK_CIRCLEMINUS = 20;
+        public const int SC_MARK_CIRCLEMINUSCONNECTED = 21;
+        public const int SC_MARK_BACKGROUND = 22;
+        public const int SC_MARK_DOTDOTDOT = 23;
+        public const int SC_MARK_ARROWS = 24;
+        public const int SC_MARK_PIXMAP = 25;
+        public const int SC_MARK_FULLRECT = 26;
+        public const int SC_MARK_LEFTRECT = 27;
+        public const int SC_MARK_AVAILABLE = 28;
+        public const int SC_MARK_UNDERLINE = 29;
+        public const int SC_MARK_RGBAIMAGE = 30;
+        public const int SC_MARK_BOOKMARK = 31;
+        public const int SC_MARK_VERTICALBOOKMARK = 32;
+        public const int SC_MARK_BAR = 33;
+        public const int SC_MARK_CHARACTER = 10000;
+        public const int SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN = 21;
+        public const int SC_MARKNUM_HISTORY_SAVED = 22;
+        public const int SC_MARKNUM_HISTORY_MODIFIED = 23;
+        public const int SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED = 24;
+        public const int SC_MARKNUM_FOLDEREND = 25;
+        public const int SC_MARKNUM_FOLDEROPENMID = 26;
+        public const int SC_MARKNUM_FOLDERMIDTAIL = 27;
+        public const int SC_MARKNUM_FOLDERTAIL = 28;
+        public const int SC_MARKNUM_FOLDERSUB = 29;
+        public const int SC_MARKNUM_FOLDER = 30;
+        public const int SC_MARKNUM_FOLDEROPEN = 31;
+        public const uint SC_MASK_FOLDERS = 0xFE000000;
+
+        public const int SC_MULTIPASTE_ONCE = 0;
+        public const int SC_MULTIPASTE_EACH = 1;
+
+        public const int SC_ORDER_PRESORTED = 0;
+        public const int SC_ORDER_PERFORMSORT = 1;
+        public const int SC_ORDER_CUSTOM = 2;
+
+        // Update notification reasons
+        public const int SC_UPDATE_CONTENT = 0x01;
+        public const int SC_UPDATE_SELECTION = 0x02;
+        public const int SC_UPDATE_V_SCROLL = 0x04;
+        public const int SC_UPDATE_H_SCROLL = 0x08;
+
+        // Modified notification types
+        public const int SC_MOD_INSERTTEXT = 0x1;
+        public const int SC_MOD_DELETETEXT = 0x2;
+        public const int SC_MOD_BEFOREINSERT = 0x400;
+        public const int SC_MOD_BEFOREDELETE = 0x800;
+        public const int SC_MOD_CHANGEANNOTATION = 0x20000;
+        public const int SC_MOD_INSERTCHECK = 0x100000;
+
+        // Modified flags
+        public const int SC_PERFORMED_USER = 0x10;
+        public const int SC_PERFORMED_UNDO = 0x20;
+        public const int SC_PERFORMED_REDO = 0x40;
+
+        // Status codes
+        public const int SC_STATUS_OK = 0;
+        public const int SC_STATUS_FAILURE = 1;
+        public const int SC_STATUS_BADALLOC = 2;
+        public const int SC_STATUS_WARN_START = 1000;
+        public const int SC_STATUS_WARN_REGEX = 1001;
+
+        // Dwell
+        public const int SC_TIME_FOREVER = 10000000;
+
+        // Property types
+        public const int SC_TYPE_BOOLEAN = 0;
+        public const int SC_TYPE_INTEGER = 1;
+        public const int SC_TYPE_STRING = 2;
+
+        // Search flags
+        public const int SCFIND_NONE = 0x0;
+        public const int SCFIND_WHOLEWORD = 0x2;
+        public const int SCFIND_MATCHCASE = 0x4;
+        public const int SCFIND_WORDSTART = 0x00100000;
+        public const int SCFIND_REGEXP = 0x00200000;
+        public const int SCFIND_POSIX = 0x00400000;
+        public const int SCFIND_CXX11REGEX = 0x00800000;
+
+        // Element colors
+        public const int SC_ELEMENT_LIST = 0;
+        public const int SC_ELEMENT_LIST_BACK = 1;
+        public const int SC_ELEMENT_LIST_SELECTED = 2;
+        public const int SC_ELEMENT_LIST_SELECTED_BACK = 3;
+        public const int SC_ELEMENT_SELECTION_TEXT = 10;
+        public const int SC_ELEMENT_SELECTION_BACK = 11;
+        public const int SC_ELEMENT_SELECTION_ADDITIONAL_TEXT = 12;
+        public const int SC_ELEMENT_SELECTION_ADDITIONAL_BACK = 13;
+        public const int SC_ELEMENT_SELECTION_SECONDARY_TEXT = 14;
+        public const int SC_ELEMENT_SELECTION_SECONDARY_BACK = 15;
+        public const int SC_ELEMENT_SELECTION_INACTIVE_TEXT = 16;
+        public const int SC_ELEMENT_SELECTION_INACTIVE_BACK = 17;
+        public const int SC_ELEMENT_SELECTION_INACTIVE_ADDITIONAL_TEXT = 18;
+        public const int SC_ELEMENT_SELECTION_INACTIVE_ADDITIONAL_BACK = 19;
+        public const int SC_ELEMENT_CARET = 40;
+        public const int SC_ELEMENT_CARET_ADDITIONAL = 41;
+        public const int SC_ELEMENT_CARET_LINE_BACK = 50;
+        public const int SC_ELEMENT_WHITE_SPACE = 60;
+        public const int SC_ELEMENT_WHITE_SPACE_BACK = 61;
+        public const int SC_ELEMENT_HOT_SPOT_ACTIVE = 70;
+        public const int SC_ELEMENT_HOT_SPOT_ACTIVE_BACK = 71;
+        public const int SC_ELEMENT_FOLD_LINE = 80;
+        public const int SC_ELEMENT_HIDDEN_LINE = 81;
+
+        // Change history
+        public const int SC_CHANGE_HISTORY_DISABLED = 0;
+        public const int SC_CHANGE_HISTORY_ENABLED = 1;
+        public const int SC_CHANGE_HISTORY_MARKERS = 2;
+        public const int SC_CHANGE_HISTORY_INDICATORS = 4;
+
+        // Functions
+        public const int SCI_START = 2000;
+        public const int SCI_OPTIONAL_START = 3000;
+        public const int SCI_LEXER_START = 4000;
+        public const int SCI_ADDTEXT = 2001;
+        public const int SCI_ADDSTYLEDTEXT = 2002;
+        public const int SCI_INSERTTEXT = 2003;
+        public const int SCI_CHANGEINSERTION = 2672;
+        public const int SCI_CLEARALL = 2004;
+        public const int SCI_DELETERANGE = 2645;
+        public const int SCI_CLEARDOCUMENTSTYLE = 2005;
+        public const int SCI_GETLENGTH = 2006;
+        public const int SCI_GETCHARAT = 2007;
+        public const int SCI_GETCURRENTPOS = 2008;
+        public const int SCI_GETANCHOR = 2009;
+        public const int SCI_GETSTYLEAT = 2010;
+        public const int SCI_REDO = 2011;
+        public const int SCI_SETUNDOCOLLECTION = 2012;
+        public const int SCI_SELECTALL = 2013;
+        public const int SCI_SETSAVEPOINT = 2014;
+        public const int SCI_GETSTYLEDTEXT = 2015;
+        public const int SCI_CANREDO = 2016;
+        public const int SCI_MARKERLINEFROMHANDLE = 2017;
+        public const int SCI_MARKERDELETEHANDLE = 2018;
+        public const int SCI_GETUNDOCOLLECTION = 2019;
+        public const int SCI_GETVIEWWS = 2020;
+        public const int SCI_SETVIEWWS = 2021;
+        public const int SCI_POSITIONFROMPOINT = 2022;
+        public const int SCI_POSITIONFROMPOINTCLOSE = 2023;
+        public const int SCI_GOTOLINE = 2024;
+        public const int SCI_GOTOPOS = 2025;
+        public const int SCI_SETANCHOR = 2026;
+        public const int SCI_GETCURLINE = 2027;
+        public const int SCI_GETENDSTYLED = 2028;
+        public const int SCI_CONVERTEOLS = 2029;
+        public const int SCI_GETEOLMODE = 2030;
+        public const int SCI_SETEOLMODE = 2031;
+        public const int SCI_STARTSTYLING = 2032;
+        public const int SCI_SETSTYLING = 2033;
+        public const int SCI_GETBUFFEREDDRAW = 2034;
+        public const int SCI_SETBUFFEREDDRAW = 2035;
+        public const int SCI_SETTABWIDTH = 2036;
+        public const int SCI_GETTABWIDTH = 2121;
+        public const int SCI_CLEARTABSTOPS = 2675;
+        public const int SCI_ADDTABSTOP = 2676;
+        public const int SCI_GETNEXTTABSTOP = 2677;
+        public const int SCI_SETCODEPAGE = 2037;
+        public const int SCI_MARKERDEFINE = 2040;
+        public const int SCI_MARKERSETFORE = 2041;
+        public const int SCI_MARKERSETBACK = 2042;
+        public const int SCI_MARKERSETFORETRANSLUCENT = 2294;
+        public const int SCI_MARKERSETBACKTRANSLUCENT = 2295;
+        public const int SCI_MARKERSETBACKSELECTED = 2292;
+        public const int SCI_MARKERENABLEHIGHLIGHT = 2293;
+        public const int SCI_MARKERADD = 2043;
+        public const int SCI_MARKERDELETE = 2044;
+        public const int SCI_MARKERDELETEALL = 2045;
+        public const int SCI_MARKERGET = 2046;
+        public const int SCI_MARKERNEXT = 2047;
+        public const int SCI_MARKERPREVIOUS = 2048;
+        public const int SCI_MARKERDEFINEPIXMAP = 2049;
+        public const int SCI_MARKERADDSET = 2466;
+        public const int SCI_MARKERSETALPHA = 2476;
+        public const int SCI_SETMARGINTYPEN = 2240;
+        public const int SCI_GETMARGINTYPEN = 2241;
+        public const int SCI_SETMARGINWIDTHN = 2242;
+        public const int SCI_GETMARGINWIDTHN = 2243;
+        public const int SCI_SETMARGINMASKN = 2244;
+        public const int SCI_GETMARGINMASKN = 2245;
+        public const int SCI_SETMARGINSENSITIVEN = 2246;
+        public const int SCI_GETMARGINSENSITIVEN = 2247;
+        public const int SCI_SETMARGINCURSORN = 2248;
+        public const int SCI_GETMARGINCURSORN = 2249;
+        public const int SCI_SETMARGINBACKN = 2250;
+        public const int SCI_GETMARGINBACKN = 2251;
+        public const int SCI_SETMARGINS = 2252;
+        public const int SCI_GETMARGINS = 2253;
+        public const int SCI_STYLECLEARALL = 2050;
+        public const int SCI_STYLESETFORE = 2051;
+        public const int SCI_STYLESETBACK = 2052;
+        public const int SCI_STYLESETBOLD = 2053;
+        public const int SCI_STYLESETITALIC = 2054;
+        public const int SCI_STYLESETSIZE = 2055;
+        public const int SCI_STYLESETFONT = 2056;
+        public const int SCI_STYLESETEOLFILLED = 2057;
+        public const int SCI_STYLERESETDEFAULT = 2058;
+        public const int SCI_STYLESETUNDERLINE = 2059;
+        public const int SCI_STYLEGETFORE = 2481;
+        public const int SCI_STYLEGETBACK = 2482;
+        public const int SCI_STYLEGETBOLD = 2483;
+        public const int SCI_STYLEGETITALIC = 2484;
+        public const int SCI_STYLEGETSIZE = 2485;
+        public const int SCI_STYLEGETFONT = 2486;
+        public const int SCI_STYLEGETEOLFILLED = 2487;
+        public const int SCI_STYLEGETUNDERLINE = 2488;
+        public const int SCI_STYLEGETCASE = 2489;
+        public const int SCI_STYLEGETCHARACTERSET = 2490;
+        public const int SCI_STYLEGETVISIBLE = 2491;
+        public const int SCI_STYLEGETCHANGEABLE = 2492;
+        public const int SCI_STYLEGETHOTSPOT = 2493;
+        public const int SCI_STYLESETCASE = 2060;
+        public const int SCI_STYLESETSIZEFRACTIONAL = 2061;
+        public const int SCI_STYLEGETSIZEFRACTIONAL = 2062;
+        public const int SCI_STYLESETWEIGHT = 2063;
+        public const int SCI_STYLEGETWEIGHT = 2064;
+        public const int SCI_STYLESETCHARACTERSET = 2066;
+        public const int SCI_STYLESETHOTSPOT = 2409;
+        public const int SCI_SETSELFORE = 2067;
+        public const int SCI_SETSELBACK = 2068;
+        public const int SCI_GETSELALPHA = 2477;
+        public const int SCI_SETSELALPHA = 2478;
+        public const int SCI_GETSELEOLFILLED = 2479;
+        public const int SCI_SETSELEOLFILLED = 2480;
+        public const int SCI_SETCARETFORE = 2069;
+        public const int SCI_ASSIGNCMDKEY = 2070;
+        public const int SCI_CLEARCMDKEY = 2071;
+        public const int SCI_CLEARALLCMDKEYS = 2072;
+        public const int SCI_SETSTYLINGEX = 2073;
+        public const int SCI_STYLESETVISIBLE = 2074;
+        public const int SCI_GETCARETPERIOD = 2075;
+        public const int SCI_SETCARETPERIOD = 2076;
+        public const int SCI_SETWORDCHARS = 2077;
+        public const int SCI_GETWORDCHARS = 2646;
+        public const int SCI_BEGINUNDOACTION = 2078;
+        public const int SCI_ENDUNDOACTION = 2079;
+        public const int SCI_INDICSETSTYLE = 2080;
+        public const int SCI_INDICGETSTYLE = 2081;
+        public const int SCI_INDICSETFORE = 2082;
+        public const int SCI_INDICGETFORE = 2083;
+        public const int SCI_INDICSETUNDER = 2510;
+        public const int SCI_INDICGETUNDER = 2511;
+        public const int SCI_INDICSETHOVERSTYLE = 2680;
+        public const int SCI_INDICGETHOVERSTYLE = 2681;
+        public const int SCI_INDICSETHOVERFORE = 2682;
+        public const int SCI_INDICGETHOVERFORE = 2683;
+        public const int SCI_INDICSETFLAGS = 2684;
+        public const int SCI_INDICGETFLAGS = 2685;
+        public const int SCI_SETWHITESPACEFORE = 2084;
+        public const int SCI_SETWHITESPACEBACK = 2085;
+        public const int SCI_SETWHITESPACESIZE = 2086;
+        public const int SCI_GETWHITESPACESIZE = 2087;
+        // public const int SCI_SETSTYLEBITS = 2090;
+        // public const int SCI_GETSTYLEBITS = 2091;
+        public const int SCI_SETLINESTATE = 2092;
+        public const int SCI_GETLINESTATE = 2093;
+        public const int SCI_GETMAXLINESTATE = 2094;
+        public const int SCI_GETCARETLINEVISIBLE = 2095;
+        public const int SCI_SETCARETLINEVISIBLE = 2096;
+        public const int SCI_GETCARETLINEBACK = 2097;
+        public const int SCI_SETCARETLINEBACK = 2098;
+        public const int SCI_STYLESETCHANGEABLE = 2099;
+        public const int SCI_AUTOCSHOW = 2100;
+        public const int SCI_AUTOCCANCEL = 2101;
+        public const int SCI_AUTOCACTIVE = 2102;
+        public const int SCI_AUTOCPOSSTART = 2103;
+        public const int SCI_AUTOCCOMPLETE = 2104;
+        public const int SCI_AUTOCSTOPS = 2105;
+        public const int SCI_AUTOCSETSEPARATOR = 2106;
+        public const int SCI_AUTOCGETSEPARATOR = 2107;
+        public const int SCI_AUTOCSELECT = 2108;
+        public const int SCI_AUTOCSETCANCELATSTART = 2110;
+        public const int SCI_AUTOCGETCANCELATSTART = 2111;
+        public const int SCI_AUTOCSETFILLUPS = 2112;
+        public const int SCI_AUTOCSETCHOOSESINGLE = 2113;
+        public const int SCI_AUTOCGETCHOOSESINGLE = 2114;
+        public const int SCI_AUTOCSETIGNORECASE = 2115;
+        public const int SCI_AUTOCGETIGNORECASE = 2116;
+        public const int SCI_USERLISTSHOW = 2117;
+        public const int SCI_AUTOCSETAUTOHIDE = 2118;
+        public const int SCI_AUTOCGETAUTOHIDE = 2119;
+        public const int SCI_AUTOCSETDROPRESTOFWORD = 2270;
+        public const int SCI_AUTOCGETDROPRESTOFWORD = 2271;
+        public const int SCI_REGISTERIMAGE = 2405;
+        public const int SCI_CLEARREGISTEREDIMAGES = 2408;
+        public const int SCI_AUTOCGETTYPESEPARATOR = 2285;
+        public const int SCI_AUTOCSETTYPESEPARATOR = 2286;
+        public const int SCI_AUTOCSETMAXWIDTH = 2208;
+        public const int SCI_AUTOCGETMAXWIDTH = 2209;
+        public const int SCI_AUTOCSETMAXHEIGHT = 2210;
+        public const int SCI_AUTOCGETMAXHEIGHT = 2211;
+        public const int SCI_SETINDENT = 2122;
+        public const int SCI_GETINDENT = 2123;
+        public const int SCI_SETUSETABS = 2124;
+        public const int SCI_GETUSETABS = 2125;
+        public const int SCI_SETLINEINDENTATION = 2126;
+        public const int SCI_GETLINEINDENTATION = 2127;
+        public const int SCI_GETLINEINDENTPOSITION = 2128;
+        public const int SCI_GETCOLUMN = 2129;
+        public const int SCI_COUNTCHARACTERS = 2633;
+        public const int SCI_SETHSCROLLBAR = 2130;
+        public const int SCI_GETHSCROLLBAR = 2131;
+        public const int SCI_SETINDENTATIONGUIDES = 2132;
+        public const int SCI_GETINDENTATIONGUIDES = 2133;
+        public const int SCI_SETHIGHLIGHTGUIDE = 2134;
+        public const int SCI_GETHIGHLIGHTGUIDE = 2135;
+        public const int SCI_GETLINEENDPOSITION = 2136;
+        public const int SCI_GETCODEPAGE = 2137;
+        public const int SCI_GETCARETFORE = 2138;
+        public const int SCI_GETREADONLY = 2140;
+        public const int SCI_SETCURRENTPOS = 2141;
+        public const int SCI_SETSELECTIONSTART = 2142;
+        public const int SCI_GETSELECTIONSTART = 2143;
+        public const int SCI_SETSELECTIONEND = 2144;
+        public const int SCI_GETSELECTIONEND = 2145;
+        public const int SCI_SETEMPTYSELECTION = 2556;
+        public const int SCI_SETPRINTMAGNIFICATION = 2146;
+        public const int SCI_GETPRINTMAGNIFICATION = 2147;
+        public const int SCI_SETPRINTCOLOURMODE = 2148;
+        public const int SCI_GETPRINTCOLOURMODE = 2149;
+        public const int SCI_FINDTEXT = 2150;
+        public const int SCI_FORMATRANGE = 2151;
+        public const int SCI_GETFIRSTVISIBLELINE = 2152;
+        public const int SCI_GETLINE = 2153;
+        public const int SCI_GETLINECOUNT = 2154;
+        public const int SCI_SETMARGINLEFT = 2155;
+        public const int SCI_GETMARGINLEFT = 2156;
+        public const int SCI_SETMARGINRIGHT = 2157;
+        public const int SCI_GETMARGINRIGHT = 2158;
+        public const int SCI_GETMODIFY = 2159;
+        public const int SCI_SETSEL = 2160;
+        public const int SCI_GETSELTEXT = 2161;
+        public const int SCI_GETTEXTRANGE = 2162;
+        public const int SCI_HIDESELECTION = 2163;
+        public const int SCI_POINTXFROMPOSITION = 2164;
+        public const int SCI_POINTYFROMPOSITION = 2165;
+        public const int SCI_LINEFROMPOSITION = 2166;
+        public const int SCI_POSITIONFROMLINE = 2167;
+        public const int SCI_LINESCROLL = 2168;
+        public const int SCI_SCROLLCARET = 2169;
+        public const int SCI_SCROLLRANGE = 2569;
+        public const int SCI_REPLACESEL = 2170;
+        public const int SCI_SETREADONLY = 2171;
+        public const int SCI_NULL = 2172;
+        public const int SCI_CANPASTE = 2173;
+        public const int SCI_CANUNDO = 2174;
+        public const int SCI_EMPTYUNDOBUFFER = 2175;
+        public const int SCI_UNDO = 2176;
+        public const int SCI_CUT = 2177;
+        public const int SCI_COPY = 2178;
+        public const int SCI_PASTE = 2179;
+        public const int SCI_CLEAR = 2180;
+        public const int SCI_SETTEXT = 2181;
+        public const int SCI_GETTEXT = 2182;
+        public const int SCI_GETTEXTLENGTH = 2183;
+        public const int SCI_GETDIRECTFUNCTION = 2184;
+        public const int SCI_GETDIRECTPOINTER = 2185;
+        public const int SCI_SETOVERTYPE = 2186;
+        public const int SCI_GETOVERTYPE = 2187;
+        public const int SCI_SETCARETWIDTH = 2188;
+        public const int SCI_GETCARETWIDTH = 2189;
+        public const int SCI_SETTARGETSTART = 2190;
+        public const int SCI_GETTARGETSTART = 2191;
+        public const int SCI_SETTARGETEND = 2192;
+        public const int SCI_GETTARGETEND = 2193;
+        public const int SCI_REPLACETARGET = 2194;
+        public const int SCI_REPLACETARGETRE = 2195;
+        public const int SCI_FINDTEXTFULL = 2196;
+        public const int SCI_SEARCHINTARGET = 2197;
+        public const int SCI_SETSEARCHFLAGS = 2198;
+        public const int SCI_GETSEARCHFLAGS = 2199;
+        public const int SCI_CALLTIPSHOW = 2200;
+        public const int SCI_CALLTIPCANCEL = 2201;
+        public const int SCI_CALLTIPACTIVE = 2202;
+        public const int SCI_CALLTIPPOSSTART = 2203;
+        public const int SCI_CALLTIPSETPOSSTART = 2214;
+        public const int SCI_CALLTIPSETHLT = 2204;
+        public const int SCI_CALLTIPSETBACK = 2205;
+        public const int SCI_CALLTIPSETFORE = 2206;
+        public const int SCI_CALLTIPSETFOREHLT = 2207;
+        public const int SCI_CALLTIPUSESTYLE = 2212;
+        public const int SCI_CALLTIPSETPOSITION = 2213;
+        public const int SCI_VISIBLEFROMDOCLINE = 2220;
+        public const int SCI_DOCLINEFROMVISIBLE = 2221;
+        public const int SCI_WRAPCOUNT = 2235;
+        public const int SCI_SETFOLDLEVEL = 2222;
+        public const int SCI_GETFOLDLEVEL = 2223;
+        public const int SCI_GETLASTCHILD = 2224;
+        public const int SCI_GETFOLDPARENT = 2225;
+        public const int SCI_SHOWLINES = 2226;
+        public const int SCI_HIDELINES = 2227;
+        public const int SCI_GETLINEVISIBLE = 2228;
+        public const int SCI_GETALLLINESVISIBLE = 2236;
+        public const int SCI_SETFOLDEXPANDED = 2229;
+        public const int SCI_GETFOLDEXPANDED = 2230;
+        public const int SCI_TOGGLEFOLD = 2231;
+        public const int SCI_FOLDLINE = 2237;
+        public const int SCI_FOLDCHILDREN = 2238;
+        public const int SCI_EXPANDCHILDREN = 2239;
+        public const int SCI_FOLDALL = 2662;
+        public const int SCI_ENSUREVISIBLE = 2232;
+        public const int SCI_SETAUTOMATICFOLD = 2663;
+        public const int SCI_GETAUTOMATICFOLD = 2664;
+        public const int SCI_SETFOLDFLAGS = 2233;
+        public const int SCI_ENSUREVISIBLEENFORCEPOLICY = 2234;
+        public const int SCI_SETTABINDENTS = 2260;
+        public const int SCI_GETTABINDENTS = 2261;
+        public const int SCI_SETBACKSPACEUNINDENTS = 2262;
+        public const int SCI_GETBACKSPACEUNINDENTS = 2263;
+        public const int SCI_SETMOUSEDWELLTIME = 2264;
+        public const int SCI_GETMOUSEDWELLTIME = 2265;
+        public const int SCI_WORDSTARTPOSITION = 2266;
+        public const int SCI_WORDENDPOSITION = 2267;
+        public const int SCI_ISRANGEWORD = 2691;
+        public const int SCI_SETWRAPMODE = 2268;
+        public const int SCI_GETWRAPMODE = 2269;
+        public const int SCI_SETWRAPVISUALFLAGS = 2460;
+        public const int SCI_GETWRAPVISUALFLAGS = 2461;
+        public const int SCI_SETWRAPVISUALFLAGSLOCATION = 2462;
+        public const int SCI_GETWRAPVISUALFLAGSLOCATION = 2463;
+        public const int SCI_SETWRAPSTARTINDENT = 2464;
+        public const int SCI_GETWRAPSTARTINDENT = 2465;
+        public const int SCI_SETWRAPINDENTMODE = 2472;
+        public const int SCI_GETWRAPINDENTMODE = 2473;
+        public const int SCI_SETLAYOUTCACHE = 2272;
+        public const int SCI_GETLAYOUTCACHE = 2273;
+        public const int SCI_SETSCROLLWIDTH = 2274;
+        public const int SCI_GETSCROLLWIDTH = 2275;
+        public const int SCI_SETSCROLLWIDTHTRACKING = 2516;
+        public const int SCI_GETSCROLLWIDTHTRACKING = 2517;
+        public const int SCI_TEXTWIDTH = 2276;
+        public const int SCI_SETENDATLASTLINE = 2277;
+        public const int SCI_GETENDATLASTLINE = 2278;
+        public const int SCI_TEXTHEIGHT = 2279;
+        public const int SCI_SETVSCROLLBAR = 2280;
+        public const int SCI_GETVSCROLLBAR = 2281;
+        public const int SCI_APPENDTEXT = 2282;
+        public const int SCI_GETTWOPHASEDRAW = 2283;
+        public const int SCI_SETTWOPHASEDRAW = 2284;
+        public const int SCI_GETPHASESDRAW = 2673;
+        public const int SCI_SETPHASESDRAW = 2674;
+        public const int SCI_SETFONTQUALITY = 2611;
+        public const int SCI_GETFONTQUALITY = 2612;
+        public const int SCI_SETFIRSTVISIBLELINE = 2613;
+        public const int SCI_SETMULTIPASTE = 2614;
+        public const int SCI_GETMULTIPASTE = 2615;
+        public const int SCI_GETTAG = 2616;
+        public const int SCI_TARGETFROMSELECTION = 2287;
+        public const int SCI_TARGETWHOLEDOCUMENT = 2690;
+        public const int SCI_LINESJOIN = 2288;
+        public const int SCI_LINESSPLIT = 2289;
+        public const int SCI_SETFOLDMARGINCOLOUR = 2290;
+        public const int SCI_SETFOLDMARGINHICOLOUR = 2291;
+        public const int SCI_LINEDOWN = 2300;
+        public const int SCI_LINEDOWNEXTEND = 2301;
+        public const int SCI_LINEUP = 2302;
+        public const int SCI_LINEUPEXTEND = 2303;
+        public const int SCI_CHARLEFT = 2304;
+        public const int SCI_CHARLEFTEXTEND = 2305;
+        public const int SCI_CHARRIGHT = 2306;
+        public const int SCI_CHARRIGHTEXTEND = 2307;
+        public const int SCI_WORDLEFT = 2308;
+        public const int SCI_WORDLEFTEXTEND = 2309;
+        public const int SCI_WORDRIGHT = 2310;
+        public const int SCI_WORDRIGHTEXTEND = 2311;
+        public const int SCI_HOME = 2312;
+        public const int SCI_HOMEEXTEND = 2313;
+        public const int SCI_LINEEND = 2314;
+        public const int SCI_LINEENDEXTEND = 2315;
+        public const int SCI_DOCUMENTSTART = 2316;
+        public const int SCI_DOCUMENTSTARTEXTEND = 2317;
+        public const int SCI_DOCUMENTEND = 2318;
+        public const int SCI_DOCUMENTENDEXTEND = 2319;
+        public const int SCI_PAGEUP = 2320;
+        public const int SCI_PAGEUPEXTEND = 2321;
+        public const int SCI_PAGEDOWN = 2322;
+        public const int SCI_PAGEDOWNEXTEND = 2323;
+        public const int SCI_EDITTOGGLEOVERTYPE = 2324;
+        public const int SCI_CANCEL = 2325;
+        public const int SCI_DELETEBACK = 2326;
+        public const int SCI_TAB = 2327;
+        public const int SCI_BACKTAB = 2328;
+        public const int SCI_NEWLINE = 2329;
+        public const int SCI_FORMFEED = 2330;
+        public const int SCI_VCHOME = 2331;
+        public const int SCI_VCHOMEEXTEND = 2332;
+        public const int SCI_ZOOMIN = 2333;
+        public const int SCI_ZOOMOUT = 2334;
+        public const int SCI_DELWORDLEFT = 2335;
+        public const int SCI_DELWORDRIGHT = 2336;
+        public const int SCI_DELWORDRIGHTEND = 2518;
+        public const int SCI_LINECUT = 2337;
+        public const int SCI_LINEDELETE = 2338;
+        public const int SCI_LINETRANSPOSE = 2339;
+        public const int SCI_LINEDUPLICATE = 2404;
+        public const int SCI_LOWERCASE = 2340;
+        public const int SCI_UPPERCASE = 2341;
+        public const int SCI_LINESCROLLDOWN = 2342;
+        public const int SCI_LINESCROLLUP = 2343;
+        public const int SCI_DELETEBACKNOTLINE = 2344;
+        public const int SCI_HOMEDISPLAY = 2345;
+        public const int SCI_HOMEDISPLAYEXTEND = 2346;
+        public const int SCI_LINEENDDISPLAY = 2347;
+        public const int SCI_LINEENDDISPLAYEXTEND = 2348;
+        public const int SCI_HOMEWRAP = 2349;
+        public const int SCI_LINEREVERSE = 2354;
+        public const int SCI_HOMEWRAPEXTEND = 2450;
+        public const int SCI_LINEENDWRAP = 2451;
+        public const int SCI_LINEENDWRAPEXTEND = 2452;
+        public const int SCI_VCHOMEWRAP = 2453;
+        public const int SCI_VCHOMEWRAPEXTEND = 2454;
+        public const int SCI_LINECOPY = 2455;
+        public const int SCI_MOVECARETINSIDEVIEW = 2401;
+        public const int SCI_LINELENGTH = 2350;
+        public const int SCI_BRACEHIGHLIGHT = 2351;
+        public const int SCI_BRACEHIGHLIGHTINDICATOR = 2498;
+        public const int SCI_BRACEBADLIGHT = 2352;
+        public const int SCI_BRACEBADLIGHTINDICATOR = 2499;
+        public const int SCI_BRACEMATCH = 2353;
+        public const int SCI_GETVIEWEOL = 2355;
+        public const int SCI_SETVIEWEOL = 2356;
+        public const int SCI_GETDOCPOINTER = 2357;
+        public const int SCI_SETDOCPOINTER = 2358;
+        public const int SCI_SETMODEVENTMASK = 2359;
+        public const int SCI_GETEDGECOLUMN = 2360;
+        public const int SCI_SETEDGECOLUMN = 2361;
+        public const int SCI_GETEDGEMODE = 2362;
+        public const int SCI_SETEDGEMODE = 2363;
+        public const int SCI_GETEDGECOLOUR = 2364;
+        public const int SCI_SETEDGECOLOUR = 2365;
+        public const int SCI_SEARCHANCHOR = 2366;
+        public const int SCI_SEARCHNEXT = 2367;
+        public const int SCI_SEARCHPREV = 2368;
+        public const int SCI_LINESONSCREEN = 2370;
+        public const int SCI_USEPOPUP = 2371;
+        public const int SCI_SELECTIONISRECTANGLE = 2372;
+        public const int SCI_SETZOOM = 2373;
+        public const int SCI_GETZOOM = 2374;
+        public const int SCI_CREATEDOCUMENT = 2375;
+        public const int SCI_ADDREFDOCUMENT = 2376;
+        public const int SCI_RELEASEDOCUMENT = 2377;
+        public const int SCI_GETMODEVENTMASK = 2378;
+        public const int SCI_SETFOCUS = 2380;
+        public const int SCI_GETFOCUS = 2381;
+        public const int SCI_SETSTATUS = 2382;
+        public const int SCI_GETSTATUS = 2383;
+        public const int SCI_SETMOUSEDOWNCAPTURES = 2384;
+        public const int SCI_GETMOUSEDOWNCAPTURES = 2385;
+        public const int SCI_SETCURSOR = 2386;
+        public const int SCI_GETCURSOR = 2387;
+        public const int SCI_SETCONTROLCHARSYMBOL = 2388;
+        public const int SCI_GETCONTROLCHARSYMBOL = 2389;
+        public const int SCI_WORDPARTLEFT = 2390;
+        public const int SCI_WORDPARTLEFTEXTEND = 2391;
+        public const int SCI_WORDPARTRIGHT = 2392;
+        public const int SCI_WORDPARTRIGHTEXTEND = 2393;
+        public const int SCI_SETVISIBLEPOLICY = 2394;
+        public const int SCI_DELLINELEFT = 2395;
+        public const int SCI_DELLINERIGHT = 2396;
+        public const int SCI_SETXOFFSET = 2397;
+        public const int SCI_GETXOFFSET = 2398;
+        public const int SCI_CHOOSECARETX = 2399;
+        public const int SCI_GRABFOCUS = 2400;
+        public const int SCI_SETXCARETPOLICY = 2402;
+        public const int SCI_SETYCARETPOLICY = 2403;
+        public const int SCI_SETPRINTWRAPMODE = 2406;
+        public const int SCI_GETPRINTWRAPMODE = 2407;
+        public const int SCI_SETHOTSPOTACTIVEFORE = 2410;
+        public const int SCI_GETHOTSPOTACTIVEFORE = 2494;
+        public const int SCI_SETHOTSPOTACTIVEBACK = 2411;
+        public const int SCI_GETHOTSPOTACTIVEBACK = 2495;
+        public const int SCI_SETHOTSPOTACTIVEUNDERLINE = 2412;
+        public const int SCI_GETHOTSPOTACTIVEUNDERLINE = 2496;
+        public const int SCI_SETHOTSPOTSINGLELINE = 2421;
+        public const int SCI_GETHOTSPOTSINGLELINE = 2497;
+        public const int SCI_PARADOWN = 2413;
+        public const int SCI_PARADOWNEXTEND = 2414;
+        public const int SCI_PARAUP = 2415;
+        public const int SCI_PARAUPEXTEND = 2416;
+        // public const int SCI_POSITIONBEFORE = 2417; // Bad, bad, bad. Don't use these...
+        // public const int SCI_POSITIONAFTER = 2418;  // they treat \r\n as one character.
+        public const int SCI_POSITIONRELATIVE = 2670;
+        public const int SCI_COPYRANGE = 2419;
+        public const int SCI_COPYTEXT = 2420;
+        public const int SCI_SETSELECTIONMODE = 2422;
+        public const int SCI_GETSELECTIONMODE = 2423;
+        public const int SCI_GETLINESELSTARTPOSITION = 2424;
+        public const int SCI_GETLINESELENDPOSITION = 2425;
+        public const int SCI_LINEDOWNRECTEXTEND = 2426;
+        public const int SCI_LINEUPRECTEXTEND = 2427;
+        public const int SCI_CHARLEFTRECTEXTEND = 2428;
+        public const int SCI_CHARRIGHTRECTEXTEND = 2429;
+        public const int SCI_HOMERECTEXTEND = 2430;
+        public const int SCI_VCHOMERECTEXTEND = 2431;
+        public const int SCI_LINEENDRECTEXTEND = 2432;
+        public const int SCI_PAGEUPRECTEXTEND = 2433;
+        public const int SCI_PAGEDOWNRECTEXTEND = 2434;
+        public const int SCI_STUTTEREDPAGEUP = 2435;
+        public const int SCI_STUTTEREDPAGEUPEXTEND = 2436;
+        public const int SCI_STUTTEREDPAGEDOWN = 2437;
+        public const int SCI_STUTTEREDPAGEDOWNEXTEND = 2438;
+        public const int SCI_WORDLEFTEND = 2439;
+        public const int SCI_WORDLEFTENDEXTEND = 2440;
+        public const int SCI_WORDRIGHTEND = 2441;
+        public const int SCI_WORDRIGHTENDEXTEND = 2442;
+        public const int SCI_SETWHITESPACECHARS = 2443;
+        public const int SCI_GETWHITESPACECHARS = 2647;
+        public const int SCI_SETPUNCTUATIONCHARS = 2648;
+        public const int SCI_GETPUNCTUATIONCHARS = 2649;
+        public const int SCI_SETCHARSDEFAULT = 2444;
+        public const int SCI_AUTOCGETCURRENT = 2445;
+        public const int SCI_AUTOCGETCURRENTTEXT = 2610;
+        public const int SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR = 2634;
+        public const int SCI_AUTOCGETCASEINSENSITIVEBEHAVIOUR = 2635;
+        public const int SCI_AUTOCSETMULTI = 2636;
+        public const int SCI_AUTOCGETMULTI = 2637;
+        public const int SCI_AUTOCSETORDER = 2660;
+        public const int SCI_AUTOCGETORDER = 2661;
+        public const int SCI_ALLOCATE = 2446;
+        public const int SCI_TARGETASUTF8 = 2447;
+        public const int SCI_SETLENGTHFORENCODE = 2448;
+        public const int SCI_ENCODEDFROMUTF8 = 2449;
+        public const int SCI_FINDCOLUMN = 2456;
+        public const int SCI_GETCARETSTICKY = 2457;
+        public const int SCI_SETCARETSTICKY = 2458;
+        public const int SCI_TOGGLECARETSTICKY = 2459;
+        public const int SCI_SETPASTECONVERTENDINGS = 2467;
+        public const int SCI_GETPASTECONVERTENDINGS = 2468;
+        public const int SCI_SELECTIONDUPLICATE = 2469;
+        public const int SCI_SETCARETLINEBACKALPHA = 2470;
+        public const int SCI_GETCARETLINEBACKALPHA = 2471;
+        public const int SCI_SETCARETSTYLE = 2512;
+        public const int SCI_GETCARETSTYLE = 2513;
+        public const int SCI_SETINDICATORCURRENT = 2500;
+        public const int SCI_GETINDICATORCURRENT = 2501;
+        public const int SCI_SETINDICATORVALUE = 2502;
+        public const int SCI_GETINDICATORVALUE = 2503;
+        public const int SCI_INDICATORFILLRANGE = 2504;
+        public const int SCI_INDICATORCLEARRANGE = 2505;
+        public const int SCI_INDICATORALLONFOR = 2506;
+        public const int SCI_INDICATORVALUEAT = 2507;
+        public const int SCI_INDICATORSTART = 2508;
+        public const int SCI_INDICATOREND = 2509;
+        public const int SCI_SETPOSITIONCACHE = 2514;
+        public const int SCI_GETPOSITIONCACHE = 2515;
+        public const int SCI_COPYALLOWLINE = 2519;
+        public const int SCI_GETCHARACTERPOINTER = 2520;
+        public const int SCI_GETRANGEPOINTER = 2643;
+        public const int SCI_GETGAPPOSITION = 2644;
+        public const int SCI_INDICSETALPHA = 2523;
+        public const int SCI_INDICGETALPHA = 2524;
+        public const int SCI_INDICSETOUTLINEALPHA = 2558;
+        public const int SCI_INDICGETOUTLINEALPHA = 2559;
+        public const int SCI_SETEXTRAASCENT = 2525;
+        public const int SCI_GETEXTRAASCENT = 2526;
+        public const int SCI_SETEXTRADESCENT = 2527;
+        public const int SCI_GETEXTRADESCENT = 2528;
+        public const int SCI_MARKERSYMBOLDEFINED = 2529;
+        public const int SCI_MARGINSETTEXT = 2530;
+        public const int SCI_MARGINGETTEXT = 2531;
+        public const int SCI_MARGINSETSTYLE = 2532;
+        public const int SCI_MARGINGETSTYLE = 2533;
+        public const int SCI_MARGINSETSTYLES = 2534;
+        public const int SCI_MARGINGETSTYLES = 2535;
+        public const int SCI_MARGINTEXTCLEARALL = 2536;
+        public const int SCI_MARGINSETSTYLEOFFSET = 2537;
+        public const int SCI_MARGINGETSTYLEOFFSET = 2538;
+        public const int SCI_SETMARGINOPTIONS = 2539;
+        public const int SCI_GETMARGINOPTIONS = 2557;
+        public const int SCI_ANNOTATIONSETTEXT = 2540;
+        public const int SCI_ANNOTATIONGETTEXT = 2541;
+        public const int SCI_ANNOTATIONSETSTYLE = 2542;
+        public const int SCI_ANNOTATIONGETSTYLE = 2543;
+        public const int SCI_ANNOTATIONSETSTYLES = 2544;
+        public const int SCI_ANNOTATIONGETSTYLES = 2545;
+        public const int SCI_ANNOTATIONGETLINES = 2546;
+        public const int SCI_ANNOTATIONCLEARALL = 2547;
+        public const int SCI_ANNOTATIONSETVISIBLE = 2548;
+        public const int SCI_ANNOTATIONGETVISIBLE = 2549;
+        public const int SCI_ANNOTATIONSETSTYLEOFFSET = 2550;
+        public const int SCI_ANNOTATIONGETSTYLEOFFSET = 2551;
+        public const int SCI_RELEASEALLEXTENDEDSTYLES = 2552;
+        public const int SCI_ALLOCATEEXTENDEDSTYLES = 2553;
+        public const int SCI_ADDUNDOACTION = 2560;
+        public const int SCI_CHARPOSITIONFROMPOINT = 2561;
+        public const int SCI_CHARPOSITIONFROMPOINTCLOSE = 2562;
+        public const int SCI_SETMOUSESELECTIONRECTANGULARSWITCH = 2668;
+        public const int SCI_GETMOUSESELECTIONRECTANGULARSWITCH = 2669;
+        public const int SCI_SETMULTIPLESELECTION = 2563;
+        public const int SCI_GETMULTIPLESELECTION = 2564;
+        public const int SCI_SETADDITIONALSELECTIONTYPING = 2565;
+        public const int SCI_GETADDITIONALSELECTIONTYPING = 2566;
+        public const int SCI_SETADDITIONALCARETSBLINK = 2567;
+        public const int SCI_GETADDITIONALCARETSBLINK = 2568;
+        public const int SCI_SETADDITIONALCARETSVISIBLE = 2608;
+        public const int SCI_GETADDITIONALCARETSVISIBLE = 2609;
+        public const int SCI_GETTABDRAWMODE = 2698;
+        public const int SCI_SETTABDRAWMODE = 2699;
+        public const int SCI_GETSELECTIONS = 2570;
+        public const int SCI_GETSELECTIONEMPTY = 2650;
+        public const int SCI_CLEARSELECTIONS = 2571;
+        public const int SCI_SETSELECTION = 2572;
+        public const int SCI_ADDSELECTION = 2573;
+        public const int SCI_DROPSELECTIONN = 2671;
+        public const int SCI_SETMAINSELECTION = 2574;
+        public const int SCI_GETMAINSELECTION = 2575;
+        public const int SCI_SETSELECTIONNCARET = 2576;
+        public const int SCI_GETSELECTIONNCARET = 2577;
+        public const int SCI_SETSELECTIONNANCHOR = 2578;
+        public const int SCI_GETSELECTIONNANCHOR = 2579;
+        public const int SCI_SETSELECTIONNCARETVIRTUALSPACE = 2580;
+        public const int SCI_GETSELECTIONNCARETVIRTUALSPACE = 2581;
+        public const int SCI_SETSELECTIONNANCHORVIRTUALSPACE = 2582;
+        public const int SCI_GETSELECTIONNANCHORVIRTUALSPACE = 2583;
+        public const int SCI_SETSELECTIONNSTART = 2584;
+        public const int SCI_GETSELECTIONNSTART = 2585;
+        public const int SCI_SETSELECTIONNEND = 2586;
+        public const int SCI_GETSELECTIONNEND = 2587;
+        public const int SCI_SETRECTANGULARSELECTIONCARET = 2588;
+        public const int SCI_GETRECTANGULARSELECTIONCARET = 2589;
+        public const int SCI_SETRECTANGULARSELECTIONANCHOR = 2590;
+        public const int SCI_GETRECTANGULARSELECTIONANCHOR = 2591;
+        public const int SCI_SETRECTANGULARSELECTIONCARETVIRTUALSPACE = 2592;
+        public const int SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE = 2593;
+        public const int SCI_SETRECTANGULARSELECTIONANCHORVIRTUALSPACE = 2594;
+        public const int SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE = 2595;
+        public const int SCI_SETVIRTUALSPACEOPTIONS = 2596;
+        public const int SCI_GETVIRTUALSPACEOPTIONS = 2597;
+        public const int SCI_SETRECTANGULARSELECTIONMODIFIER = 2598;
+        public const int SCI_GETRECTANGULARSELECTIONMODIFIER = 2599;
+        public const int SCI_SETADDITIONALSELFORE = 2600;
+        public const int SCI_SETADDITIONALSELBACK = 2601;
+        public const int SCI_SETADDITIONALSELALPHA = 2602;
+        public const int SCI_GETADDITIONALSELALPHA = 2603;
+        public const int SCI_SETADDITIONALCARETFORE = 2604;
+        public const int SCI_GETADDITIONALCARETFORE = 2605;
+        public const int SCI_ROTATESELECTION = 2606;
+        public const int SCI_SWAPMAINANCHORCARET = 2607;
+        public const int SCI_MULTIPLESELECTADDNEXT = 2688;
+        public const int SCI_MULTIPLESELECTADDEACH = 2689;
+        public const int SCI_CHANGELEXERSTATE = 2617;
+        public const int SCI_CONTRACTEDFOLDNEXT = 2618;
+        public const int SCI_VERTICALCENTRECARET = 2619;
+        public const int SCI_MOVESELECTEDLINESUP = 2620;
+        public const int SCI_MOVESELECTEDLINESDOWN = 2621;
+        public const int SCI_SETIDENTIFIER = 2622;
+        public const int SCI_GETIDENTIFIER = 2623;
+        public const int SCI_RGBAIMAGESETWIDTH = 2624;
+        public const int SCI_RGBAIMAGESETHEIGHT = 2625;
+        public const int SCI_RGBAIMAGESETSCALE = 2651;
+        public const int SCI_MARKERDEFINERGBAIMAGE = 2626;
+        public const int SCI_REGISTERRGBAIMAGE = 2627;
+        public const int SCI_SCROLLTOSTART = 2628;
+        public const int SCI_SCROLLTOEND = 2629;
+        public const int SCI_SETTECHNOLOGY = 2630;
+        public const int SCI_GETTECHNOLOGY = 2631;
+        public const int SCI_CREATELOADER = 2632;
+        public const int SCI_FINDINDICATORSHOW = 2640;
+        public const int SCI_FINDINDICATORFLASH = 2641;
+        public const int SCI_FINDINDICATORHIDE = 2642;
+        public const int SCI_VCHOMEDISPLAY = 2652;
+        public const int SCI_VCHOMEDISPLAYEXTEND = 2653;
+        public const int SCI_GETCARETLINEVISIBLEALWAYS = 2654;
+        public const int SCI_SETCARETLINEVISIBLEALWAYS = 2655;
+        public const int SCI_SETLINEENDTYPESALLOWED = 2656;
+        public const int SCI_GETLINEENDTYPESALLOWED = 2657;
+        public const int SCI_GETLINEENDTYPESACTIVE = 2658;
+        public const int SCI_SETREPRESENTATION = 2665;
+        public const int SCI_GETREPRESENTATION = 2666;
+        public const int SCI_CLEARREPRESENTATION = 2667;
+        public const int SCI_SETTARGETRANGE = 2686;
+        public const int SCI_GETTARGETTEXT = 2687;
+        public const int SCI_SETIDLESTYLING = 2692;
+        public const int SCI_GETIDLESTYLING = 2693;
+        public const int SCI_MULTIEDGEADDLINE = 2694;
+        public const int SCI_MULTIEDGECLEARALL = 2695;
+        public const int SCI_SETMOUSEWHEELCAPTURES = 2696;
+        public const int SCI_GETMOUSEWHEELCAPTURES = 2697;
+        public const int SCI_TOGGLEFOLDSHOWTEXT = 2700;
+        public const int SCI_FOLDDISPLAYTEXTSETSTYLE = 2701;
+        public const int SCI_GETCARETLINEFRAME = 2704;
+        public const int SCI_SETCARETLINEFRAME = 2705;
+        public const int SCI_SETELEMENTCOLOUR = 2753;
+        public const int SCI_GETELEMENTCOLOUR = 2754;
+        public const int SCI_RESETELEMENTCOLOUR = 2755;
+        public const int SCI_GETELEMENTISSET = 2756;
+        public const int SCI_GETELEMENTALLOWSTRANSLUCENT = 2757;
+        public const int SCI_GETELEMENTBASECOLOUR = 2758;
+        public const int SCI_GETSELECTIONLAYER = 2762;
+        public const int SCI_SETSELECTIONLAYER = 2763;
+        public const int SCI_GETCARETLINELAYER = 2764;
+        public const int SCI_SETCARETLINELAYER = 2765;
+        public const int SCI_SETCHANGEHISTORY = 2780;
+        public const int SCI_GETCHANGEHISTORY = 2781;
+        public const int SCI_STARTRECORD = 3001;
+        public const int SCI_STOPRECORD = 3002;
+        public const int SCI_SETLEXER = 4001;
+        public const int SCI_GETLEXER = 4002;
+        public const int SCI_COLOURISE = 4003;
+        public const int SCI_SETPROPERTY = 4004;
+        public const int SCI_SETKEYWORDS = 4005;
+        public const int SCI_SETLEXERLANGUAGE = 4006;
+        public const int SCI_LOADLEXERLIBRARY = 4007;
+        public const int SCI_GETPROPERTY = 4008;
+        public const int SCI_GETPROPERTYEXPANDED = 4009;
+        public const int SCI_GETPROPERTYINT = 4010;
+        // public const int SCI_GETSTYLEBITSNEEDED = 4011;
+        public const int SCI_GETLEXERLANGUAGE = 4012;
+        public const int SCI_PRIVATELEXERCALL = 4013;
+        public const int SCI_PROPERTYNAMES = 4014;
+        public const int SCI_PROPERTYTYPE = 4015;
+        public const int SCI_DESCRIBEPROPERTY = 4016;
+        public const int SCI_DESCRIBEKEYWORDSETS = 4017;
+        public const int SCI_GETLINEENDTYPESSUPPORTED = 4018;
+        public const int SCI_ALLOCATESUBSTYLES = 4020;
+        public const int SCI_GETSUBSTYLESSTART = 4021;
+        public const int SCI_GETSUBSTYLESLENGTH = 4022;
+        public const int SCI_GETSTYLEFROMSUBSTYLE = 4027;
+        public const int SCI_GETPRIMARYSTYLEFROMSTYLE = 4028;
+        public const int SCI_FREESUBSTYLES = 4023;
+        public const int SCI_SETIDENTIFIERS = 4024;
+        public const int SCI_DISTANCETOSECONDARYSTYLES = 4025;
+        public const int SCI_GETSUBSTYLEBASES = 4026;
+        // public const int SCI_SETUSEPALETTE = 2039;
+        // public const int SCI_GETUSEPALETTE = 2139;
+        public const int SC_BIDIRECTIONAL_DISABLED = 0;
+        public const int SC_BIDIRECTIONAL_L2R = 1;
+        public const int SC_BIDIRECTIONAL_R2L = 2;
+        public const int SCI_GETBIDIRECTIONAL = 2708;
+        public const int SCI_SETBIDIRECTIONAL = 2709;
+        public const int SCI_SETILEXER = 4033;
+
+        // Keys
+        public const int SCK_DOWN = 300;
+        public const int SCK_UP = 301;
+        public const int SCK_LEFT = 302;
+        public const int SCK_RIGHT = 303;
+        public const int SCK_HOME = 304;
+        public const int SCK_END = 305;
+        public const int SCK_PRIOR = 306;
+        public const int SCK_NEXT = 307;
+        public const int SCK_DELETE = 308;
+        public const int SCK_INSERT = 309;
+        public const int SCK_ESCAPE = 7;
+        public const int SCK_BACK = 8;
+        public const int SCK_TAB = 9;
+        public const int SCK_RETURN = 13;
+        public const int SCK_ADD = 310;
+        public const int SCK_SUBTRACT = 311;
+        public const int SCK_DIVIDE = 312;
+        public const int SCK_WIN = 313;
+        public const int SCK_RWIN = 314;
+        public const int SCK_MENU = 315;
+
+        // Notifications
+        public const int SCN_STYLENEEDED = 2000;
+        public const int SCN_CHARADDED = 2001;
+        public const int SCN_SAVEPOINTREACHED = 2002;
+        public const int SCN_SAVEPOINTLEFT = 2003;
+        public const int SCN_MODIFYATTEMPTRO = 2004;
+        public const int SCN_KEY = 2005;
+        public const int SCN_DOUBLECLICK = 2006;
+        public const int SCN_UPDATEUI = 2007;
+        public const int SCN_MODIFIED = 2008;
+        public const int SCN_MACRORECORD = 2009;
+        public const int SCN_MARGINCLICK = 2010;
+        public const int SCN_NEEDSHOWN = 2011;
+        public const int SCN_PAINTED = 2013;
+        public const int SCN_USERLISTSELECTION = 2014;
+        public const int SCN_URIDROPPED = 2015;
+        public const int SCN_DWELLSTART = 2016;
+        public const int SCN_DWELLEND = 2017;
+        public const int SCN_ZOOM = 2018;
+        public const int SCN_HOTSPOTCLICK = 2019;
+        public const int SCN_HOTSPOTDOUBLECLICK = 2020;
+        public const int SCN_CALLTIPCLICK = 2021;
+        public const int SCN_AUTOCSELECTION = 2022;
+        public const int SCN_INDICATORCLICK = 2023;
+        public const int SCN_INDICATORRELEASE = 2024;
+        public const int SCN_AUTOCCANCELLED = 2025;
+        public const int SCN_AUTOCCHARDELETED = 2026;
+        public const int SCN_HOTSPOTRELEASECLICK = 2027;
+        public const int SCN_FOCUSIN = 2028;
+        public const int SCN_FOCUSOUT = 2029;
+        public const int SCN_AUTOCCOMPLETED = 2030;
+        public const int SCN_MARGINRIGHTCLICK = 2031;
+        public const int SCN_AUTOCSELECTIONCHANGE = 2032;
+
+        // Popup
+        public const int SC_POPUP_NEVER = 0;
+        public const int SC_POPUP_ALL = 1;
+        public const int SC_POPUP_TEXT = 2;
+
+        // Line wrapping
+        public const int SC_WRAP_NONE = 0;
+        public const int SC_WRAP_WORD = 1;
+        public const int SC_WRAP_CHAR = 2;
+        public const int SC_WRAP_WHITESPACE = 3;
+
+        public const int SC_WRAPVISUALFLAG_NONE = 0x0000;
+        public const int SC_WRAPVISUALFLAG_END = 0x0001;
+        public const int SC_WRAPVISUALFLAG_START = 0x0002;
+        public const int SC_WRAPVISUALFLAG_MARGIN = 0x0004;
+
+        public const int SC_WRAPVISUALFLAGLOC_DEFAULT = 0x0000;
+        public const int SC_WRAPVISUALFLAGLOC_END_BY_TEXT = 0x0001;
+        public const int SC_WRAPVISUALFLAGLOC_START_BY_TEXT = 0x0002;
+
+        public const int SC_WRAPINDENT_FIXED = 0;
+        public const int SC_WRAPINDENT_SAME = 1;
+        public const int SC_WRAPINDENT_INDENT = 2;
+
+        // Virtual space
+        public const int SCVS_NONE = 0;
+        public const int SCVS_RECTANGULARSELECTION = 1;
+        public const int SCVS_USERACCESSIBLE = 2;
+        public const int SCVS_NOWRAPLINESTART = 4;
+
+        // Styles constants
+        public const int STYLE_DEFAULT = 32;
+        public const int STYLE_LINENUMBER = 33;
+        public const int STYLE_BRACELIGHT = 34;
+        public const int STYLE_BRACEBAD = 35;
+        public const int STYLE_CONTROLCHAR = 36;
+        public const int STYLE_INDENTGUIDE = 37;
+        public const int STYLE_CALLTIP = 38;
+        public const int STYLE_FOLDDISPLAYTEXT = 39;
+        public const int STYLE_LASTPREDEFINED = 39;
+        public const int STYLE_MAX = 255;
+
+        public const int SC_FONT_SIZE_MULTIPLIER = 100;
+        public const int SC_CASE_MIXED = 0;
+        public const int SC_CASE_UPPER = 1;
+        public const int SC_CASE_LOWER = 2;
+        public const int SC_CASE_CAMEL = 3;
+
+        // Technology
+        public const int SC_TECHNOLOGY_DEFAULT = 0;
+        public const int SC_TECHNOLOGY_DIRECTWRITE = 1;
+        public const int SC_TECHNOLOGY_DIRECTWRITERETAIN = 2;
+        public const int SC_TECHNOLOGY_DIRECTWRITEDC = 3;
+
+        // Tab draw
+        public const int SCTD_LONGARROW = 0;
+        public const int SCTD_STRIKEOUT = 1;
+
+        // Undo
+        public const int UNDO_MAY_COALESCE = 1;
+
+        // Whitespace
+        public const int SCWS_INVISIBLE = 0;
+        public const int SCWS_VISIBLEALWAYS = 1;
+        public const int SCWS_VISIBLEAFTERINDENT = 2;
+        public const int SCWS_VISIBLEONLYININDENT = 3;
+
+        // Window messages
+        public const int WM_CREATE = 0x0001;
+        public const int WM_DESTROY = 0x0002;
+        public const int WM_SETCURSOR = 0x0020;
+        public const int WM_NOTIFY = 0x004E;
+        public const int WM_NCPAINT = 0x0085;
+        public const int WM_LBUTTONDBLCLK = 0x0203;
+        public const int WM_RBUTTONDBLCLK = 0x0206;
+        public const int WM_MBUTTONDBLCLK = 0x0209;
+        public const int WM_XBUTTONDBLCLK = 0x020D;
+        public const int WM_USER = 0x0400;
+        public const int WM_REFLECT = WM_USER + 0x1C00;
+
+        // Window styles
+        public const int WS_BORDER = 0x00800000;
+        public const int WS_EX_CLIENTEDGE = 0x00000200;
+
+        public const int RGN_AND = 1;
+
+        #endregion Constants
+
+        #region Lexer Constants
+
+        // Map the constant language names
+        public static readonly Dictionary<int, string> NameConstantMap = new Dictionary<int, string>() {
             { SCLEX_CONTAINER, "" },
             { SCLEX_NULL, "null" },
             { SCLEX_PYTHON, "python" },
@@ -1358,869 +1358,870 @@ public static class NativeMethods
             { SCLEX_JULIA, "julia" },
         };
 
-    // Lexers
-    public const int SCLEX_CONTAINER = 0;
-    public const int SCLEX_NULL = 1;
-    public const int SCLEX_PYTHON = 2;
-    public const int SCLEX_CPP = 3;
-    public const int SCLEX_HTML = 4;
-    public const int SCLEX_XML = 5;
-    public const int SCLEX_PERL = 6;
-    public const int SCLEX_SQL = 7;
-    public const int SCLEX_VB = 8;
-    public const int SCLEX_PROPERTIES = 9;
-    public const int SCLEX_ERRORLIST = 10;
-    public const int SCLEX_MAKEFILE = 11;
-    public const int SCLEX_BATCH = 12;
-    public const int SCLEX_XCODE = 13;
-    public const int SCLEX_LATEX = 14;
-    public const int SCLEX_LUA = 15;
-    public const int SCLEX_DIFF = 16;
-    public const int SCLEX_CONF = 17;
-    public const int SCLEX_PASCAL = 18;
-    public const int SCLEX_AVE = 19;
-    public const int SCLEX_ADA = 20;
-    public const int SCLEX_LISP = 21;
-    public const int SCLEX_RUBY = 22;
-    public const int SCLEX_EIFFEL = 23;
-    public const int SCLEX_EIFFELKW = 24;
-    public const int SCLEX_TCL = 25;
-    public const int SCLEX_NNCRONTAB = 26;
-    public const int SCLEX_BULLANT = 27;
-    public const int SCLEX_VBSCRIPT = 28;
-    public const int SCLEX_BAAN = 31;
-    public const int SCLEX_MATLAB = 32;
-    public const int SCLEX_SCRIPTOL = 33;
-    public const int SCLEX_ASM = 34;
-    public const int SCLEX_CPPNOCASE = 35;
-    public const int SCLEX_FORTRAN = 36;
-    public const int SCLEX_F77 = 37;
-    public const int SCLEX_CSS = 38;
-    public const int SCLEX_POV = 39;
-    public const int SCLEX_LOUT = 40;
-    public const int SCLEX_ESCRIPT = 41;
-    public const int SCLEX_PS = 42;
-    public const int SCLEX_NSIS = 43;
-    public const int SCLEX_MMIXAL = 44;
-    public const int SCLEX_CLW = 45;
-    public const int SCLEX_CLWNOCASE = 46;
-    public const int SCLEX_LOT = 47;
-    public const int SCLEX_YAML = 48;
-    public const int SCLEX_TEX = 49;
-    public const int SCLEX_METAPOST = 50;
-    public const int SCLEX_POWERBASIC = 51;
-    public const int SCLEX_FORTH = 52;
-    public const int SCLEX_ERLANG = 53;
-    public const int SCLEX_OCTAVE = 54;
-    public const int SCLEX_MSSQL = 55;
-    public const int SCLEX_VERILOG = 56;
-    public const int SCLEX_KIX = 57;
-    public const int SCLEX_GUI4CLI = 58;
-    public const int SCLEX_SPECMAN = 59;
-    public const int SCLEX_AU3 = 60;
-    public const int SCLEX_APDL = 61;
-    public const int SCLEX_BASH = 62;
-    public const int SCLEX_ASN1 = 63;
-    public const int SCLEX_VHDL = 64;
-    public const int SCLEX_CAML = 65;
-    public const int SCLEX_BLITZBASIC = 66;
-    public const int SCLEX_PUREBASIC = 67;
-    public const int SCLEX_HASKELL = 68;
-    public const int SCLEX_PHPSCRIPT = 69;
-    public const int SCLEX_TADS3 = 70;
-    public const int SCLEX_REBOL = 71;
-    public const int SCLEX_SMALLTALK = 72;
-    public const int SCLEX_FLAGSHIP = 73;
-    public const int SCLEX_CSOUND = 74;
-    public const int SCLEX_FREEBASIC = 75;
-    public const int SCLEX_INNOSETUP = 76;
-    public const int SCLEX_OPAL = 77;
-    public const int SCLEX_SPICE = 78;
-    public const int SCLEX_D = 79;
-    public const int SCLEX_CMAKE = 80;
-    public const int SCLEX_GAP = 81;
-    public const int SCLEX_PLM = 82;
-    public const int SCLEX_PROGRESS = 83;
-    public const int SCLEX_ABAQUS = 84;
-    public const int SCLEX_ASYMPTOTE = 85;
-    public const int SCLEX_R = 86;
-    public const int SCLEX_MAGIK = 87;
-    public const int SCLEX_POWERSHELL = 88;
-    public const int SCLEX_MYSQL = 89;
-    public const int SCLEX_PO = 90;
-    public const int SCLEX_TAL = 91;
-    public const int SCLEX_COBOL = 92;
-    public const int SCLEX_TACL = 93;
-    public const int SCLEX_SORCUS = 94;
-    public const int SCLEX_POWERPRO = 95;
-    public const int SCLEX_NIMROD = 96;
-    public const int SCLEX_SML = 97;
-    public const int SCLEX_MARKDOWN = 98;
-    public const int SCLEX_TXT2TAGS = 99;
-    public const int SCLEX_A68K = 100;
-    public const int SCLEX_MODULA = 101;
-    public const int SCLEX_COFFEESCRIPT = 102;
-    public const int SCLEX_TCMD = 103;
-    public const int SCLEX_AVS = 104;
-    public const int SCLEX_ECL = 105;
-    public const int SCLEX_OSCRIPT = 106;
-    public const int SCLEX_VISUALPROLOG = 107;
-    public const int SCLEX_LITERATEHASKELL = 108;
-    public const int SCLEX_STTXT = 109;
-    public const int SCLEX_KVIRC = 110;
-    public const int SCLEX_RUST = 111;
-    public const int SCLEX_DMAP = 112;
-    public const int SCLEX_AS = 113;
-    public const int SCLEX_DMIS = 114;
-    public const int SCLEX_REGISTRY = 115;
-    public const int SCLEX_BIBTEX = 116;
-    public const int SCLEX_SREC = 117;
-    public const int SCLEX_IHEX = 118;
-    public const int SCLEX_TEHEX = 119;
-    public const int SCLEX_JSON = 120;
-    public const int SCLEX_EDIFACT = 121;
-    public const int SCLEX_INDENT = 122;
-    public const int SCLEX_MAXIMA = 123;
-    public const int SCLEX_STATA = 124;
-    public const int SCLEX_SAS = 125;
-    public const int SCLEX_NIM = 126;
-    public const int SCLEX_CIL = 127;
-    public const int SCLEX_X12 = 128;
-    public const int SCLEX_DATAFLEX = 129;
-    public const int SCLEX_HOLLYWOOD = 130;
-    public const int SCLEX_RAKU = 131;
-    public const int SCLEX_FSHARP = 132;
-    public const int SCLEX_JULIA = 133;
-    public const int SCLEX_AUTOMATIC = 1000;
+        // Lexers
+        public const int SCLEX_CONTAINER = 0;
+        public const int SCLEX_NULL = 1;
+        public const int SCLEX_PYTHON = 2;
+        public const int SCLEX_CPP = 3;
+        public const int SCLEX_HTML = 4;
+        public const int SCLEX_XML = 5;
+        public const int SCLEX_PERL = 6;
+        public const int SCLEX_SQL = 7;
+        public const int SCLEX_VB = 8;
+        public const int SCLEX_PROPERTIES = 9;
+        public const int SCLEX_ERRORLIST = 10;
+        public const int SCLEX_MAKEFILE = 11;
+        public const int SCLEX_BATCH = 12;
+        public const int SCLEX_XCODE = 13;
+        public const int SCLEX_LATEX = 14;
+        public const int SCLEX_LUA = 15;
+        public const int SCLEX_DIFF = 16;
+        public const int SCLEX_CONF = 17;
+        public const int SCLEX_PASCAL = 18;
+        public const int SCLEX_AVE = 19;
+        public const int SCLEX_ADA = 20;
+        public const int SCLEX_LISP = 21;
+        public const int SCLEX_RUBY = 22;
+        public const int SCLEX_EIFFEL = 23;
+        public const int SCLEX_EIFFELKW = 24;
+        public const int SCLEX_TCL = 25;
+        public const int SCLEX_NNCRONTAB = 26;
+        public const int SCLEX_BULLANT = 27;
+        public const int SCLEX_VBSCRIPT = 28;
+        public const int SCLEX_BAAN = 31;
+        public const int SCLEX_MATLAB = 32;
+        public const int SCLEX_SCRIPTOL = 33;
+        public const int SCLEX_ASM = 34;
+        public const int SCLEX_CPPNOCASE = 35;
+        public const int SCLEX_FORTRAN = 36;
+        public const int SCLEX_F77 = 37;
+        public const int SCLEX_CSS = 38;
+        public const int SCLEX_POV = 39;
+        public const int SCLEX_LOUT = 40;
+        public const int SCLEX_ESCRIPT = 41;
+        public const int SCLEX_PS = 42;
+        public const int SCLEX_NSIS = 43;
+        public const int SCLEX_MMIXAL = 44;
+        public const int SCLEX_CLW = 45;
+        public const int SCLEX_CLWNOCASE = 46;
+        public const int SCLEX_LOT = 47;
+        public const int SCLEX_YAML = 48;
+        public const int SCLEX_TEX = 49;
+        public const int SCLEX_METAPOST = 50;
+        public const int SCLEX_POWERBASIC = 51;
+        public const int SCLEX_FORTH = 52;
+        public const int SCLEX_ERLANG = 53;
+        public const int SCLEX_OCTAVE = 54;
+        public const int SCLEX_MSSQL = 55;
+        public const int SCLEX_VERILOG = 56;
+        public const int SCLEX_KIX = 57;
+        public const int SCLEX_GUI4CLI = 58;
+        public const int SCLEX_SPECMAN = 59;
+        public const int SCLEX_AU3 = 60;
+        public const int SCLEX_APDL = 61;
+        public const int SCLEX_BASH = 62;
+        public const int SCLEX_ASN1 = 63;
+        public const int SCLEX_VHDL = 64;
+        public const int SCLEX_CAML = 65;
+        public const int SCLEX_BLITZBASIC = 66;
+        public const int SCLEX_PUREBASIC = 67;
+        public const int SCLEX_HASKELL = 68;
+        public const int SCLEX_PHPSCRIPT = 69;
+        public const int SCLEX_TADS3 = 70;
+        public const int SCLEX_REBOL = 71;
+        public const int SCLEX_SMALLTALK = 72;
+        public const int SCLEX_FLAGSHIP = 73;
+        public const int SCLEX_CSOUND = 74;
+        public const int SCLEX_FREEBASIC = 75;
+        public const int SCLEX_INNOSETUP = 76;
+        public const int SCLEX_OPAL = 77;
+        public const int SCLEX_SPICE = 78;
+        public const int SCLEX_D = 79;
+        public const int SCLEX_CMAKE = 80;
+        public const int SCLEX_GAP = 81;
+        public const int SCLEX_PLM = 82;
+        public const int SCLEX_PROGRESS = 83;
+        public const int SCLEX_ABAQUS = 84;
+        public const int SCLEX_ASYMPTOTE = 85;
+        public const int SCLEX_R = 86;
+        public const int SCLEX_MAGIK = 87;
+        public const int SCLEX_POWERSHELL = 88;
+        public const int SCLEX_MYSQL = 89;
+        public const int SCLEX_PO = 90;
+        public const int SCLEX_TAL = 91;
+        public const int SCLEX_COBOL = 92;
+        public const int SCLEX_TACL = 93;
+        public const int SCLEX_SORCUS = 94;
+        public const int SCLEX_POWERPRO = 95;
+        public const int SCLEX_NIMROD = 96;
+        public const int SCLEX_SML = 97;
+        public const int SCLEX_MARKDOWN = 98;
+        public const int SCLEX_TXT2TAGS = 99;
+        public const int SCLEX_A68K = 100;
+        public const int SCLEX_MODULA = 101;
+        public const int SCLEX_COFFEESCRIPT = 102;
+        public const int SCLEX_TCMD = 103;
+        public const int SCLEX_AVS = 104;
+        public const int SCLEX_ECL = 105;
+        public const int SCLEX_OSCRIPT = 106;
+        public const int SCLEX_VISUALPROLOG = 107;
+        public const int SCLEX_LITERATEHASKELL = 108;
+        public const int SCLEX_STTXT = 109;
+        public const int SCLEX_KVIRC = 110;
+        public const int SCLEX_RUST = 111;
+        public const int SCLEX_DMAP = 112;
+        public const int SCLEX_AS = 113;
+        public const int SCLEX_DMIS = 114;
+        public const int SCLEX_REGISTRY = 115;
+        public const int SCLEX_BIBTEX = 116;
+        public const int SCLEX_SREC = 117;
+        public const int SCLEX_IHEX = 118;
+        public const int SCLEX_TEHEX = 119;
+        public const int SCLEX_JSON = 120;
+        public const int SCLEX_EDIFACT = 121;
+        public const int SCLEX_INDENT = 122;
+        public const int SCLEX_MAXIMA = 123;
+        public const int SCLEX_STATA = 124;
+        public const int SCLEX_SAS = 125;
+        public const int SCLEX_NIM = 126;
+        public const int SCLEX_CIL = 127;
+        public const int SCLEX_X12 = 128;
+        public const int SCLEX_DATAFLEX = 129;
+        public const int SCLEX_HOLLYWOOD = 130;
+        public const int SCLEX_RAKU = 131;
+        public const int SCLEX_FSHARP = 132;
+        public const int SCLEX_JULIA = 133;
+        public const int SCLEX_AUTOMATIC = 1000;
 
-    // Ada
-    public const int SCE_ADA_DEFAULT = 0;
-    public const int SCE_ADA_WORD = 1;
-    public const int SCE_ADA_IDENTIFIER = 2;
-    public const int SCE_ADA_NUMBER = 3;
-    public const int SCE_ADA_DELIMITER = 4;
-    public const int SCE_ADA_CHARACTER = 5;
-    public const int SCE_ADA_CHARACTEREOL = 6;
-    public const int SCE_ADA_STRING = 7;
-    public const int SCE_ADA_STRINGEOL = 8;
-    public const int SCE_ADA_LABEL = 9;
-    public const int SCE_ADA_COMMENTLINE = 10;
-    public const int SCE_ADA_ILLEGAL = 11;
+        // Ada
+        public const int SCE_ADA_DEFAULT = 0;
+        public const int SCE_ADA_WORD = 1;
+        public const int SCE_ADA_IDENTIFIER = 2;
+        public const int SCE_ADA_NUMBER = 3;
+        public const int SCE_ADA_DELIMITER = 4;
+        public const int SCE_ADA_CHARACTER = 5;
+        public const int SCE_ADA_CHARACTEREOL = 6;
+        public const int SCE_ADA_STRING = 7;
+        public const int SCE_ADA_STRINGEOL = 8;
+        public const int SCE_ADA_LABEL = 9;
+        public const int SCE_ADA_COMMENTLINE = 10;
+        public const int SCE_ADA_ILLEGAL = 11;
 
-    // ASM
-    public const int SCE_ASM_DEFAULT = 0;
-    public const int SCE_ASM_COMMENT = 1;
-    public const int SCE_ASM_NUMBER = 2;
-    public const int SCE_ASM_STRING = 3;
-    public const int SCE_ASM_OPERATOR = 4;
-    public const int SCE_ASM_IDENTIFIER = 5;
-    public const int SCE_ASM_CPUINSTRUCTION = 6;
-    public const int SCE_ASM_MATHINSTRUCTION = 7;
-    public const int SCE_ASM_REGISTER = 8;
-    public const int SCE_ASM_DIRECTIVE = 9;
-    public const int SCE_ASM_DIRECTIVEOPERAND = 10;
-    public const int SCE_ASM_COMMENTBLOCK = 11;
-    public const int SCE_ASM_CHARACTER = 12;
-    public const int SCE_ASM_STRINGEOL = 13;
-    public const int SCE_ASM_EXTINSTRUCTION = 14;
-    public const int SCE_ASM_COMMENTDIRECTIVE = 15;
+        // ASM
+        public const int SCE_ASM_DEFAULT = 0;
+        public const int SCE_ASM_COMMENT = 1;
+        public const int SCE_ASM_NUMBER = 2;
+        public const int SCE_ASM_STRING = 3;
+        public const int SCE_ASM_OPERATOR = 4;
+        public const int SCE_ASM_IDENTIFIER = 5;
+        public const int SCE_ASM_CPUINSTRUCTION = 6;
+        public const int SCE_ASM_MATHINSTRUCTION = 7;
+        public const int SCE_ASM_REGISTER = 8;
+        public const int SCE_ASM_DIRECTIVE = 9;
+        public const int SCE_ASM_DIRECTIVEOPERAND = 10;
+        public const int SCE_ASM_COMMENTBLOCK = 11;
+        public const int SCE_ASM_CHARACTER = 12;
+        public const int SCE_ASM_STRINGEOL = 13;
+        public const int SCE_ASM_EXTINSTRUCTION = 14;
+        public const int SCE_ASM_COMMENTDIRECTIVE = 15;
 
-    // Batch
-    public const int SCE_BAT_DEFAULT = 0;
-    public const int SCE_BAT_COMMENT = 1;
-    public const int SCE_BAT_WORD = 2;
-    public const int SCE_BAT_LABEL = 3;
-    public const int SCE_BAT_HIDE = 4;
-    public const int SCE_BAT_COMMAND = 5;
-    public const int SCE_BAT_IDENTIFIER = 6;
-    public const int SCE_BAT_OPERATOR = 7;
+        // Batch
+        public const int SCE_BAT_DEFAULT = 0;
+        public const int SCE_BAT_COMMENT = 1;
+        public const int SCE_BAT_WORD = 2;
+        public const int SCE_BAT_LABEL = 3;
+        public const int SCE_BAT_HIDE = 4;
+        public const int SCE_BAT_COMMAND = 5;
+        public const int SCE_BAT_IDENTIFIER = 6;
+        public const int SCE_BAT_OPERATOR = 7;
 
-    // CPP
-    public const int SCE_C_DEFAULT = 0;
-    public const int SCE_C_COMMENT = 1;
-    public const int SCE_C_COMMENTLINE = 2;
-    public const int SCE_C_COMMENTDOC = 3;
-    public const int SCE_C_NUMBER = 4;
-    public const int SCE_C_WORD = 5;
-    public const int SCE_C_STRING = 6;
-    public const int SCE_C_CHARACTER = 7;
-    public const int SCE_C_UUID = 8;
-    public const int SCE_C_PREPROCESSOR = 9;
-    public const int SCE_C_OPERATOR = 10;
-    public const int SCE_C_IDENTIFIER = 11;
-    public const int SCE_C_STRINGEOL = 12;
-    public const int SCE_C_VERBATIM = 13;
-    public const int SCE_C_REGEX = 14;
-    public const int SCE_C_COMMENTLINEDOC = 15;
-    public const int SCE_C_WORD2 = 16;
-    public const int SCE_C_COMMENTDOCKEYWORD = 17;
-    public const int SCE_C_COMMENTDOCKEYWORDERROR = 18;
-    public const int SCE_C_GLOBALCLASS = 19;
-    public const int SCE_C_STRINGRAW = 20;
-    public const int SCE_C_TRIPLEVERBATIM = 21;
-    public const int SCE_C_HASHQUOTEDSTRING = 22;
-    public const int SCE_C_PREPROCESSORCOMMENT = 23;
-    public const int SCE_C_PREPROCESSORCOMMENTDOC = 24;
-    public const int SCE_C_USERLITERAL = 25;
-    public const int SCE_C_TASKMARKER = 26;
-    public const int SCE_C_ESCAPESEQUENCE = 27;
+        // CPP
+        public const int SCE_C_DEFAULT = 0;
+        public const int SCE_C_COMMENT = 1;
+        public const int SCE_C_COMMENTLINE = 2;
+        public const int SCE_C_COMMENTDOC = 3;
+        public const int SCE_C_NUMBER = 4;
+        public const int SCE_C_WORD = 5;
+        public const int SCE_C_STRING = 6;
+        public const int SCE_C_CHARACTER = 7;
+        public const int SCE_C_UUID = 8;
+        public const int SCE_C_PREPROCESSOR = 9;
+        public const int SCE_C_OPERATOR = 10;
+        public const int SCE_C_IDENTIFIER = 11;
+        public const int SCE_C_STRINGEOL = 12;
+        public const int SCE_C_VERBATIM = 13;
+        public const int SCE_C_REGEX = 14;
+        public const int SCE_C_COMMENTLINEDOC = 15;
+        public const int SCE_C_WORD2 = 16;
+        public const int SCE_C_COMMENTDOCKEYWORD = 17;
+        public const int SCE_C_COMMENTDOCKEYWORDERROR = 18;
+        public const int SCE_C_GLOBALCLASS = 19;
+        public const int SCE_C_STRINGRAW = 20;
+        public const int SCE_C_TRIPLEVERBATIM = 21;
+        public const int SCE_C_HASHQUOTEDSTRING = 22;
+        public const int SCE_C_PREPROCESSORCOMMENT = 23;
+        public const int SCE_C_PREPROCESSORCOMMENTDOC = 24;
+        public const int SCE_C_USERLITERAL = 25;
+        public const int SCE_C_TASKMARKER = 26;
+        public const int SCE_C_ESCAPESEQUENCE = 27;
 
-    //CLW
-    public const int SCE_CLW_DEFAULT = 0;
-    public const int SCE_CLW_LABEL = 1;
-    public const int SCE_CLW_COMMENT = 2;
-    public const int SCE_CLW_STRING = 3;
-    public const int SCE_CLW_USER_IDENTIFIER = 4;
-    public const int SCE_CLW_INTEGER_CONSTANT = 5;
-    public const int SCE_CLW_REAL_CONSTANT = 6;
-    public const int SCE_CLW_PICTURE_STRING = 7;
-    public const int SCE_CLW_KEYWORD = 8;
-    public const int SCE_CLW_COMPILER_DIRECTIVE = 9;
-    public const int SCE_CLW_RUNTIME_EXPRESSIONS = 10;
-    public const int SCE_CLW_BUILTIN_PROCEDURES_FUNCTION = 11;
-    public const int SCE_CLW_STRUCTURE_DATA_TYPE = 12;
-    public const int SCE_CLW_ATTRIBUTE = 13;
-    public const int SCE_CLW_STANDARD_EQUATE = 14;
-    public const int SCE_CLW_ERROR = 15;
-    public const int SCE_CLW_DEPRECATED = 16;
+        //CLW
+        public const int SCE_CLW_DEFAULT = 0;
+        public const int SCE_CLW_LABEL = 1;
+        public const int SCE_CLW_COMMENT = 2;
+        public const int SCE_CLW_STRING = 3;
+        public const int SCE_CLW_USER_IDENTIFIER = 4;
+        public const int SCE_CLW_INTEGER_CONSTANT = 5;
+        public const int SCE_CLW_REAL_CONSTANT = 6;
+        public const int SCE_CLW_PICTURE_STRING = 7;
+        public const int SCE_CLW_KEYWORD = 8;
+        public const int SCE_CLW_COMPILER_DIRECTIVE = 9;
+        public const int SCE_CLW_RUNTIME_EXPRESSIONS = 10;
+        public const int SCE_CLW_BUILTIN_PROCEDURES_FUNCTION = 11;
+        public const int SCE_CLW_STRUCTURE_DATA_TYPE = 12;
+        public const int SCE_CLW_ATTRIBUTE = 13;
+        public const int SCE_CLW_STANDARD_EQUATE = 14;
+        public const int SCE_CLW_ERROR = 15;
+        public const int SCE_CLW_DEPRECATED = 16;
 
-    // CSS
-    public const int SCE_CSS_DEFAULT = 0;
-    public const int SCE_CSS_TAG = 1;
-    public const int SCE_CSS_CLASS = 2;
-    public const int SCE_CSS_PSEUDOCLASS = 3;
-    public const int SCE_CSS_UNKNOWN_PSEUDOCLASS = 4;
-    public const int SCE_CSS_OPERATOR = 5;
-    public const int SCE_CSS_IDENTIFIER = 6;
-    public const int SCE_CSS_UNKNOWN_IDENTIFIER = 7;
-    public const int SCE_CSS_VALUE = 8;
-    public const int SCE_CSS_COMMENT = 9;
-    public const int SCE_CSS_ID = 10;
-    public const int SCE_CSS_IMPORTANT = 11;
-    public const int SCE_CSS_DIRECTIVE = 12;
-    public const int SCE_CSS_DOUBLESTRING = 13;
-    public const int SCE_CSS_SINGLESTRING = 14;
-    public const int SCE_CSS_IDENTIFIER2 = 15;
-    public const int SCE_CSS_ATTRIBUTE = 16;
-    public const int SCE_CSS_IDENTIFIER3 = 17;
-    public const int SCE_CSS_PSEUDOELEMENT = 18;
-    public const int SCE_CSS_EXTENDED_IDENTIFIER = 19;
-    public const int SCE_CSS_EXTENDED_PSEUDOCLASS = 20;
-    public const int SCE_CSS_EXTENDED_PSEUDOELEMENT = 21;
-    public const int SCE_CSS_MEDIA = 22;
-    public const int SCE_CSS_VARIABLE = 23;
+        // CSS
+        public const int SCE_CSS_DEFAULT = 0;
+        public const int SCE_CSS_TAG = 1;
+        public const int SCE_CSS_CLASS = 2;
+        public const int SCE_CSS_PSEUDOCLASS = 3;
+        public const int SCE_CSS_UNKNOWN_PSEUDOCLASS = 4;
+        public const int SCE_CSS_OPERATOR = 5;
+        public const int SCE_CSS_IDENTIFIER = 6;
+        public const int SCE_CSS_UNKNOWN_IDENTIFIER = 7;
+        public const int SCE_CSS_VALUE = 8;
+        public const int SCE_CSS_COMMENT = 9;
+        public const int SCE_CSS_ID = 10;
+        public const int SCE_CSS_IMPORTANT = 11;
+        public const int SCE_CSS_DIRECTIVE = 12;
+        public const int SCE_CSS_DOUBLESTRING = 13;
+        public const int SCE_CSS_SINGLESTRING = 14;
+        public const int SCE_CSS_IDENTIFIER2 = 15;
+        public const int SCE_CSS_ATTRIBUTE = 16;
+        public const int SCE_CSS_IDENTIFIER3 = 17;
+        public const int SCE_CSS_PSEUDOELEMENT = 18;
+        public const int SCE_CSS_EXTENDED_IDENTIFIER = 19;
+        public const int SCE_CSS_EXTENDED_PSEUDOCLASS = 20;
+        public const int SCE_CSS_EXTENDED_PSEUDOELEMENT = 21;
+        public const int SCE_CSS_MEDIA = 22;
+        public const int SCE_CSS_VARIABLE = 23;
 
-    // Fortran
-    public const int SCE_F_DEFAULT = 0;
-    public const int SCE_F_COMMENT = 1;
-    public const int SCE_F_NUMBER = 2;
-    public const int SCE_F_STRING1 = 3;
-    public const int SCE_F_STRING2 = 4;
-    public const int SCE_F_STRINGEOL = 5;
-    public const int SCE_F_OPERATOR = 6;
-    public const int SCE_F_IDENTIFIER = 7;
-    public const int SCE_F_WORD = 8;
-    public const int SCE_F_WORD2 = 9;
-    public const int SCE_F_WORD3 = 10;
-    public const int SCE_F_PREPROCESSOR = 11;
-    public const int SCE_F_OPERATOR2 = 12;
-    public const int SCE_F_LABEL = 13;
-    public const int SCE_F_CONTINUATION = 14;
+        // Fortran
+        public const int SCE_F_DEFAULT = 0;
+        public const int SCE_F_COMMENT = 1;
+        public const int SCE_F_NUMBER = 2;
+        public const int SCE_F_STRING1 = 3;
+        public const int SCE_F_STRING2 = 4;
+        public const int SCE_F_STRINGEOL = 5;
+        public const int SCE_F_OPERATOR = 6;
+        public const int SCE_F_IDENTIFIER = 7;
+        public const int SCE_F_WORD = 8;
+        public const int SCE_F_WORD2 = 9;
+        public const int SCE_F_WORD3 = 10;
+        public const int SCE_F_PREPROCESSOR = 11;
+        public const int SCE_F_OPERATOR2 = 12;
+        public const int SCE_F_LABEL = 13;
+        public const int SCE_F_CONTINUATION = 14;
 
-    // HTML
-    public const int SCE_H_DEFAULT = 0;
-    public const int SCE_H_TAG = 1;
-    public const int SCE_H_TAGUNKNOWN = 2;
-    public const int SCE_H_ATTRIBUTE = 3;
-    public const int SCE_H_ATTRIBUTEUNKNOWN = 4;
-    public const int SCE_H_NUMBER = 5;
-    public const int SCE_H_DOUBLESTRING = 6;
-    public const int SCE_H_SINGLESTRING = 7;
-    public const int SCE_H_OTHER = 8;
-    public const int SCE_H_COMMENT = 9;
-    public const int SCE_H_ENTITY = 10;
-    public const int SCE_H_TAGEND = 11;
-    public const int SCE_H_XMLSTART = 12;
-    public const int SCE_H_XMLEND = 13;
-    public const int SCE_H_SCRIPT = 14;
-    public const int SCE_H_ASP = 15;
-    public const int SCE_H_ASPAT = 16;
-    public const int SCE_H_CDATA = 17;
-    public const int SCE_H_QUESTION = 18;
-    public const int SCE_H_VALUE = 19;
-    public const int SCE_H_XCCOMMENT = 20;
+        // HTML
+        public const int SCE_H_DEFAULT = 0;
+        public const int SCE_H_TAG = 1;
+        public const int SCE_H_TAGUNKNOWN = 2;
+        public const int SCE_H_ATTRIBUTE = 3;
+        public const int SCE_H_ATTRIBUTEUNKNOWN = 4;
+        public const int SCE_H_NUMBER = 5;
+        public const int SCE_H_DOUBLESTRING = 6;
+        public const int SCE_H_SINGLESTRING = 7;
+        public const int SCE_H_OTHER = 8;
+        public const int SCE_H_COMMENT = 9;
+        public const int SCE_H_ENTITY = 10;
+        public const int SCE_H_TAGEND = 11;
+        public const int SCE_H_XMLSTART = 12;
+        public const int SCE_H_XMLEND = 13;
+        public const int SCE_H_SCRIPT = 14;
+        public const int SCE_H_ASP = 15;
+        public const int SCE_H_ASPAT = 16;
+        public const int SCE_H_CDATA = 17;
+        public const int SCE_H_QUESTION = 18;
+        public const int SCE_H_VALUE = 19;
+        public const int SCE_H_XCCOMMENT = 20;
 
-    // JavaScript
-    public const int SCE_HJ_START = 40;
-    public const int SCE_HJ_DEFAULT = 41;
-    public const int SCE_HJ_COMMENT = 42;
-    public const int SCE_HJ_COMMENTLINE = 43;
-    public const int SCE_HJ_COMMENTDOC = 44;
-    public const int SCE_HJ_NUMBER = 45;
-    public const int SCE_HJ_WORD = 46;
-    public const int SCE_HJ_KEYWORD = 47;
-    public const int SCE_HJ_DOUBLESTRING = 48;
-    public const int SCE_HJ_SINGLESTRING = 49;
-    public const int SCE_HJ_SYMBOLS = 50;
-    public const int SCE_HJ_STRINGEOL = 51;
-    public const int SCE_HJ_REGEX = 52;
+        // JavaScript
+        public const int SCE_HJ_START = 40;
+        public const int SCE_HJ_DEFAULT = 41;
+        public const int SCE_HJ_COMMENT = 42;
+        public const int SCE_HJ_COMMENTLINE = 43;
+        public const int SCE_HJ_COMMENTDOC = 44;
+        public const int SCE_HJ_NUMBER = 45;
+        public const int SCE_HJ_WORD = 46;
+        public const int SCE_HJ_KEYWORD = 47;
+        public const int SCE_HJ_DOUBLESTRING = 48;
+        public const int SCE_HJ_SINGLESTRING = 49;
+        public const int SCE_HJ_SYMBOLS = 50;
+        public const int SCE_HJ_STRINGEOL = 51;
+        public const int SCE_HJ_REGEX = 52;
 
-    // JSON
-    public const int SCE_JSON_DEFAULT = 0;
-    public const int SCE_JSON_NUMBER = 1;
-    public const int SCE_JSON_STRING = 2;
-    public const int SCE_JSON_STRINGEOL = 3;
-    public const int SCE_JSON_PROPERTYNAME = 4;
-    public const int SCE_JSON_ESCAPESEQUENCE = 5;
-    public const int SCE_JSON_LINECOMMENT = 6;
-    public const int SCE_JSON_BLOCKCOMMENT = 7;
-    public const int SCE_JSON_OPERATOR = 8;
-    public const int SCE_JSON_URI = 9;
-    public const int SCE_JSON_COMPACTIRI = 10;
-    public const int SCE_JSON_KEYWORD = 11;
-    public const int SCE_JSON_LDKEYWORD = 12;
-    public const int SCE_JSON_ERROR = 13;
+        // JSON
+        public const int SCE_JSON_DEFAULT = 0;
+        public const int SCE_JSON_NUMBER = 1;
+        public const int SCE_JSON_STRING = 2;
+        public const int SCE_JSON_STRINGEOL = 3;
+        public const int SCE_JSON_PROPERTYNAME = 4;
+        public const int SCE_JSON_ESCAPESEQUENCE = 5;
+        public const int SCE_JSON_LINECOMMENT = 6;
+        public const int SCE_JSON_BLOCKCOMMENT = 7;
+        public const int SCE_JSON_OPERATOR = 8;
+        public const int SCE_JSON_URI = 9;
+        public const int SCE_JSON_COMPACTIRI = 10;
+        public const int SCE_JSON_KEYWORD = 11;
+        public const int SCE_JSON_LDKEYWORD = 12;
+        public const int SCE_JSON_ERROR = 13;
 
-    // Lisp
-    public const int SCE_LISP_DEFAULT = 0;
-    public const int SCE_LISP_COMMENT = 1;
-    public const int SCE_LISP_NUMBER = 2;
-    public const int SCE_LISP_KEYWORD = 3;
-    public const int SCE_LISP_KEYWORD_KW = 4;
-    public const int SCE_LISP_SYMBOL = 5;
-    public const int SCE_LISP_STRING = 6;
-    public const int SCE_LISP_STRINGEOL = 8;
-    public const int SCE_LISP_IDENTIFIER = 9;
-    public const int SCE_LISP_OPERATOR = 10;
-    public const int SCE_LISP_SPECIAL = 11;
-    public const int SCE_LISP_MULTI_COMMENT = 12;
+        // Lisp
+        public const int SCE_LISP_DEFAULT = 0;
+        public const int SCE_LISP_COMMENT = 1;
+        public const int SCE_LISP_NUMBER = 2;
+        public const int SCE_LISP_KEYWORD = 3;
+        public const int SCE_LISP_KEYWORD_KW = 4;
+        public const int SCE_LISP_SYMBOL = 5;
+        public const int SCE_LISP_STRING = 6;
+        public const int SCE_LISP_STRINGEOL = 8;
+        public const int SCE_LISP_IDENTIFIER = 9;
+        public const int SCE_LISP_OPERATOR = 10;
+        public const int SCE_LISP_SPECIAL = 11;
+        public const int SCE_LISP_MULTI_COMMENT = 12;
 
-    // Lua
-    public const int SCE_LUA_DEFAULT = 0;
-    public const int SCE_LUA_COMMENT = 1;
-    public const int SCE_LUA_COMMENTLINE = 2;
-    public const int SCE_LUA_COMMENTDOC = 3;
-    public const int SCE_LUA_NUMBER = 4;
-    public const int SCE_LUA_WORD = 5;
-    public const int SCE_LUA_STRING = 6;
-    public const int SCE_LUA_CHARACTER = 7;
-    public const int SCE_LUA_LITERALSTRING = 8;
-    public const int SCE_LUA_PREPROCESSOR = 9;
-    public const int SCE_LUA_OPERATOR = 10;
-    public const int SCE_LUA_IDENTIFIER = 11;
-    public const int SCE_LUA_STRINGEOL = 12;
-    public const int SCE_LUA_WORD2 = 13;
-    public const int SCE_LUA_WORD3 = 14;
-    public const int SCE_LUA_WORD4 = 15;
-    public const int SCE_LUA_WORD5 = 16;
-    public const int SCE_LUA_WORD6 = 17;
-    public const int SCE_LUA_WORD7 = 18;
-    public const int SCE_LUA_WORD8 = 19;
-    public const int SCE_LUA_LABEL = 20;
+        // Lua
+        public const int SCE_LUA_DEFAULT = 0;
+        public const int SCE_LUA_COMMENT = 1;
+        public const int SCE_LUA_COMMENTLINE = 2;
+        public const int SCE_LUA_COMMENTDOC = 3;
+        public const int SCE_LUA_NUMBER = 4;
+        public const int SCE_LUA_WORD = 5;
+        public const int SCE_LUA_STRING = 6;
+        public const int SCE_LUA_CHARACTER = 7;
+        public const int SCE_LUA_LITERALSTRING = 8;
+        public const int SCE_LUA_PREPROCESSOR = 9;
+        public const int SCE_LUA_OPERATOR = 10;
+        public const int SCE_LUA_IDENTIFIER = 11;
+        public const int SCE_LUA_STRINGEOL = 12;
+        public const int SCE_LUA_WORD2 = 13;
+        public const int SCE_LUA_WORD3 = 14;
+        public const int SCE_LUA_WORD4 = 15;
+        public const int SCE_LUA_WORD5 = 16;
+        public const int SCE_LUA_WORD6 = 17;
+        public const int SCE_LUA_WORD7 = 18;
+        public const int SCE_LUA_WORD8 = 19;
+        public const int SCE_LUA_LABEL = 20;
 
-    public const int SCE_PAS_DEFAULT = 0;
-    public const int SCE_PAS_IDENTIFIER = 1;
-    public const int SCE_PAS_COMMENT = 2;
-    public const int SCE_PAS_COMMENT2 = 3;
-    public const int SCE_PAS_COMMENTLINE = 4;
-    public const int SCE_PAS_PREPROCESSOR = 5;
-    public const int SCE_PAS_PREPROCESSOR2 = 6;
-    public const int SCE_PAS_NUMBER = 7;
-    public const int SCE_PAS_HEXNUMBER = 8;
-    public const int SCE_PAS_WORD = 9;
-    public const int SCE_PAS_STRING = 10;
-    public const int SCE_PAS_STRINGEOL = 11;
-    public const int SCE_PAS_CHARACTER = 12;
-    public const int SCE_PAS_OPERATOR = 13;
-    public const int SCE_PAS_ASM = 14;
+        public const int SCE_PAS_DEFAULT = 0;
+        public const int SCE_PAS_IDENTIFIER = 1;
+        public const int SCE_PAS_COMMENT = 2;
+        public const int SCE_PAS_COMMENT2 = 3;
+        public const int SCE_PAS_COMMENTLINE = 4;
+        public const int SCE_PAS_PREPROCESSOR = 5;
+        public const int SCE_PAS_PREPROCESSOR2 = 6;
+        public const int SCE_PAS_NUMBER = 7;
+        public const int SCE_PAS_HEXNUMBER = 8;
+        public const int SCE_PAS_WORD = 9;
+        public const int SCE_PAS_STRING = 10;
+        public const int SCE_PAS_STRINGEOL = 11;
+        public const int SCE_PAS_CHARACTER = 12;
+        public const int SCE_PAS_OPERATOR = 13;
+        public const int SCE_PAS_ASM = 14;
 
-    // Matlab
-    public const int SCE_MATLAB_DEFAULT = 0;
-    public const int SCE_MATLAB_COMMENT = 1;
-    public const int SCE_MATLAB_COMMAND = 2;
-    public const int SCE_MATLAB_NUMBER = 3;
-    public const int SCE_MATLAB_KEYWORD = 4;
-    public const int SCE_MATLAB_STRING = 5;
-    public const int SCE_MATLAB_OPERATOR = 6;
-    public const int SCE_MATLAB_IDENTIFIER = 7;
-    public const int SCE_MATLAB_DOUBLEQUOTESTRING = 8;
+        // Matlab
+        public const int SCE_MATLAB_DEFAULT = 0;
+        public const int SCE_MATLAB_COMMENT = 1;
+        public const int SCE_MATLAB_COMMAND = 2;
+        public const int SCE_MATLAB_NUMBER = 3;
+        public const int SCE_MATLAB_KEYWORD = 4;
+        public const int SCE_MATLAB_STRING = 5;
+        public const int SCE_MATLAB_OPERATOR = 6;
+        public const int SCE_MATLAB_IDENTIFIER = 7;
+        public const int SCE_MATLAB_DOUBLEQUOTESTRING = 8;
 
-    // Perl
-    public const int SCE_PL_DEFAULT = 0;
-    public const int SCE_PL_ERROR = 1;
-    public const int SCE_PL_COMMENTLINE = 2;
-    public const int SCE_PL_POD = 3;
-    public const int SCE_PL_NUMBER = 4;
-    public const int SCE_PL_WORD = 5;
-    public const int SCE_PL_STRING = 6;
-    public const int SCE_PL_CHARACTER = 7;
-    public const int SCE_PL_PUNCTUATION = 8;
-    public const int SCE_PL_PREPROCESSOR = 9;
-    public const int SCE_PL_OPERATOR = 10;
-    public const int SCE_PL_IDENTIFIER = 11;
-    public const int SCE_PL_SCALAR = 12;
-    public const int SCE_PL_ARRAY = 13;
-    public const int SCE_PL_HASH = 14;
-    public const int SCE_PL_SYMBOLTABLE = 15;
-    public const int SCE_PL_VARIABLE_INDEXER = 16;
-    public const int SCE_PL_REGEX = 17;
-    public const int SCE_PL_REGSUBST = 18;
-    public const int SCE_PL_LONGQUOTE = 19;
-    public const int SCE_PL_BACKTICKS = 20;
-    public const int SCE_PL_DATASECTION = 21;
-    public const int SCE_PL_HERE_DELIM = 22;
-    public const int SCE_PL_HERE_Q = 23;
-    public const int SCE_PL_HERE_QQ = 24;
-    public const int SCE_PL_HERE_QX = 25;
-    public const int SCE_PL_STRING_Q = 26;
-    public const int SCE_PL_STRING_QQ = 27;
-    public const int SCE_PL_STRING_QX = 28;
-    public const int SCE_PL_STRING_QR = 29;
-    public const int SCE_PL_STRING_QW = 30;
-    public const int SCE_PL_POD_VERB = 31;
-    public const int SCE_PL_SUB_PROTOTYPE = 40;
-    public const int SCE_PL_FORMAT_IDENT = 41;
-    public const int SCE_PL_FORMAT = 42;
-    public const int SCE_PL_STRING_VAR = 43;
-    public const int SCE_PL_XLAT = 44;
-    public const int SCE_PL_REGEX_VAR = 54;
-    public const int SCE_PL_REGSUBST_VAR = 55;
-    public const int SCE_PL_BACKTICKS_VAR = 57;
-    public const int SCE_PL_HERE_QQ_VAR = 61;
-    public const int SCE_PL_HERE_QX_VAR = 62;
-    public const int SCE_PL_STRING_QQ_VAR = 64;
-    public const int SCE_PL_STRING_QX_VAR = 65;
-    public const int SCE_PL_STRING_QR_VAR = 66;
+        // Perl
+        public const int SCE_PL_DEFAULT = 0;
+        public const int SCE_PL_ERROR = 1;
+        public const int SCE_PL_COMMENTLINE = 2;
+        public const int SCE_PL_POD = 3;
+        public const int SCE_PL_NUMBER = 4;
+        public const int SCE_PL_WORD = 5;
+        public const int SCE_PL_STRING = 6;
+        public const int SCE_PL_CHARACTER = 7;
+        public const int SCE_PL_PUNCTUATION = 8;
+        public const int SCE_PL_PREPROCESSOR = 9;
+        public const int SCE_PL_OPERATOR = 10;
+        public const int SCE_PL_IDENTIFIER = 11;
+        public const int SCE_PL_SCALAR = 12;
+        public const int SCE_PL_ARRAY = 13;
+        public const int SCE_PL_HASH = 14;
+        public const int SCE_PL_SYMBOLTABLE = 15;
+        public const int SCE_PL_VARIABLE_INDEXER = 16;
+        public const int SCE_PL_REGEX = 17;
+        public const int SCE_PL_REGSUBST = 18;
+        public const int SCE_PL_LONGQUOTE = 19;
+        public const int SCE_PL_BACKTICKS = 20;
+        public const int SCE_PL_DATASECTION = 21;
+        public const int SCE_PL_HERE_DELIM = 22;
+        public const int SCE_PL_HERE_Q = 23;
+        public const int SCE_PL_HERE_QQ = 24;
+        public const int SCE_PL_HERE_QX = 25;
+        public const int SCE_PL_STRING_Q = 26;
+        public const int SCE_PL_STRING_QQ = 27;
+        public const int SCE_PL_STRING_QX = 28;
+        public const int SCE_PL_STRING_QR = 29;
+        public const int SCE_PL_STRING_QW = 30;
+        public const int SCE_PL_POD_VERB = 31;
+        public const int SCE_PL_SUB_PROTOTYPE = 40;
+        public const int SCE_PL_FORMAT_IDENT = 41;
+        public const int SCE_PL_FORMAT = 42;
+        public const int SCE_PL_STRING_VAR = 43;
+        public const int SCE_PL_XLAT = 44;
+        public const int SCE_PL_REGEX_VAR = 54;
+        public const int SCE_PL_REGSUBST_VAR = 55;
+        public const int SCE_PL_BACKTICKS_VAR = 57;
+        public const int SCE_PL_HERE_QQ_VAR = 61;
+        public const int SCE_PL_HERE_QX_VAR = 62;
+        public const int SCE_PL_STRING_QQ_VAR = 64;
+        public const int SCE_PL_STRING_QX_VAR = 65;
+        public const int SCE_PL_STRING_QR_VAR = 66;
 
-    // PowerShell
-    public const int SCE_POWERSHELL_DEFAULT = 0;
-    public const int SCE_POWERSHELL_COMMENT = 1;
-    public const int SCE_POWERSHELL_STRING = 2;
-    public const int SCE_POWERSHELL_CHARACTER = 3;
-    public const int SCE_POWERSHELL_NUMBER = 4;
-    public const int SCE_POWERSHELL_VARIABLE = 5;
-    public const int SCE_POWERSHELL_OPERATOR = 6;
-    public const int SCE_POWERSHELL_IDENTIFIER = 7;
-    public const int SCE_POWERSHELL_KEYWORD = 8;
-    public const int SCE_POWERSHELL_CMDLET = 9;
-    public const int SCE_POWERSHELL_ALIAS = 10;
-    public const int SCE_POWERSHELL_FUNCTION = 11;
-    public const int SCE_POWERSHELL_USER1 = 12;
-    public const int SCE_POWERSHELL_COMMENTSTREAM = 13;
-    public const int SCE_POWERSHELL_HERE_STRING = 14;
-    public const int SCE_POWERSHELL_HERE_CHARACTER = 15;
-    public const int SCE_POWERSHELL_COMMENTDOCKEYWORD = 16;
+        // PowerShell
+        public const int SCE_POWERSHELL_DEFAULT = 0;
+        public const int SCE_POWERSHELL_COMMENT = 1;
+        public const int SCE_POWERSHELL_STRING = 2;
+        public const int SCE_POWERSHELL_CHARACTER = 3;
+        public const int SCE_POWERSHELL_NUMBER = 4;
+        public const int SCE_POWERSHELL_VARIABLE = 5;
+        public const int SCE_POWERSHELL_OPERATOR = 6;
+        public const int SCE_POWERSHELL_IDENTIFIER = 7;
+        public const int SCE_POWERSHELL_KEYWORD = 8;
+        public const int SCE_POWERSHELL_CMDLET = 9;
+        public const int SCE_POWERSHELL_ALIAS = 10;
+        public const int SCE_POWERSHELL_FUNCTION = 11;
+        public const int SCE_POWERSHELL_USER1 = 12;
+        public const int SCE_POWERSHELL_COMMENTSTREAM = 13;
+        public const int SCE_POWERSHELL_HERE_STRING = 14;
+        public const int SCE_POWERSHELL_HERE_CHARACTER = 15;
+        public const int SCE_POWERSHELL_COMMENTDOCKEYWORD = 16;
 
-    // Properties
-    public const int SCE_PROPS_DEFAULT = 0;
-    public const int SCE_PROPS_COMMENT = 1;
-    public const int SCE_PROPS_SECTION = 2;
-    public const int SCE_PROPS_ASSIGNMENT = 3;
-    public const int SCE_PROPS_DEFVAL = 4;
-    public const int SCE_PROPS_KEY = 5;
+        // Properties
+        public const int SCE_PROPS_DEFAULT = 0;
+        public const int SCE_PROPS_COMMENT = 1;
+        public const int SCE_PROPS_SECTION = 2;
+        public const int SCE_PROPS_ASSIGNMENT = 3;
+        public const int SCE_PROPS_DEFVAL = 4;
+        public const int SCE_PROPS_KEY = 5;
 
-    // PHP script
-    public const int SCE_HPHP_COMPLEX_VARIABLE = 104;
-    public const int SCE_HPHP_DEFAULT = 118;
-    public const int SCE_HPHP_HSTRING = 119;
-    public const int SCE_HPHP_SIMPLESTRING = 120;
-    public const int SCE_HPHP_WORD = 121;
-    public const int SCE_HPHP_NUMBER = 122;
-    public const int SCE_HPHP_VARIABLE = 123;
-    public const int SCE_HPHP_COMMENT = 124;
-    public const int SCE_HPHP_COMMENTLINE = 125;
-    public const int SCE_HPHP_HSTRING_VARIABLE = 126;
-    public const int SCE_HPHP_OPERATOR = 127;
+        // PHP script
+        public const int SCE_HPHP_COMPLEX_VARIABLE = 104;
+        public const int SCE_HPHP_DEFAULT = 118;
+        public const int SCE_HPHP_HSTRING = 119;
+        public const int SCE_HPHP_SIMPLESTRING = 120;
+        public const int SCE_HPHP_WORD = 121;
+        public const int SCE_HPHP_NUMBER = 122;
+        public const int SCE_HPHP_VARIABLE = 123;
+        public const int SCE_HPHP_COMMENT = 124;
+        public const int SCE_HPHP_COMMENTLINE = 125;
+        public const int SCE_HPHP_HSTRING_VARIABLE = 126;
+        public const int SCE_HPHP_OPERATOR = 127;
 
-    // SQL
-    public const int SCE_SQL_DEFAULT = 0;
-    public const int SCE_SQL_COMMENT = 1;
-    public const int SCE_SQL_COMMENTLINE = 2;
-    public const int SCE_SQL_COMMENTDOC = 3;
-    public const int SCE_SQL_NUMBER = 4;
-    public const int SCE_SQL_WORD = 5;
-    public const int SCE_SQL_STRING = 6;
-    public const int SCE_SQL_CHARACTER = 7;
-    public const int SCE_SQL_SQLPLUS = 8;
-    public const int SCE_SQL_SQLPLUS_PROMPT = 9;
-    public const int SCE_SQL_OPERATOR = 10;
-    public const int SCE_SQL_IDENTIFIER = 11;
-    public const int SCE_SQL_SQLPLUS_COMMENT = 13;
-    public const int SCE_SQL_COMMENTLINEDOC = 15;
-    public const int SCE_SQL_WORD2 = 16;
-    public const int SCE_SQL_COMMENTDOCKEYWORD = 17;
-    public const int SCE_SQL_COMMENTDOCKEYWORDERROR = 18;
-    public const int SCE_SQL_USER1 = 19;
-    public const int SCE_SQL_USER2 = 20;
-    public const int SCE_SQL_USER3 = 21;
-    public const int SCE_SQL_USER4 = 22;
-    public const int SCE_SQL_QUOTEDIDENTIFIER = 23;
-    public const int SCE_SQL_QOPERATOR = 24;
+        // SQL
+        public const int SCE_SQL_DEFAULT = 0;
+        public const int SCE_SQL_COMMENT = 1;
+        public const int SCE_SQL_COMMENTLINE = 2;
+        public const int SCE_SQL_COMMENTDOC = 3;
+        public const int SCE_SQL_NUMBER = 4;
+        public const int SCE_SQL_WORD = 5;
+        public const int SCE_SQL_STRING = 6;
+        public const int SCE_SQL_CHARACTER = 7;
+        public const int SCE_SQL_SQLPLUS = 8;
+        public const int SCE_SQL_SQLPLUS_PROMPT = 9;
+        public const int SCE_SQL_OPERATOR = 10;
+        public const int SCE_SQL_IDENTIFIER = 11;
+        public const int SCE_SQL_SQLPLUS_COMMENT = 13;
+        public const int SCE_SQL_COMMENTLINEDOC = 15;
+        public const int SCE_SQL_WORD2 = 16;
+        public const int SCE_SQL_COMMENTDOCKEYWORD = 17;
+        public const int SCE_SQL_COMMENTDOCKEYWORDERROR = 18;
+        public const int SCE_SQL_USER1 = 19;
+        public const int SCE_SQL_USER2 = 20;
+        public const int SCE_SQL_USER3 = 21;
+        public const int SCE_SQL_USER4 = 22;
+        public const int SCE_SQL_QUOTEDIDENTIFIER = 23;
+        public const int SCE_SQL_QOPERATOR = 24;
 
-    // Python
-    public const int SCE_P_DEFAULT = 0;
-    public const int SCE_P_COMMENTLINE = 1;
-    public const int SCE_P_NUMBER = 2;
-    public const int SCE_P_STRING = 3;
-    public const int SCE_P_CHARACTER = 4;
-    public const int SCE_P_WORD = 5;
-    public const int SCE_P_TRIPLE = 6;
-    public const int SCE_P_TRIPLEDOUBLE = 7;
-    public const int SCE_P_CLASSNAME = 8;
-    public const int SCE_P_DEFNAME = 9;
-    public const int SCE_P_OPERATOR = 10;
-    public const int SCE_P_IDENTIFIER = 11;
-    public const int SCE_P_COMMENTBLOCK = 12;
-    public const int SCE_P_STRINGEOL = 13;
-    public const int SCE_P_WORD2 = 14;
-    public const int SCE_P_DECORATOR = 15;
+        // Python
+        public const int SCE_P_DEFAULT = 0;
+        public const int SCE_P_COMMENTLINE = 1;
+        public const int SCE_P_NUMBER = 2;
+        public const int SCE_P_STRING = 3;
+        public const int SCE_P_CHARACTER = 4;
+        public const int SCE_P_WORD = 5;
+        public const int SCE_P_TRIPLE = 6;
+        public const int SCE_P_TRIPLEDOUBLE = 7;
+        public const int SCE_P_CLASSNAME = 8;
+        public const int SCE_P_DEFNAME = 9;
+        public const int SCE_P_OPERATOR = 10;
+        public const int SCE_P_IDENTIFIER = 11;
+        public const int SCE_P_COMMENTBLOCK = 12;
+        public const int SCE_P_STRINGEOL = 13;
+        public const int SCE_P_WORD2 = 14;
+        public const int SCE_P_DECORATOR = 15;
 
-    // Ruby
-    public const int SCE_RB_DEFAULT = 0;
-    public const int SCE_RB_ERROR = 1;
-    public const int SCE_RB_COMMENTLINE = 2;
-    public const int SCE_RB_POD = 3;
-    public const int SCE_RB_NUMBER = 4;
-    public const int SCE_RB_WORD = 5;
-    public const int SCE_RB_STRING = 6;
-    public const int SCE_RB_CHARACTER = 7;
-    public const int SCE_RB_CLASSNAME = 8;
-    public const int SCE_RB_DEFNAME = 9;
-    public const int SCE_RB_OPERATOR = 10;
-    public const int SCE_RB_IDENTIFIER = 11;
-    public const int SCE_RB_REGEX = 12;
-    public const int SCE_RB_GLOBAL = 13;
-    public const int SCE_RB_SYMBOL = 14;
-    public const int SCE_RB_MODULE_NAME = 15;
-    public const int SCE_RB_INSTANCE_VAR = 16;
-    public const int SCE_RB_CLASS_VAR = 17;
-    public const int SCE_RB_BACKTICKS = 18;
-    public const int SCE_RB_DATASECTION = 19;
-    public const int SCE_RB_HERE_DELIM = 20;
-    public const int SCE_RB_HERE_Q = 21;
-    public const int SCE_RB_HERE_QQ = 22;
-    public const int SCE_RB_HERE_QX = 23;
-    public const int SCE_RB_STRING_Q = 24;
-    public const int SCE_RB_STRING_QQ = 25;
-    public const int SCE_RB_STRING_QX = 26;
-    public const int SCE_RB_STRING_QR = 27;
-    public const int SCE_RB_STRING_QW = 28;
-    public const int SCE_RB_WORD_DEMOTED = 29;
-    public const int SCE_RB_STDIN = 30;
-    public const int SCE_RB_STDOUT = 31;
-    public const int SCE_RB_STDERR = 40;
-    public const int SCE_RB_UPPER_BOUND = 41;
+        // Ruby
+        public const int SCE_RB_DEFAULT = 0;
+        public const int SCE_RB_ERROR = 1;
+        public const int SCE_RB_COMMENTLINE = 2;
+        public const int SCE_RB_POD = 3;
+        public const int SCE_RB_NUMBER = 4;
+        public const int SCE_RB_WORD = 5;
+        public const int SCE_RB_STRING = 6;
+        public const int SCE_RB_CHARACTER = 7;
+        public const int SCE_RB_CLASSNAME = 8;
+        public const int SCE_RB_DEFNAME = 9;
+        public const int SCE_RB_OPERATOR = 10;
+        public const int SCE_RB_IDENTIFIER = 11;
+        public const int SCE_RB_REGEX = 12;
+        public const int SCE_RB_GLOBAL = 13;
+        public const int SCE_RB_SYMBOL = 14;
+        public const int SCE_RB_MODULE_NAME = 15;
+        public const int SCE_RB_INSTANCE_VAR = 16;
+        public const int SCE_RB_CLASS_VAR = 17;
+        public const int SCE_RB_BACKTICKS = 18;
+        public const int SCE_RB_DATASECTION = 19;
+        public const int SCE_RB_HERE_DELIM = 20;
+        public const int SCE_RB_HERE_Q = 21;
+        public const int SCE_RB_HERE_QQ = 22;
+        public const int SCE_RB_HERE_QX = 23;
+        public const int SCE_RB_STRING_Q = 24;
+        public const int SCE_RB_STRING_QQ = 25;
+        public const int SCE_RB_STRING_QX = 26;
+        public const int SCE_RB_STRING_QR = 27;
+        public const int SCE_RB_STRING_QW = 28;
+        public const int SCE_RB_WORD_DEMOTED = 29;
+        public const int SCE_RB_STDIN = 30;
+        public const int SCE_RB_STDOUT = 31;
+        public const int SCE_RB_STDERR = 40;
+        public const int SCE_RB_UPPER_BOUND = 41;
 
-    // Smalltalk
-    public const int SCE_ST_DEFAULT = 0;
-    public const int SCE_ST_STRING = 1;
-    public const int SCE_ST_NUMBER = 2;
-    public const int SCE_ST_COMMENT = 3;
-    public const int SCE_ST_SYMBOL = 4;
-    public const int SCE_ST_BINARY = 5;
-    public const int SCE_ST_BOOL = 6;
-    public const int SCE_ST_SELF = 7;
-    public const int SCE_ST_SUPER = 8;
-    public const int SCE_ST_NIL = 9;
-    public const int SCE_ST_GLOBAL = 10;
-    public const int SCE_ST_RETURN = 11;
-    public const int SCE_ST_SPECIAL = 12;
-    public const int SCE_ST_KWSEND = 13;
-    public const int SCE_ST_ASSIGN = 14;
-    public const int SCE_ST_CHARACTER = 15;
-    public const int SCE_ST_SPEC_SEL = 16;
+        // Smalltalk
+        public const int SCE_ST_DEFAULT = 0;
+        public const int SCE_ST_STRING = 1;
+        public const int SCE_ST_NUMBER = 2;
+        public const int SCE_ST_COMMENT = 3;
+        public const int SCE_ST_SYMBOL = 4;
+        public const int SCE_ST_BINARY = 5;
+        public const int SCE_ST_BOOL = 6;
+        public const int SCE_ST_SELF = 7;
+        public const int SCE_ST_SUPER = 8;
+        public const int SCE_ST_NIL = 9;
+        public const int SCE_ST_GLOBAL = 10;
+        public const int SCE_ST_RETURN = 11;
+        public const int SCE_ST_SPECIAL = 12;
+        public const int SCE_ST_KWSEND = 13;
+        public const int SCE_ST_ASSIGN = 14;
+        public const int SCE_ST_CHARACTER = 15;
+        public const int SCE_ST_SPEC_SEL = 16;
 
-    // Basic / VB
-    public const int SCE_B_DEFAULT = 0;
-    public const int SCE_B_COMMENT = 1;
-    public const int SCE_B_NUMBER = 2;
-    public const int SCE_B_KEYWORD = 3;
-    public const int SCE_B_STRING = 4;
-    public const int SCE_B_PREPROCESSOR = 5;
-    public const int SCE_B_OPERATOR = 6;
-    public const int SCE_B_IDENTIFIER = 7;
-    public const int SCE_B_DATE = 8;
-    public const int SCE_B_STRINGEOL = 9;
-    public const int SCE_B_KEYWORD2 = 10;
-    public const int SCE_B_KEYWORD3 = 11;
-    public const int SCE_B_KEYWORD4 = 12;
-    public const int SCE_B_CONSTANT = 13;
-    public const int SCE_B_ASM = 14;
-    public const int SCE_B_LABEL = 15;
-    public const int SCE_B_ERROR = 16;
-    public const int SCE_B_HEXNUMBER = 17;
-    public const int SCE_B_BINNUMBER = 18;
-    public const int SCE_B_COMMENTBLOCK = 19;
-    public const int SCE_B_DOCLINE = 20;
-    public const int SCE_B_DOCBLOCK = 21;
-    public const int SCE_B_DOCKEYWORD = 22;
+        // Basic / VB
+        public const int SCE_B_DEFAULT = 0;
+        public const int SCE_B_COMMENT = 1;
+        public const int SCE_B_NUMBER = 2;
+        public const int SCE_B_KEYWORD = 3;
+        public const int SCE_B_STRING = 4;
+        public const int SCE_B_PREPROCESSOR = 5;
+        public const int SCE_B_OPERATOR = 6;
+        public const int SCE_B_IDENTIFIER = 7;
+        public const int SCE_B_DATE = 8;
+        public const int SCE_B_STRINGEOL = 9;
+        public const int SCE_B_KEYWORD2 = 10;
+        public const int SCE_B_KEYWORD3 = 11;
+        public const int SCE_B_KEYWORD4 = 12;
+        public const int SCE_B_CONSTANT = 13;
+        public const int SCE_B_ASM = 14;
+        public const int SCE_B_LABEL = 15;
+        public const int SCE_B_ERROR = 16;
+        public const int SCE_B_HEXNUMBER = 17;
+        public const int SCE_B_BINNUMBER = 18;
+        public const int SCE_B_COMMENTBLOCK = 19;
+        public const int SCE_B_DOCLINE = 20;
+        public const int SCE_B_DOCBLOCK = 21;
+        public const int SCE_B_DOCKEYWORD = 22;
 
-    // Markdown
-    public const int SCE_MARKDOWN_DEFAULT = 0;
-    public const int SCE_MARKDOWN_LINE_BEGIN = 1;
-    public const int SCE_MARKDOWN_STRONG1 = 2;
-    public const int SCE_MARKDOWN_STRONG2 = 3;
-    public const int SCE_MARKDOWN_EM1 = 4;
-    public const int SCE_MARKDOWN_EM2 = 5;
-    public const int SCE_MARKDOWN_HEADER1 = 6;
-    public const int SCE_MARKDOWN_HEADER2 = 7;
-    public const int SCE_MARKDOWN_HEADER3 = 8;
-    public const int SCE_MARKDOWN_HEADER4 = 9;
-    public const int SCE_MARKDOWN_HEADER5 = 10;
-    public const int SCE_MARKDOWN_HEADER6 = 11;
-    public const int SCE_MARKDOWN_PRECHAR = 12;
-    public const int SCE_MARKDOWN_ULIST_ITEM = 13;
-    public const int SCE_MARKDOWN_OLIST_ITEM = 14;
-    public const int SCE_MARKDOWN_BLOCKQUOTE = 15;
-    public const int SCE_MARKDOWN_STRIKEOUT = 16;
-    public const int SCE_MARKDOWN_HRULE = 17;
-    public const int SCE_MARKDOWN_LINK = 18;
-    public const int SCE_MARKDOWN_CODE = 19;
-    public const int SCE_MARKDOWN_CODE2 = 20;
-    public const int SCE_MARKDOWN_CODEBK = 21;
+        // Markdown
+        public const int SCE_MARKDOWN_DEFAULT = 0;
+        public const int SCE_MARKDOWN_LINE_BEGIN = 1;
+        public const int SCE_MARKDOWN_STRONG1 = 2;
+        public const int SCE_MARKDOWN_STRONG2 = 3;
+        public const int SCE_MARKDOWN_EM1 = 4;
+        public const int SCE_MARKDOWN_EM2 = 5;
+        public const int SCE_MARKDOWN_HEADER1 = 6;
+        public const int SCE_MARKDOWN_HEADER2 = 7;
+        public const int SCE_MARKDOWN_HEADER3 = 8;
+        public const int SCE_MARKDOWN_HEADER4 = 9;
+        public const int SCE_MARKDOWN_HEADER5 = 10;
+        public const int SCE_MARKDOWN_HEADER6 = 11;
+        public const int SCE_MARKDOWN_PRECHAR = 12;
+        public const int SCE_MARKDOWN_ULIST_ITEM = 13;
+        public const int SCE_MARKDOWN_OLIST_ITEM = 14;
+        public const int SCE_MARKDOWN_BLOCKQUOTE = 15;
+        public const int SCE_MARKDOWN_STRIKEOUT = 16;
+        public const int SCE_MARKDOWN_HRULE = 17;
+        public const int SCE_MARKDOWN_LINK = 18;
+        public const int SCE_MARKDOWN_CODE = 19;
+        public const int SCE_MARKDOWN_CODE2 = 20;
+        public const int SCE_MARKDOWN_CODEBK = 21;
 
-    // R
-    public const int SCE_R_DEFAULT = 0;
-    public const int SCE_R_COMMENT = 1;
-    public const int SCE_R_KWORD = 2;
-    public const int SCE_R_BASEKWORD = 3;
-    public const int SCE_R_OTHERKWORD = 4;
-    public const int SCE_R_NUMBER = 5;
-    public const int SCE_R_STRING = 6;
-    public const int SCE_R_STRING2 = 7;
-    public const int SCE_R_OPERATOR = 8;
-    public const int SCE_R_IDENTIFIER = 9;
-    public const int SCE_R_INFIX = 10;
-    public const int SCE_R_INFIXEOL = 11;
+        // R
+        public const int SCE_R_DEFAULT = 0;
+        public const int SCE_R_COMMENT = 1;
+        public const int SCE_R_KWORD = 2;
+        public const int SCE_R_BASEKWORD = 3;
+        public const int SCE_R_OTHERKWORD = 4;
+        public const int SCE_R_NUMBER = 5;
+        public const int SCE_R_STRING = 6;
+        public const int SCE_R_STRING2 = 7;
+        public const int SCE_R_OPERATOR = 8;
+        public const int SCE_R_IDENTIFIER = 9;
+        public const int SCE_R_INFIX = 10;
+        public const int SCE_R_INFIXEOL = 11;
 
-    // Verilog
-    public const int SCE_V_DEFAULT = 0;
-    public const int SCE_V_COMMENT = 1;
-    public const int SCE_V_COMMENTLINE = 2;
-    public const int SCE_V_COMMENTLINEBANG = 3;
-    public const int SCE_V_NUMBER = 4;
-    public const int SCE_V_WORD = 5;
-    public const int SCE_V_STRING = 6;
-    public const int SCE_V_WORD2 = 7;
-    public const int SCE_V_WORD3 = 8;
-    public const int SCE_V_PREPROCESSOR = 9;
-    public const int SCE_V_OPERATOR = 10;
-    public const int SCE_V_IDENTIFIER = 11;
-    public const int SCE_V_STRINGEOL = 12;
-    public const int SCE_V_USER = 19;
-    public const int SCE_V_COMMENT_WORD = 20;
-    public const int SCE_V_INPUT = 21;
-    public const int SCE_V_OUTPUT = 22;
-    public const int SCE_V_INOUT = 23;
-    public const int SCE_V_PORT_CONNECT = 24;
+        // Verilog
+        public const int SCE_V_DEFAULT = 0;
+        public const int SCE_V_COMMENT = 1;
+        public const int SCE_V_COMMENTLINE = 2;
+        public const int SCE_V_COMMENTLINEBANG = 3;
+        public const int SCE_V_NUMBER = 4;
+        public const int SCE_V_WORD = 5;
+        public const int SCE_V_STRING = 6;
+        public const int SCE_V_WORD2 = 7;
+        public const int SCE_V_WORD3 = 8;
+        public const int SCE_V_PREPROCESSOR = 9;
+        public const int SCE_V_OPERATOR = 10;
+        public const int SCE_V_IDENTIFIER = 11;
+        public const int SCE_V_STRINGEOL = 12;
+        public const int SCE_V_USER = 19;
+        public const int SCE_V_COMMENT_WORD = 20;
+        public const int SCE_V_INPUT = 21;
+        public const int SCE_V_OUTPUT = 22;
+        public const int SCE_V_INOUT = 23;
+        public const int SCE_V_PORT_CONNECT = 24;
 
-    #endregion Lexer Constants
+        #endregion Lexer Constants
 
-    #region Callbacks
+        #region Callbacks
 
-    public delegate IntPtr Scintilla_DirectFunction(IntPtr ptr, int iMessage, IntPtr wParam, IntPtr lParam);
+        public delegate IntPtr Scintilla_DirectFunction(IntPtr ptr, int iMessage, IntPtr wParam, IntPtr lParam);
 
-    public delegate IntPtr CreateLexer(string lexerName);
+        public delegate IntPtr CreateLexer(string lexerName);
 
-    public delegate void GetLexerName(UIntPtr index, IntPtr name, IntPtr bufferLength);
+        public delegate void GetLexerName(UIntPtr index, IntPtr name, IntPtr bufferLength);
 
-    public delegate IntPtr GetLexerCount();
+        public delegate IntPtr GetLexerCount();
 
-    public delegate string LexerNameFromID(IntPtr identifier);
+        public delegate string LexerNameFromID(IntPtr identifier);
 
-    #endregion Callbacks
+        #endregion Callbacks
 
-    #region Functions
+        #region Functions
 
-    [DllImport(DLL_NAME_USER32, SetLastError = true)]
-    public static extern IntPtr MB_GetString(uint hInst);
+        [DllImport(DLL_NAME_USER32, SetLastError = true)]
+        public static extern IntPtr MB_GetString(uint hInst);
 
-    public static string GetMessageBoxString(uint msgId) =>
-        Marshal.PtrToStringUni(MB_GetString(msgId));
+        public static string GetMessageBoxString(uint msgId) =>
+            Marshal.PtrToStringUni(MB_GetString(msgId));
 
-    [DllImport(DLL_NAME_USER32, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool CloseClipboard();
+        [DllImport(DLL_NAME_USER32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CloseClipboard();
 
-    [DllImport(DLL_NAME_GDI32, ExactSpelling = true)]
-    public static extern int CombineRgn(IntPtr hrgnDest, IntPtr hrgnSrc1, IntPtr hrgnSrc2, int fnCombineMode);
+        [DllImport(DLL_NAME_GDI32, ExactSpelling = true)]
+        public static extern int CombineRgn(IntPtr hrgnDest, IntPtr hrgnSrc1, IntPtr hrgnSrc2, int fnCombineMode);
 
-    [DllImport(DLL_NAME_GDI32, ExactSpelling = true)]
-    public static extern IntPtr CreateRectRgn(int x1, int y1, int x2, int y2);
+        [DllImport(DLL_NAME_GDI32, ExactSpelling = true)]
+        public static extern IntPtr CreateRectRgn(int x1, int y1, int x2, int y2);
 
-    [DllImport(DLL_NAME_KERNEL32, CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
-    public static extern IntPtr GetProcAddress(HandleRef hModule, string lpProcName);
+        [DllImport(DLL_NAME_KERNEL32, CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
+        public static extern IntPtr GetProcAddress(HandleRef hModule, string lpProcName);
 
-    [DllImport(DLL_NAME_USER32, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool EmptyClipboard();
+        [DllImport(DLL_NAME_USER32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EmptyClipboard();
 
-    [DllImport(DLL_NAME_USER32, ExactSpelling = true)]
-    public static extern IntPtr GetWindowDC(IntPtr hWnd);
+        [DllImport(DLL_NAME_USER32, ExactSpelling = true)]
+        public static extern IntPtr GetWindowDC(IntPtr hWnd);
 
-    [DllImport(DLL_NAME_USER32, ExactSpelling = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+        [DllImport(DLL_NAME_USER32, ExactSpelling = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
-    [DllImport(DLL_NAME_KERNEL32, EntryPoint = "LoadLibraryW", CharSet = CharSet.Unicode, SetLastError = true)]
-    public static extern IntPtr LoadLibrary(string lpFileName);
+        [DllImport(DLL_NAME_KERNEL32, EntryPoint = "LoadLibraryW", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr LoadLibrary(string lpFileName);
 
-    [DllImport(DLL_NAME_KERNEL32, EntryPoint = "RtlMoveMemory", SetLastError = true)]
-    public static extern void MoveMemory(IntPtr dest, IntPtr src, int length);
+        [DllImport(DLL_NAME_KERNEL32, EntryPoint = "RtlMoveMemory", SetLastError = true)]
+        public static extern void MoveMemory(IntPtr dest, IntPtr src, int length);
 
-    [DllImport(DLL_NAME_USER32, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool OpenClipboard(IntPtr hWndNewOwner);
+        [DllImport(DLL_NAME_USER32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool OpenClipboard(IntPtr hWndNewOwner);
 
-    [DllImport(DLL_NAME_USER32, SetLastError = true)]
-    public static extern uint RegisterClipboardFormat(string lpszFormat);
+        [DllImport(DLL_NAME_USER32, SetLastError = true)]
+        public static extern uint RegisterClipboardFormat(string lpszFormat);
 
-    [DllImport(DLL_NAME_USER32, ExactSpelling = true)]
-    public static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+        [DllImport(DLL_NAME_USER32, ExactSpelling = true)]
+        public static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
 
-    [DllImport(DLL_NAME_OLE32, ExactSpelling = true)]
-    public static extern int RevokeDragDrop(IntPtr hwnd);
+        [DllImport(DLL_NAME_OLE32, ExactSpelling = true)]
+        public static extern int RevokeDragDrop(IntPtr hwnd);
 
-    [DllImport(DLL_NAME_USER32, EntryPoint = "SendMessageW", CharSet = CharSet.Unicode, SetLastError = true)]
-    public static extern IntPtr SendMessage(HandleRef hWnd, int msg, IntPtr wParam, IntPtr lParam);
+        [DllImport(DLL_NAME_USER32, EntryPoint = "SendMessageW", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
-    [DllImport(DLL_NAME_USER32, SetLastError = true)]
-    public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+        [DllImport(DLL_NAME_USER32, SetLastError = true)]
+        public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
 
-    [DllImport(DLL_NAME_USER32, SetLastError = true)]
-    public static extern IntPtr SetParent(IntPtr hWndChild, IntPtr hWndNewParent);
+        [DllImport(DLL_NAME_USER32, SetLastError = true)]
+        public static extern IntPtr SetParent(IntPtr hWndChild, IntPtr hWndNewParent);
 
-    #endregion Functions
+        #endregion Functions
 
-    #region Structures
+        #region Structures
 
-    // http://www.openrce.org/articles/full_view/23
-    // It's worth noting that this structure (and the 64-bit version below) represents the ILoader
-    // class virtual function table (vtable), NOT the ILoader interface defined in ILexer.h.
-    // In this case they are identical because the ILoader class contains only functions.
-    [StructLayout(LayoutKind.Sequential)]
-    public unsafe struct ILoaderVTable32
-    {
-        public ReleaseDelegate Release;
-        public AddDataDelegate AddData;
-        public ConvertToDocumentDelegate ConvertToDocument;
+        // http://www.openrce.org/articles/full_view/23
+        // It's worth noting that this structure (and the 64-bit version below) represents the ILoader
+        // class virtual function table (vtable), NOT the ILoader interface defined in ILexer.h.
+        // In this case they are identical because the ILoader class contains only functions.
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct ILoaderVTable32
+        {
+            public ReleaseDelegate Release;
+            public AddDataDelegate AddData;
+            public ConvertToDocumentDelegate ConvertToDocument;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        public delegate int ReleaseDelegate(IntPtr self);
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate int ReleaseDelegate(IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        public delegate int AddDataDelegate(IntPtr self, byte* data, int length);
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate int AddDataDelegate(IntPtr self, byte* data, int length);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        public delegate IntPtr ConvertToDocumentDelegate(IntPtr self);
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate IntPtr ConvertToDocumentDelegate(IntPtr self);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct ILoaderVTable64
+        {
+            public ReleaseDelegate Release;
+            public AddDataDelegate AddData;
+            public ConvertToDocumentDelegate ConvertToDocument;
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate int ReleaseDelegate(IntPtr self);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate int AddDataDelegate(IntPtr self, byte* data, int length);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate IntPtr ConvertToDocumentDelegate(IntPtr self);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Sci_CharacterRange
+        {
+            public int cpMin;
+            public int cpMax;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Sci_CharacterRangeFull
+        {
+            public IntPtr cpMin;
+            public IntPtr cpMax;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Sci_NotifyHeader
+        {
+            public IntPtr hwndFrom;
+            public IntPtr idFrom;
+            public int code;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Sci_TextRange
+        {
+            public Sci_CharacterRange chrg;
+            public IntPtr lpstrText;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Sci_TextRangeFull
+        {
+            public Sci_CharacterRangeFull chrg;
+            public IntPtr lpstrText;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Sci_TextToFind
+        {
+            public Sci_CharacterRange chrg;
+            public IntPtr lpstrText;
+            public Sci_CharacterRange chrgText;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Sci_TextToFindFull
+        {
+            public Sci_CharacterRangeFull chrg;
+            public IntPtr lpstrText;
+            public Sci_CharacterRangeFull chrgText;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SCNotification
+        {
+            public Sci_NotifyHeader nmhdr;
+            public IntPtr position;
+            public int ch;
+            public int modifiers;
+            public int modificationType;
+            public IntPtr text;
+            public IntPtr length;
+            public IntPtr linesAdded;
+            public int message;
+            public IntPtr wParam;
+            public IntPtr lParam;
+            public IntPtr line;
+            public int foldLevelNow;
+            public int foldLevelPrev;
+            public int margin;
+            public int listType;
+            public int x;
+            public int y;
+            public int token;
+            public IntPtr annotationLinesAdded;
+            public int updated;
+            public int listCompletionMethod;
+        }
+
+        #endregion Structures
     }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public unsafe struct ILoaderVTable64
-    {
-        public ReleaseDelegate Release;
-        public AddDataDelegate AddData;
-        public ConvertToDocumentDelegate ConvertToDocument;
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate int ReleaseDelegate(IntPtr self);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate int AddDataDelegate(IntPtr self, byte* data, int length);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate IntPtr ConvertToDocumentDelegate(IntPtr self);
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct RECT
-    {
-        public int left;
-        public int top;
-        public int right;
-        public int bottom;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Sci_CharacterRange
-    {
-        public int cpMin;
-        public int cpMax;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Sci_CharacterRangeFull
-    {
-        public nint cpMin;
-        public nint cpMax;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Sci_NotifyHeader
-    {
-        public IntPtr hwndFrom;
-        public IntPtr idFrom;
-        public int code;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Sci_TextRange
-    {
-        public Sci_CharacterRange chrg;
-        public IntPtr lpstrText;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Sci_TextRangeFull
-    {
-        public Sci_CharacterRangeFull chrg;
-        public IntPtr lpstrText;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Sci_TextToFind
-    {
-        public Sci_CharacterRange chrg;
-        public IntPtr lpstrText;
-        public Sci_CharacterRange chrgText;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Sci_TextToFindFull
-    {
-        public Sci_CharacterRangeFull chrg;
-        public IntPtr lpstrText;
-        public Sci_CharacterRangeFull chrgText;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct SCNotification
-    {
-        public Sci_NotifyHeader nmhdr;
-        public IntPtr position;
-        public int ch;
-        public int modifiers;
-        public int modificationType;
-        public IntPtr text;
-        public IntPtr length;
-        public IntPtr linesAdded;
-        public int message;
-        public IntPtr wParam;
-        public IntPtr lParam;
-        public IntPtr line;
-        public int foldLevelNow;
-        public int foldLevelPrev;
-        public int margin;
-        public int listType;
-        public int x;
-        public int y;
-        public int token;
-        public IntPtr annotationLinesAdded;
-        public int updated;
-        public int listCompletionMethod;
-    }
-
-    #endregion Structures
-}
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+}

--- a/Scintilla.NET/NeedShownEventArgs.cs
+++ b/Scintilla.NET/NeedShownEventArgs.cs
@@ -1,61 +1,62 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.NeedShown" /> event.
-/// </summary>
-public class NeedShownEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private readonly int byteLength;
-    private int? position;
-    private int? length;
-
     /// <summary>
-    /// Gets the length of the text that needs to be shown.
+    /// Provides data for the <see cref="Scintilla.NeedShown" /> event.
     /// </summary>
-    /// <returns>The length of text starting at <see cref="Position" /> that needs to be shown.</returns>
-    public int Length
+    public class NeedShownEventArgs : EventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private readonly int byteLength;
+        private int? position;
+        private int? length;
+
+        /// <summary>
+        /// Gets the length of the text that needs to be shown.
+        /// </summary>
+        /// <returns>The length of text starting at <see cref="Position" /> that needs to be shown.</returns>
+        public int Length
         {
-            if (this.length == null)
+            get
             {
-                int endBytePosition = this.bytePosition + this.byteLength;
-                int endPosition = this.scintilla.Lines.ByteToCharPosition(endBytePosition);
-                this.length = endPosition - Position;
+                if (this.length == null)
+                {
+                    int endBytePosition = this.bytePosition + this.byteLength;
+                    int endPosition = this.scintilla.Lines.ByteToCharPosition(endBytePosition);
+                    this.length = endPosition - Position;
+                }
+
+                return (int)this.length;
             }
-
-            return (int)this.length;
         }
-    }
 
-    /// <summary>
-    /// Gets the zero-based document position where text needs to be shown.
-    /// </summary>
-    /// <returns>The zero-based document position where the range of text to be shown starts.</returns>
-    public int Position
-    {
-        get
+        /// <summary>
+        /// Gets the zero-based document position where text needs to be shown.
+        /// </summary>
+        /// <returns>The zero-based document position where the range of text to be shown starts.</returns>
+        public int Position
         {
-            this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+            get
+            {
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
-            return (int)this.position;
+                return (int)this.position;
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NeedShownEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="bytePosition">The zero-based byte position within the document where text needs to be shown.</param>
-    /// <param name="byteLength">The length in bytes of the text that needs to be shown.</param>
-    public NeedShownEventArgs(Scintilla scintilla, int bytePosition, int byteLength)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
-        this.byteLength = byteLength;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NeedShownEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="bytePosition">The zero-based byte position within the document where text needs to be shown.</param>
+        /// <param name="byteLength">The length in bytes of the text that needs to be shown.</param>
+        public NeedShownEventArgs(Scintilla scintilla, int bytePosition, int byteLength)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+            this.byteLength = byteLength;
+        }
     }
 }

--- a/Scintilla.NET/Order.cs
+++ b/Scintilla.NET/Order.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The sorting order for autocompletion lists.
-/// </summary>
-public enum Order
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Requires that an autocompletion lists be sorted in alphabetical order. This is the default.
+    /// The sorting order for autocompletion lists.
     /// </summary>
-    Presorted = NativeMethods.SC_ORDER_PRESORTED,
+    public enum Order
+    {
+        /// <summary>
+        /// Requires that an autocompletion lists be sorted in alphabetical order. This is the default.
+        /// </summary>
+        Presorted = NativeMethods.SC_ORDER_PRESORTED,
 
-    /// <summary>
-    /// Instructs a <see cref="Scintilla" /> control to perform an alphabetical sort of autocompletion lists.
-    /// </summary>
-    PerformSort = NativeMethods.SC_ORDER_PERFORMSORT,
+        /// <summary>
+        /// Instructs a <see cref="Scintilla" /> control to perform an alphabetical sort of autocompletion lists.
+        /// </summary>
+        PerformSort = NativeMethods.SC_ORDER_PERFORMSORT,
 
-    /// <summary>
-    /// User-defined order.
-    /// </summary>
-    Custom = NativeMethods.SC_ORDER_CUSTOM
+        /// <summary>
+        /// User-defined order.
+        /// </summary>
+        Custom = NativeMethods.SC_ORDER_CUSTOM
+    }
 }

--- a/Scintilla.NET/Phases.cs
+++ b/Scintilla.NET/Phases.cs
@@ -1,23 +1,24 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The number of phases used when drawing.
-/// </summary>
-public enum Phases
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Drawing is done in a single phase. This is the fastest but provides no support for kerning.
+    /// The number of phases used when drawing.
     /// </summary>
-    One = NativeMethods.SC_PHASES_ONE,
+    public enum Phases
+    {
+        /// <summary>
+        /// Drawing is done in a single phase. This is the fastest but provides no support for kerning.
+        /// </summary>
+        One = NativeMethods.SC_PHASES_ONE,
 
-    /// <summary>
-    /// Drawing is done in two phases; the background first and then the text. This is the default.
-    /// </summary>
-    Two = NativeMethods.SC_PHASES_TWO,
+        /// <summary>
+        /// Drawing is done in two phases; the background first and then the text. This is the default.
+        /// </summary>
+        Two = NativeMethods.SC_PHASES_TWO,
 
-    /// <summary>
-    /// Drawing is done in multiple phases; once for each feature. This is the slowest but allows
-    /// extreme ascenders and descenders to overflow into adjacent lines.
-    /// </summary>
-    Multiple = NativeMethods.SC_PHASES_MULTIPLE
+        /// <summary>
+        /// Drawing is done in multiple phases; once for each feature. This is the slowest but allows
+        /// extreme ascenders and descenders to overflow into adjacent lines.
+        /// </summary>
+        Multiple = NativeMethods.SC_PHASES_MULTIPLE
+    }
 }

--- a/Scintilla.NET/PopupMode.cs
+++ b/Scintilla.NET/PopupMode.cs
@@ -1,25 +1,26 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Behavior of the standard edit control context menu.
-/// </summary>
-/// <seealso cref="Scintilla.UsePopup(PopupMode)" />
-public enum PopupMode
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Never show the default editing menu.
+    /// Behavior of the standard edit control context menu.
     /// </summary>
-    Never = NativeMethods.SC_POPUP_NEVER,
+    /// <seealso cref="Scintilla.UsePopup(PopupMode)" />
+    public enum PopupMode
+    {
+        /// <summary>
+        /// Never show the default editing menu.
+        /// </summary>
+        Never = NativeMethods.SC_POPUP_NEVER,
 
-    /// <summary>
-    /// Show default editing menu if clicking on the control.
-    /// </summary>
-    All = NativeMethods.SC_POPUP_ALL,
+        /// <summary>
+        /// Show default editing menu if clicking on the control.
+        /// </summary>
+        All = NativeMethods.SC_POPUP_ALL,
 
-    /// <summary>
-    /// Show default editing menu only if clicking on text area.
-    /// </summary>
-    /// <remarks>To receive the <see cref="Scintilla.MarginRightClick" /> event, this value must be used.</remarks>
-    /// <seealso cref="Scintilla.MarginRightClick" />
-    Text = NativeMethods.SC_POPUP_TEXT
+        /// <summary>
+        /// Show default editing menu only if clicking on text area.
+        /// </summary>
+        /// <remarks>To receive the <see cref="Scintilla.MarginRightClick" /> event, this value must be used.</remarks>
+        /// <seealso cref="Scintilla.MarginRightClick" />
+        Text = NativeMethods.SC_POPUP_TEXT
+    }
 }

--- a/Scintilla.NET/ProjectionEqualityComparer.cs
+++ b/Scintilla.NET/ProjectionEqualityComparer.cs
@@ -3,133 +3,135 @@
 using System;
 using System.Collections.Generic;
 
-namespace ScintillaNET;
-/// <summary>
-/// Non-generic class to produce instances of the generic class,
-/// optionally using type inference.
-/// </summary>
-internal static class ProjectionEqualityComparer
+namespace ScintillaNET
 {
     /// <summary>
-    /// Creates an instance of ProjectionEqualityComparer using the specified projection.
+    /// Non-generic class to produce instances of the generic class,
+    /// optionally using type inference.
     /// </summary>
-    /// <typeparam name="TSource">Type parameter for the elements to be compared</typeparam>
-    /// <typeparam name="TKey">Type parameter for the keys to be compared,
-    /// after being projected from the elements</typeparam>
-    /// <param name="projection">Projection to use when determining the key of an element</param>
-    /// <returns>A comparer which will compare elements by projecting 
-    /// each element to its key, and comparing keys</returns>
-    public static ProjectionEqualityComparer<TSource, TKey> Create<TSource, TKey>(Func<TSource, TKey> projection)
+    internal static class ProjectionEqualityComparer
     {
-        return new ProjectionEqualityComparer<TSource, TKey>(projection);
-    }
-
-    /// <summary>
-    /// Creates an instance of ProjectionEqualityComparer using the specified projection.
-    /// The ignored parameter is solely present to aid type inference.
-    /// </summary>
-    /// <typeparam name="TSource">Type parameter for the elements to be compared</typeparam>
-    /// <typeparam name="TKey">Type parameter for the keys to be compared,
-    /// after being projected from the elements</typeparam>
-    /// <param name="ignored">Value is ignored - type may be used by type inference</param>
-    /// <param name="projection">Projection to use when determining the key of an element</param>
-    /// <returns>A comparer which will compare elements by projecting
-    /// each element to its key, and comparing keys</returns>
-    public static ProjectionEqualityComparer<TSource, TKey> Create<TSource, TKey>
-    (TSource ignored,
-        Func<TSource, TKey> projection)
-    {
-        return new ProjectionEqualityComparer<TSource, TKey>(projection);
-    }
-}
-
-/// <summary>
-/// Class generic in the source only to produce instances of the 
-/// doubly generic class, optionally using type inference.
-/// </summary>
-internal static class ProjectionEqualityComparer<TSource>
-{
-    /// <summary>
-    /// Creates an instance of ProjectionEqualityComparer using the specified projection.
-    /// </summary>
-    /// <typeparam name="TKey">Type parameter for the keys to be compared,
-    /// after being projected from the elements</typeparam>
-    /// <param name="projection">Projection to use when determining the key of an element</param>
-    /// <returns>A comparer which will compare elements by projecting each element to its key,
-    /// and comparing keys</returns>        
-    public static ProjectionEqualityComparer<TSource, TKey> Create<TKey>(Func<TSource, TKey> projection)
-    {
-        return new ProjectionEqualityComparer<TSource, TKey>(projection);
-    }
-}
-
-/// <summary>
-/// Comparer which projects each element of the comparison to a key, and then compares
-/// those keys using the specified (or default) comparer for the key type.
-/// </summary>
-/// <typeparam name="TSource">Type of elements which this comparer 
-/// will be asked to compare</typeparam>
-/// <typeparam name="TKey">Type of the key projected
-/// from the element</typeparam>
-internal class ProjectionEqualityComparer<TSource, TKey> : IEqualityComparer<TSource>
-{
-    private readonly Func<TSource, TKey> projection;
-    private readonly IEqualityComparer<TKey> comparer;
-
-    /// <summary>
-    /// Creates a new instance using the specified projection, which must not be null.
-    /// The default comparer for the projected type is used.
-    /// </summary>
-    /// <param name="projection">Projection to use during comparisons</param>
-    public ProjectionEqualityComparer(Func<TSource, TKey> projection)
-        : this(projection, null)
-    {
-    }
-
-    /// <summary>
-    /// Creates a new instance using the specified projection, which must not be null.
-    /// </summary>
-    /// <param name="projection">Projection to use during comparisons</param>
-    /// <param name="comparer">The comparer to use on the keys. May be null, in
-    /// which case the default comparer will be used.</param>
-    public ProjectionEqualityComparer(Func<TSource, TKey> projection, IEqualityComparer<TKey> comparer)
-    {
-        this.comparer = comparer ?? EqualityComparer<TKey>.Default;
-        this.projection = projection ?? throw new ArgumentNullException("projection");
-    }
-
-    /// <summary>
-    /// Compares the two specified values for equality by applying the projection
-    /// to each value and then using the equality comparer on the resulting keys. Null
-    /// references are never passed to the projection.
-    /// </summary>
-    public bool Equals(TSource x, TSource y)
-    {
-        if (x == null && y == null)
+        /// <summary>
+        /// Creates an instance of ProjectionEqualityComparer using the specified projection.
+        /// </summary>
+        /// <typeparam name="TSource">Type parameter for the elements to be compared</typeparam>
+        /// <typeparam name="TKey">Type parameter for the keys to be compared,
+        /// after being projected from the elements</typeparam>
+        /// <param name="projection">Projection to use when determining the key of an element</param>
+        /// <returns>A comparer which will compare elements by projecting 
+        /// each element to its key, and comparing keys</returns>
+        public static ProjectionEqualityComparer<TSource, TKey> Create<TSource, TKey>(Func<TSource, TKey> projection)
         {
-            return true;
+            return new ProjectionEqualityComparer<TSource, TKey>(projection);
         }
 
-        if (x == null || y == null)
+        /// <summary>
+        /// Creates an instance of ProjectionEqualityComparer using the specified projection.
+        /// The ignored parameter is solely present to aid type inference.
+        /// </summary>
+        /// <typeparam name="TSource">Type parameter for the elements to be compared</typeparam>
+        /// <typeparam name="TKey">Type parameter for the keys to be compared,
+        /// after being projected from the elements</typeparam>
+        /// <param name="ignored">Value is ignored - type may be used by type inference</param>
+        /// <param name="projection">Projection to use when determining the key of an element</param>
+        /// <returns>A comparer which will compare elements by projecting
+        /// each element to its key, and comparing keys</returns>
+        public static ProjectionEqualityComparer<TSource, TKey> Create<TSource, TKey>
+        (TSource ignored,
+            Func<TSource, TKey> projection)
         {
-            return false;
+            return new ProjectionEqualityComparer<TSource, TKey>(projection);
         }
-
-        return this.comparer.Equals(this.projection(x), this.projection(y));
     }
 
     /// <summary>
-    /// Produces a hash code for the given value by projecting it and
-    /// then asking the equality comparer to find the hash code of
-    /// the resulting key.
+    /// Class generic in the source only to produce instances of the 
+    /// doubly generic class, optionally using type inference.
     /// </summary>
-    public int GetHashCode(TSource obj)
+    internal static class ProjectionEqualityComparer<TSource>
     {
-        if (obj == null)
+        /// <summary>
+        /// Creates an instance of ProjectionEqualityComparer using the specified projection.
+        /// </summary>
+        /// <typeparam name="TKey">Type parameter for the keys to be compared,
+        /// after being projected from the elements</typeparam>
+        /// <param name="projection">Projection to use when determining the key of an element</param>
+        /// <returns>A comparer which will compare elements by projecting each element to its key,
+        /// and comparing keys</returns>        
+        public static ProjectionEqualityComparer<TSource, TKey> Create<TKey>(Func<TSource, TKey> projection)
         {
-            throw new ArgumentNullException("obj");
+            return new ProjectionEqualityComparer<TSource, TKey>(projection);
+        }
+    }
+
+    /// <summary>
+    /// Comparer which projects each element of the comparison to a key, and then compares
+    /// those keys using the specified (or default) comparer for the key type.
+    /// </summary>
+    /// <typeparam name="TSource">Type of elements which this comparer 
+    /// will be asked to compare</typeparam>
+    /// <typeparam name="TKey">Type of the key projected
+    /// from the element</typeparam>
+    internal class ProjectionEqualityComparer<TSource, TKey> : IEqualityComparer<TSource>
+    {
+        private readonly Func<TSource, TKey> projection;
+        private readonly IEqualityComparer<TKey> comparer;
+
+        /// <summary>
+        /// Creates a new instance using the specified projection, which must not be null.
+        /// The default comparer for the projected type is used.
+        /// </summary>
+        /// <param name="projection">Projection to use during comparisons</param>
+        public ProjectionEqualityComparer(Func<TSource, TKey> projection)
+            : this(projection, null)
+        {
         }
 
-        return this.comparer.GetHashCode(this.projection(obj));
+        /// <summary>
+        /// Creates a new instance using the specified projection, which must not be null.
+        /// </summary>
+        /// <param name="projection">Projection to use during comparisons</param>
+        /// <param name="comparer">The comparer to use on the keys. May be null, in
+        /// which case the default comparer will be used.</param>
+        public ProjectionEqualityComparer(Func<TSource, TKey> projection, IEqualityComparer<TKey> comparer)
+        {
+            this.comparer = comparer ?? EqualityComparer<TKey>.Default;
+            this.projection = projection ?? throw new ArgumentNullException("projection");
+        }
+
+        /// <summary>
+        /// Compares the two specified values for equality by applying the projection
+        /// to each value and then using the equality comparer on the resulting keys. Null
+        /// references are never passed to the projection.
+        /// </summary>
+        public bool Equals(TSource x, TSource y)
+        {
+            if (x == null && y == null)
+            {
+                return true;
+            }
+
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            return this.comparer.Equals(this.projection(x), this.projection(y));
+        }
+
+        /// <summary>
+        /// Produces a hash code for the given value by projecting it and
+        /// then asking the equality comparer to find the hash code of
+        /// the resulting key.
+        /// </summary>
+        public int GetHashCode(TSource obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj");
+            }
+
+            return this.comparer.GetHashCode(this.projection(obj));
+        }
     }
 }

--- a/Scintilla.NET/PropertyType.cs
+++ b/Scintilla.NET/PropertyType.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Lexer property types.
-/// </summary>
-public enum PropertyType
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// A Boolean property. This is the default.
+    /// Lexer property types.
     /// </summary>
-    Boolean = NativeMethods.SC_TYPE_BOOLEAN,
+    public enum PropertyType
+    {
+        /// <summary>
+        /// A Boolean property. This is the default.
+        /// </summary>
+        Boolean = NativeMethods.SC_TYPE_BOOLEAN,
 
-    /// <summary>
-    /// An integer property.
-    /// </summary>
-    Integer = NativeMethods.SC_TYPE_INTEGER,
+        /// <summary>
+        /// An integer property.
+        /// </summary>
+        Integer = NativeMethods.SC_TYPE_INTEGER,
 
-    /// <summary>
-    /// A string property.
-    /// </summary>
-    String = NativeMethods.SC_TYPE_STRING
+        /// <summary>
+        /// A string property.
+        /// </summary>
+        String = NativeMethods.SC_TYPE_STRING
+    }
 }

--- a/Scintilla.NET/SCNotificationEventArgs.cs
+++ b/Scintilla.NET/SCNotificationEventArgs.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-// For internal use only
-internal sealed class SCNotificationEventArgs : EventArgs
+namespace ScintillaNET
 {
-    public NativeMethods.SCNotification SCNotification { get; private set; }
-
-    public SCNotificationEventArgs(NativeMethods.SCNotification scn)
+    // For internal use only
+    internal sealed class SCNotificationEventArgs : EventArgs
     {
-        SCNotification = scn;
+        public NativeMethods.SCNotification SCNotification { get; private set; }
+
+        public SCNotificationEventArgs(NativeMethods.SCNotification scn)
+        {
+            SCNotification = scn;
+        }
     }
 }

--- a/Scintilla.NET/Scintilla.NET.csproj
+++ b/Scintilla.NET/Scintilla.NET.csproj
@@ -13,9 +13,6 @@
 		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 	<PropertyGroup>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
-	<PropertyGroup>
 		<DefineConstants>SCINTILLA5</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/Scintilla.NET/Scintilla.cs
+++ b/Scintilla.NET/Scintilla.cs
@@ -23,7 +23,7 @@ namespace ScintillaNET
     {
         static Scintilla()
         {
-            List<string> searchedPathList = [];
+            var searchedPathList = new List<string>();
             foreach (string path in EnumerateSatelliteLibrarySearchPaths())
             {
                 string scintillaDllPath = Path.Combine(path, "Scintilla.dll");
@@ -62,12 +62,15 @@ namespace ScintillaNET
 
         private static bool InDesignProcess()
         {
-            using var proc = Process.GetCurrentProcess();
-            string procName = proc.ProcessName;
-            return
-                procName is "devenv" or "DesignToolsServer" or // WinForms app in VS IDE
-                "xdesproc" or // WPF app in VS IDE/Blend
-                "blend";
+            using (var proc = Process.GetCurrentProcess())
+            {
+                string procName = proc.ProcessName;
+                return
+                    procName == "devenv" ||
+                    procName == "DesignToolsServer" || // WinForms app in VS IDE
+                    procName == "xdesproc" || // WPF app in VS IDE/Blend
+                    procName == "blend";
+            }
         }
 
         /// <summary>
@@ -116,39 +119,39 @@ namespace ScintillaNET
         private static Lexilla lexilla;
 
         // Events
-        private static readonly object scNotificationEventKey = new();
-        private static readonly object insertCheckEventKey = new();
-        private static readonly object beforeInsertEventKey = new();
-        private static readonly object beforeDeleteEventKey = new();
-        private static readonly object insertEventKey = new();
-        private static readonly object deleteEventKey = new();
-        private static readonly object updateUIEventKey = new();
-        private static readonly object modifyAttemptEventKey = new();
-        private static readonly object styleNeededEventKey = new();
-        private static readonly object savePointReachedEventKey = new();
-        private static readonly object savePointLeftEventKey = new();
-        private static readonly object changeAnnotationEventKey = new();
-        private static readonly object marginClickEventKey = new();
-        private static readonly object marginRightClickEventKey = new();
-        private static readonly object charAddedEventKey = new();
-        private static readonly object autoCSelectionEventKey = new();
-        private static readonly object autoCSelectionChangeEventKey = new();
-        private static readonly object autoCCompletedEventKey = new();
-        private static readonly object autoCCancelledEventKey = new();
-        private static readonly object autoCCharDeletedEventKey = new();
-        private static readonly object dwellStartEventKey = new();
-        private static readonly object callTipClickEventKey = new();
-        private static readonly object dwellEndEventKey = new();
-        private static readonly object borderStyleChangedEventKey = new();
-        private static readonly object doubleClickEventKey = new();
-        private static readonly object paintedEventKey = new();
-        private static readonly object needShownEventKey = new();
-        private static readonly object hotspotClickEventKey = new();
-        private static readonly object hotspotDoubleClickEventKey = new();
-        private static readonly object hotspotReleaseClickEventKey = new();
-        private static readonly object indicatorClickEventKey = new();
-        private static readonly object indicatorReleaseEventKey = new();
-        private static readonly object zoomChangedEventKey = new();
+        private static readonly object scNotificationEventKey = new object();
+        private static readonly object insertCheckEventKey = new object();
+        private static readonly object beforeInsertEventKey = new object();
+        private static readonly object beforeDeleteEventKey = new object();
+        private static readonly object insertEventKey = new object();
+        private static readonly object deleteEventKey = new object();
+        private static readonly object updateUIEventKey = new object();
+        private static readonly object modifyAttemptEventKey = new object();
+        private static readonly object styleNeededEventKey = new object();
+        private static readonly object savePointReachedEventKey = new object();
+        private static readonly object savePointLeftEventKey = new object();
+        private static readonly object changeAnnotationEventKey = new object();
+        private static readonly object marginClickEventKey = new object();
+        private static readonly object marginRightClickEventKey = new object();
+        private static readonly object charAddedEventKey = new object();
+        private static readonly object autoCSelectionEventKey = new object();
+        private static readonly object autoCSelectionChangeEventKey = new object();
+        private static readonly object autoCCompletedEventKey = new object();
+        private static readonly object autoCCancelledEventKey = new object();
+        private static readonly object autoCCharDeletedEventKey = new object();
+        private static readonly object dwellStartEventKey = new object();
+        private static readonly object callTipClickEventKey = new object();
+        private static readonly object dwellEndEventKey = new object();
+        private static readonly object borderStyleChangedEventKey = new object();
+        private static readonly object doubleClickEventKey = new object();
+        private static readonly object paintedEventKey = new object();
+        private static readonly object needShownEventKey = new object();
+        private static readonly object hotspotClickEventKey = new object();
+        private static readonly object hotspotDoubleClickEventKey = new object();
+        private static readonly object hotspotReleaseClickEventKey = new object();
+        private static readonly object indicatorClickEventKey = new object();
+        private static readonly object indicatorReleaseEventKey = new object();
+        private static readonly object zoomChangedEventKey = new object();
 
         // The goods
         private IntPtr sciPtr;
@@ -349,7 +352,7 @@ namespace ScintillaNET
             // That means we need to keep a copy of the string around for the life of the control AND put it
             // in a place where it won't get moved by the GC.
 
-            chars ??= string.Empty;
+            chars = chars ?? string.Empty;
 
             if (this.fillUpChars != IntPtr.Zero)
             {
@@ -1012,7 +1015,7 @@ namespace ScintillaNET
 
             fixed (byte* bp = bytes)
             {
-                NativeMethods.Sci_TextToFind textToFind = new NativeMethods.Sci_TextToFind() {
+                var textToFind = new NativeMethods.Sci_TextToFind() {
                     chrg = new NativeMethods.Sci_CharacterRange() {
                         cpMin = Lines.CharToBytePosition(Helpers.Clamp(start, 0, TextLength)),
                         cpMax = Lines.CharToBytePosition(Helpers.Clamp(end, 0, TextLength)),
@@ -1310,146 +1313,284 @@ namespace ScintillaNET
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public string GetLexerIDFromLexer(Lexer lexer)
         {
-            return lexer switch
+            switch (lexer)
             {
-                Lexer.SCLEX_A68K => "a68k",
-                Lexer.SCLEX_ADPL => "apdl",
-                Lexer.SCLEX_ASYMPTOTE => "asy",
-                Lexer.SCLEX_AU3 => "au3",
-                Lexer.SCLEX_AVE => "ave",
-                Lexer.SCLEX_AVS => "avs",
-                Lexer.SCLEX_ABAQUS => "abaqus",
-                Lexer.SCLEX_ADA => "ada",
-                Lexer.SCLEX_ASCIIDOC => "asciidoc",
-                Lexer.SCLEX_ASM => "asm",
-                Lexer.SCLEX_AS => "as",
-                Lexer.SCLEX_ASN1 => "asn1",
-                Lexer.SCLEX_BAAN => "baan",
-                Lexer.SCLEX_BASH => "bash",
-                Lexer.SCLEX_BLITZBASIC => "blitzbasic",
-                Lexer.SCLEX_PUREBASIC => "purebasic",
-                Lexer.SCLEX_FREEBASIC => "freebasic",
-                Lexer.SCLEX_BATCH => "batch",
-                Lexer.SCLEX_BIBTEX => "bibtex",
-                Lexer.SCLEX_BULLANT => "bullant",
-                Lexer.SCLEX_CIL => "cil",
-                Lexer.SCLEX_CLW => "clarion",
-                Lexer.SCLEX_CLWNOCASE => "clarionnocase",
-                Lexer.SCLEX_COBOL => "COBOL",
-                Lexer.SCLEX_CPP => "cpp",
-                Lexer.SCLEX_CPPNOCASE => "cppnocase",
-                Lexer.SCLEX_CSHARP => "cpp",
-                Lexer.SCLEX_JAVA => "cpp",
-                Lexer.SCLEX_JAVASCRIPT => "cpp",
-                Lexer.SCLEX_CSS => "css",
-                Lexer.SCLEX_CAML => "caml",
-                Lexer.SCLEX_CMAKE => "cmake",
-                Lexer.SCLEX_COFFEESCRIPT => "coffeescript",
-                Lexer.SCLEX_CONF => "conf",
-                Lexer.SCLEX_NNCRONTAB => "nncrontab",
-                Lexer.SCLEX_CSOUND => "csound",
-                Lexer.SCLEX_D => "d",
-                Lexer.SCLEX_DMAP => "DMAP",
-                Lexer.SCLEX_DMIS => "DMIS",
-                Lexer.SCLEX_DATAFLEX => "dataflex",
-                Lexer.SCLEX_DIFF => "diff",
-                Lexer.SCLEX_ECL => "ecl",
-                Lexer.SCLEX_EDIFACT => "edifact",
-                Lexer.SCLEX_ESCRIPT => "escript",
-                Lexer.SCLEX_EIFFEL => "eiffel",
-                Lexer.SCLEX_EIFFELKW => "eiffelkw",
-                Lexer.SCLEX_ERLANG => "erlang",
-                Lexer.SCLEX_ERRORLIST => "errorlist",
-                Lexer.SCLEX_FSHARP => "fsharp",
-                Lexer.SCLEX_FLAGSHIP => "flagship",
-                Lexer.SCLEX_FORTH => "forth",
-                Lexer.SCLEX_FORTRAN => "fortran",
-                Lexer.SCLEX_F77 => "f77",
-                Lexer.SCLEX_GAP => "gap",
-                Lexer.SCLEX_GDSCRIPT => "gdscript",
-                Lexer.SCLEX_GUI4CLI => "gui4cli",
-                Lexer.SCLEX_HTML => "hypertext",
-                Lexer.SCLEX_XML => "xml",
-                Lexer.SCLEX_PHPSCRIPT => "phpscript",
-                Lexer.SCLEX_HASKELL => "haskell",
-                Lexer.SCLEX_LITERATEHASKELL => "literatehaskell",
-                Lexer.SCLEX_SREC => "srec",
-                Lexer.SCLEX_IHEX => "ihex",
-                Lexer.SCLEX_TEHEX => "tehex",
-                Lexer.SCLEX_HOLLYWOOD => "hollywood",
-                Lexer.SCLEX_INDENT => "indent",
-                Lexer.SCLEX_INNOSETUP => "inno",
-                Lexer.SCLEX_JSON => "json",
-                Lexer.SCLEX_JULIA => "julia",
-                Lexer.SCLEX_KIX => "kix",
-                Lexer.SCLEX_KVIRC => "kvirc",
-                Lexer.SCLEX_LATEX => "latex",
-                Lexer.SCLEX_LISP => "lisp",
-                Lexer.SCLEX_LOUT => "lout",
-                Lexer.SCLEX_LUA => "lua",
-                Lexer.SCLEX_MMIXAL => "mmixal",
-                Lexer.SCLEX_LOT => "lot",
-                Lexer.SCLEX_MSSQL => "mssql",
-                Lexer.SCLEX_MAGIK => "magiksf",
-                Lexer.SCLEX_MAKEFILE => "makefile",
-                Lexer.SCLEX_MARKDOWN => "markdown",
-                Lexer.SCLEX_MATLAB => "matlab",
-                Lexer.SCLEX_OCTAVE => "octave",
-                Lexer.SCLEX_MAXIMA => "maxima",
-                Lexer.SCLEX_METAPOST => "metapost",
-                Lexer.SCLEX_MODULA => "modula",
-                Lexer.SCLEX_MYSQL => "mysql",
-                Lexer.SCLEX_NIM => "nim",
-                Lexer.SCLEX_NIMROD => "nimrod",
-                Lexer.SCLEX_NSIS => "nsis",
-                Lexer.SCLEX_NULL => "null",
-                Lexer.SCLEX_OSCRIPT => "oscript",
-                Lexer.SCLEX_OPAL => "opal",
-                Lexer.SCLEX_POWERBASIC => "powerbasic",
-                Lexer.SCLEX_PLM => "PL/M",
-                Lexer.SCLEX_PO => "po",
-                Lexer.SCLEX_POV => "pov",
-                Lexer.SCLEX_POSTSCRIPT => "ps",
-                Lexer.SCLEX_PASCAL => "pascal",
-                Lexer.SCLEX_PERL => "perl",
-                Lexer.SCLEX_POWERPRO => "powerpro",
-                Lexer.SCLEX_POWERSHELL => "powershell",
-                Lexer.SCLEX_PROGRESS => "abl",
-                Lexer.SCLEX_PROPERTIES => "props",
-                Lexer.SCLEX_PYTHON => "python",
-                Lexer.SCLEX_R => "r",
-                Lexer.SCLEX_S => "r",
-                Lexer.SCLEX_SPLUS => "r",
-                Lexer.SCLEX_RAKU => "raku",
-                Lexer.SCLEX_REBOL => "rebol",
-                Lexer.SCLEX_REGISTRY => "registry",
-                Lexer.SCLEX_RUBY => "ruby",
-                Lexer.SCLEX_RUST => "rust",
-                Lexer.SCLEX_SAS => "sas",
-                Lexer.SCLEX_SML => "SML",
-                Lexer.SCLEX_SQL => "sql",
-                Lexer.SCLEX_STTXT => "fcST",
-                Lexer.SCLEX_SCRIPTOL => "scriptol",
-                Lexer.SCLEX_SMALLTALK => "smalltalk",
-                Lexer.SCLEX_SORCUS => "sorcins",
-                Lexer.SCLEX_SPECMAN => "specman",
-                Lexer.SCLEX_SPICE => "spice",
-                Lexer.SCLEX_STATA => "stata",
-                Lexer.SCLEX_TACL => "TACL",
-                Lexer.SCLEX_TADS3 => "tads3",
-                Lexer.SCLEX_TAL => "TAL",
-                Lexer.SCLEX_TCL => "tcl",
-                Lexer.SCLEX_TCMD => "tcmd",
-                Lexer.SCLEX_TEX => "tex",
-                Lexer.SCLEX_TXT2TAGS => "txt2tags",
-                Lexer.SCLEX_VB => "vb",
-                Lexer.SCLEX_VBSCRIPT => "vbscript",
-                Lexer.SCLEX_VHDL => "vhdl",
-                Lexer.SCLEX_VERILOG => "verilog",
-                Lexer.SCLEX_VISUALPROLOG => "visualprolog",
-                Lexer.SCLEX_X12 => "x12",
-                Lexer.SCLEX_YAML => "yaml",
-                _ => throw new ArgumentOutOfRangeException(nameof(lexer), lexer, null),
+                case Lexer.SCLEX_A68K:
+                    return "a68k";
+                case Lexer.SCLEX_ADPL:
+                    return "apdl";
+                case Lexer.SCLEX_ASYMPTOTE:
+                    return "asy";
+                case Lexer.SCLEX_AU3:
+                    return "au3";
+                case Lexer.SCLEX_AVE:
+                    return "ave";
+                case Lexer.SCLEX_AVS:
+                    return "avs";
+                case Lexer.SCLEX_ABAQUS:
+                    return "abaqus";
+                case Lexer.SCLEX_ADA:
+                    return "ada";
+                case Lexer.SCLEX_ASCIIDOC:
+                    return "asciidoc";
+                case Lexer.SCLEX_ASM:
+                    return "asm";
+                case Lexer.SCLEX_AS:
+                    return "as";
+                case Lexer.SCLEX_ASN1:
+                    return "asn1";
+                case Lexer.SCLEX_BAAN:
+                    return "baan";
+                case Lexer.SCLEX_BASH:
+                    return "bash";
+                case Lexer.SCLEX_BLITZBASIC:
+                    return "blitzbasic";
+                case Lexer.SCLEX_PUREBASIC:
+                    return "purebasic";
+                case Lexer.SCLEX_FREEBASIC:
+                    return "freebasic";
+                case Lexer.SCLEX_BATCH:
+                    return "batch";
+                case Lexer.SCLEX_BIBTEX:
+                    return "bibtex";
+                case Lexer.SCLEX_BULLANT:
+                    return "bullant";
+                case Lexer.SCLEX_CIL:
+                    return "cil";
+                case Lexer.SCLEX_CLW:
+                    return "clarion";
+                case Lexer.SCLEX_CLWNOCASE:
+                    return "clarionnocase";
+                case Lexer.SCLEX_COBOL:
+                    return "COBOL";
+                case Lexer.SCLEX_CPP:
+                    return "cpp";
+                case Lexer.SCLEX_CPPNOCASE:
+                    return "cppnocase";
+                case Lexer.SCLEX_CSHARP:
+                    return "cpp";
+                case Lexer.SCLEX_JAVA:
+                    return "cpp";
+                case Lexer.SCLEX_JAVASCRIPT:
+                    return "cpp";
+                case Lexer.SCLEX_CSS:
+                    return "css";
+                case Lexer.SCLEX_CAML:
+                    return "caml";
+                case Lexer.SCLEX_CMAKE:
+                    return "cmake";
+                case Lexer.SCLEX_COFFEESCRIPT:
+                    return "coffeescript";
+                case Lexer.SCLEX_CONF:
+                    return "conf";
+                case Lexer.SCLEX_NNCRONTAB:
+                    return "nncrontab";
+                case Lexer.SCLEX_CSOUND:
+                    return "csound";
+                case Lexer.SCLEX_D:
+                    return "d";
+                case Lexer.SCLEX_DMAP:
+                    return "DMAP";
+                case Lexer.SCLEX_DMIS:
+                    return "DMIS";
+                case Lexer.SCLEX_DATAFLEX:
+                    return "dataflex";
+                case Lexer.SCLEX_DIFF:
+                    return "diff";
+                case Lexer.SCLEX_ECL:
+                    return "ecl";
+                case Lexer.SCLEX_EDIFACT:
+                    return "edifact";
+                case Lexer.SCLEX_ESCRIPT:
+                    return "escript";
+                case Lexer.SCLEX_EIFFEL:
+                    return "eiffel";
+                case Lexer.SCLEX_EIFFELKW:
+                    return "eiffelkw";
+                case Lexer.SCLEX_ERLANG:
+                    return "erlang";
+                case Lexer.SCLEX_ERRORLIST:
+                    return "errorlist";
+                case Lexer.SCLEX_FSHARP:
+                    return "fsharp";
+                case Lexer.SCLEX_FLAGSHIP:
+                    return "flagship";
+                case Lexer.SCLEX_FORTH:
+                    return "forth";
+                case Lexer.SCLEX_FORTRAN:
+                    return "fortran";
+                case Lexer.SCLEX_F77:
+                    return "f77";
+                case Lexer.SCLEX_GAP:
+                    return "gap";
+                case Lexer.SCLEX_GDSCRIPT:
+                    return "gdscript";
+                case Lexer.SCLEX_GUI4CLI:
+                    return "gui4cli";
+                case Lexer.SCLEX_HTML:
+                    return "hypertext";
+                case Lexer.SCLEX_XML:
+                    return "xml";
+                case Lexer.SCLEX_PHPSCRIPT:
+                    return "phpscript";
+                case Lexer.SCLEX_HASKELL:
+                    return "haskell";
+                case Lexer.SCLEX_LITERATEHASKELL:
+                    return "literatehaskell";
+                case Lexer.SCLEX_SREC:
+                    return "srec";
+                case Lexer.SCLEX_IHEX:
+                    return "ihex";
+                case Lexer.SCLEX_TEHEX:
+                    return "tehex";
+                case Lexer.SCLEX_HOLLYWOOD:
+                    return "hollywood";
+                case Lexer.SCLEX_INDENT:
+                    return "indent";
+                case Lexer.SCLEX_INNOSETUP:
+                    return "inno";
+                case Lexer.SCLEX_JSON:
+                    return "json";
+                case Lexer.SCLEX_JULIA:
+                    return "julia";
+                case Lexer.SCLEX_KIX:
+                    return "kix";
+                case Lexer.SCLEX_KVIRC:
+                    return "kvirc";
+                case Lexer.SCLEX_LATEX:
+                    return "latex";
+                case Lexer.SCLEX_LISP:
+                    return "lisp";
+                case Lexer.SCLEX_LOUT:
+                    return "lout";
+                case Lexer.SCLEX_LUA:
+                    return "lua";
+                case Lexer.SCLEX_MMIXAL:
+                    return "mmixal";
+                case Lexer.SCLEX_LOT:
+                    return "lot";
+                case Lexer.SCLEX_MSSQL:
+                    return "mssql";
+                case Lexer.SCLEX_MAGIK:
+                    return "magiksf";
+                case Lexer.SCLEX_MAKEFILE:
+                    return "makefile";
+                case Lexer.SCLEX_MARKDOWN:
+                    return "markdown";
+                case Lexer.SCLEX_MATLAB:
+                    return "matlab";
+                case Lexer.SCLEX_OCTAVE:
+                    return "octave";
+                case Lexer.SCLEX_MAXIMA:
+                    return "maxima";
+                case Lexer.SCLEX_METAPOST:
+                    return "metapost";
+                case Lexer.SCLEX_MODULA:
+                    return "modula";
+                case Lexer.SCLEX_MYSQL:
+                    return "mysql";
+                case Lexer.SCLEX_NIM:
+                    return "nim";
+                case Lexer.SCLEX_NIMROD:
+                    return "nimrod";
+                case Lexer.SCLEX_NSIS:
+                    return "nsis";
+                case Lexer.SCLEX_NULL:
+                    return "null";
+                case Lexer.SCLEX_OSCRIPT:
+                    return "oscript";
+                case Lexer.SCLEX_OPAL:
+                    return "opal";
+                case Lexer.SCLEX_POWERBASIC:
+                    return "powerbasic";
+                case Lexer.SCLEX_PLM:
+                    return "PL/M";
+                case Lexer.SCLEX_PO:
+                    return "po";
+                case Lexer.SCLEX_POV:
+                    return "pov";
+                case Lexer.SCLEX_POSTSCRIPT:
+                    return "ps";
+                case Lexer.SCLEX_PASCAL:
+                    return "pascal";
+                case Lexer.SCLEX_PERL:
+                    return "perl";
+                case Lexer.SCLEX_POWERPRO:
+                    return "powerpro";
+                case Lexer.SCLEX_POWERSHELL:
+                    return "powershell";
+                case Lexer.SCLEX_PROGRESS:
+                    return "abl";
+                case Lexer.SCLEX_PROPERTIES:
+                    return "props";
+                case Lexer.SCLEX_PYTHON:
+                    return "python";
+                case Lexer.SCLEX_R:
+                    return "r";
+                case Lexer.SCLEX_S:
+                    return "r";
+                case Lexer.SCLEX_SPLUS:
+                    return "r";
+                case Lexer.SCLEX_RAKU:
+                    return "raku";
+                case Lexer.SCLEX_REBOL:
+                    return "rebol";
+                case Lexer.SCLEX_REGISTRY:
+                    return "registry";
+                case Lexer.SCLEX_RUBY:
+                    return "ruby";
+                case Lexer.SCLEX_RUST:
+                    return "rust";
+                case Lexer.SCLEX_SAS:
+                    return "sas";
+                case Lexer.SCLEX_SML:
+                    return "SML";
+                case Lexer.SCLEX_SQL:
+                    return "sql";
+                case Lexer.SCLEX_STTXT:
+                    return "fcST";
+                case Lexer.SCLEX_SCRIPTOL:
+                    return "scriptol";
+                case Lexer.SCLEX_SMALLTALK:
+                    return "smalltalk";
+                case Lexer.SCLEX_SORCUS:
+                    return "sorcins";
+                case Lexer.SCLEX_SPECMAN:
+                    return "specman";
+                case Lexer.SCLEX_SPICE:
+                    return "spice";
+                case Lexer.SCLEX_STATA:
+                    return "stata";
+                case Lexer.SCLEX_TACL:
+                    return "TACL";
+                case Lexer.SCLEX_TADS3:
+                    return "tads3";
+                case Lexer.SCLEX_TAL:
+                    return "TAL";
+                case Lexer.SCLEX_TCL:
+                    return "tcl";
+                case Lexer.SCLEX_TCMD:
+                    return "tcmd";
+                case Lexer.SCLEX_TEX:
+                    return "tex";
+                case Lexer.SCLEX_TXT2TAGS:
+                    return "txt2tags";
+                case Lexer.SCLEX_VB:
+                    return "vb";
+                case Lexer.SCLEX_VBSCRIPT:
+                    return "vbscript";
+                case Lexer.SCLEX_VHDL:
+                    return "vhdl";
+                case Lexer.SCLEX_VERILOG:
+                    return "verilog";
+                case Lexer.SCLEX_VISUALPROLOG:
+                    return "visualprolog";
+                case Lexer.SCLEX_X12:
+                    return "x12";
+                case Lexer.SCLEX_YAML:
+                    return "yaml";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(lexer), lexer, null);
             };
         }
 
@@ -2320,7 +2461,7 @@ namespace ScintillaNET
         /// </remarks>
         public unsafe int ReplaceTarget(string text)
         {
-            text ??= string.Empty;
+            text = text ?? string.Empty;
 
             byte[] bytes = Helpers.GetBytes(text, Encoding, false);
             // Scintilla asserts that lParam is not null, so make sure it isn't
@@ -2682,7 +2823,7 @@ namespace ScintillaNET
         public static void SetDestroyHandleBehavior(bool reparent)
         {
             // WM_DESTROY workaround
-            Scintilla.reparentAll ??= reparent;
+            Scintilla.reparentAll = Scintilla.reparentAll ?? reparent;
         }
 
         /// <summary>
@@ -3131,15 +3272,17 @@ namespace ScintillaNET
             IntPtr hDC = NativeMethods.GetWindowDC(m.HWnd);
             try
             {
-                using var graphics = Graphics.FromHdc(hDC);
-                // Clip everything except the border
-                var bounds = new Rectangle(0, 0, windowRect.right - windowRect.left, windowRect.bottom - windowRect.top);
-                graphics.ExcludeClip(Rectangle.Inflate(bounds, -borderSize.Width, -borderSize.Height));
+                using (var graphics = Graphics.FromHdc(hDC))
+                {
+                    // Clip everything except the border
+                    var bounds = new Rectangle(0, 0, windowRect.right - windowRect.left, windowRect.bottom - windowRect.top);
+                    graphics.ExcludeClip(Rectangle.Inflate(bounds, -borderSize.Width, -borderSize.Height));
 
-                // Paint the theme border
-                if (this.renderer.IsBackgroundPartiallyTransparent())
-                    this.renderer.DrawParentBackground(graphics, bounds, this);
-                this.renderer.DrawBackground(graphics, bounds);
+                    // Paint the theme border
+                    if (this.renderer.IsBackgroundPartiallyTransparent())
+                        this.renderer.DrawParentBackground(graphics, bounds, this);
+                    this.renderer.DrawBackground(graphics, bounds);
+                }
             }
             finally
             {
@@ -3166,7 +3309,7 @@ namespace ScintillaNET
         {
             // A standard Windows notification and a Scintilla notification header are compatible
             var scn = (NativeMethods.SCNotification)Marshal.PtrToStructure(m.LParam, typeof(NativeMethods.SCNotification));
-            if (scn.nmhdr.code is >= NativeMethods.SCN_STYLENEEDED and <= NativeMethods.SCN_AUTOCSELECTIONCHANGE)
+            if (scn.nmhdr.code >= NativeMethods.SCN_STYLENEEDED && scn.nmhdr.code <= NativeMethods.SCN_AUTOCSELECTIONCHANGE)
             {
                 if (Events[scNotificationEventKey] is EventHandler<SCNotificationEventArgs> handler)
                     handler(this, new SCNotificationEventArgs(scn));
@@ -4925,7 +5068,7 @@ namespace ScintillaNET
             set
             {
                 Style defaultFontStyle = Styles[Style.Default];
-                value ??= Parent?.Font ?? Control.DefaultFont;
+                value = value ?? Parent?.Font ?? Control.DefaultFont;
                 defaultFontStyle.Font = value.Name;
                 defaultFontStyle.SizeF = value.Size;
                 defaultFontStyle.Bold = value.Bold;
@@ -5167,7 +5310,7 @@ namespace ScintillaNET
 
                 if (!SetLexerByName(value))
                 {
-                    throw new InvalidOperationException(@$"Lexer with the name of '{value}' was not found.");
+                    throw new InvalidOperationException($@"Lexer with the name of '{value}' was not found.");
                 }
 
                 this.lexerName = value;
@@ -6371,7 +6514,7 @@ namespace ScintillaNET
 
                 // Assumption is that moving the gap will always be equal to or less expensive
                 // than using one of the APIs which requires an intermediate buffer.
-                string text = new((sbyte*)ptr, 0, length, Encoding);
+                string text = new string((sbyte*)ptr, 0, length, Encoding);
                 return text;
             }
             set

--- a/Scintilla.NET/ScintillaDesigner.cs
+++ b/Scintilla.NET/ScintillaDesigner.cs
@@ -1,42 +1,40 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms.Design;
 
-namespace ScintillaNET;
-
-internal class ScintillaDesigner : ControlDesigner
+namespace ScintillaNET
 {
-    protected override void PreFilterProperties(IDictionary properties)
+    internal class ScintillaDesigner : ControlDesigner
     {
-        base.PreFilterProperties(properties);
-
-        var scrollWidthTracking = (PropertyDescriptor)properties[nameof(Scintilla.ScrollWidthTracking)];
-        scrollWidthTracking = TypeDescriptor.CreateProperty(
-            scrollWidthTracking.ComponentType,
-            scrollWidthTracking,
-            scrollWidthTracking.Attributes.Cast<Attribute>().Concat([new RefreshPropertiesAttribute(RefreshProperties.All)]).ToArray()
-        );
-        properties[nameof(Scintilla.ScrollWidthTracking)] = scrollWidthTracking;
-
-        var scrollWidth = (PropertyDescriptor)properties[nameof(Scintilla.ScrollWidth)];
-        if ((bool)scrollWidthTracking.GetValue(Component))
+        protected override void PreFilterProperties(IDictionary properties)
         {
-            scrollWidth = TypeDescriptor.CreateProperty(
-                scrollWidth.ComponentType,
-                scrollWidth,
-                scrollWidth.Attributes.Cast<Attribute>().Concat(
-                    [
-                        new BrowsableAttribute(false),
-                        new DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Hidden),
-                    ]
-                ).ToArray()
+            base.PreFilterProperties(properties);
+
+            var scrollWidthTracking = (PropertyDescriptor)properties[nameof(Scintilla.ScrollWidthTracking)];
+            scrollWidthTracking = TypeDescriptor.CreateProperty(
+                scrollWidthTracking.ComponentType,
+                scrollWidthTracking,
+                scrollWidthTracking.Attributes.Cast<Attribute>().Concat(new Attribute[] { new RefreshPropertiesAttribute(RefreshProperties.All) }).ToArray()
             );
-            properties[nameof(Scintilla.ScrollWidth)] = scrollWidth;
+            properties[nameof(Scintilla.ScrollWidthTracking)] = scrollWidthTracking;
+
+            var scrollWidth = (PropertyDescriptor)properties[nameof(Scintilla.ScrollWidth)];
+            if ((bool)scrollWidthTracking.GetValue(Component))
+            {
+                scrollWidth = TypeDescriptor.CreateProperty(
+                    scrollWidth.ComponentType,
+                    scrollWidth,
+                    scrollWidth.Attributes.Cast<Attribute>().Concat(
+                        new Attribute[] {
+                            new BrowsableAttribute(false),
+                            new DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Hidden),
+                        }
+                    ).ToArray()
+                );
+                properties[nameof(Scintilla.ScrollWidth)] = scrollWidth;
+            }
         }
     }
 }

--- a/Scintilla.NET/ScintillaReader.cs
+++ b/Scintilla.NET/ScintillaReader.cs
@@ -1,190 +1,191 @@
 ﻿using System;
 using System.IO;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Implements a TextReader that reads from a Scintilla control.
-/// </summary>
-public class ScintillaReader : TextReader
+namespace ScintillaNET
 {
     /// <summary>
-    /// Arbitrarily chosen default buffer size
+    /// Implements a TextReader that reads from a Scintilla control.
     /// </summary>
-    private const int DefaultBufferSize = 256;
+    public class ScintillaReader : TextReader
+    {
+        /// <summary>
+        /// Arbitrarily chosen default buffer size
+        /// </summary>
+        private const int DefaultBufferSize = 256;
 
-    /// <summary>
-    /// Returns the number of buffered characters left to be read.
-    /// </summary>
-    private int BufferRemaining => this._data != null ? this._data.Length - this._dataIndex : 0;
-    /// <summary>
-    /// Returns the number of unbuffered characters left to be read.
-    /// </summary>
-    private int UnbufferedRemaining => this._lastData - this._nextData;
-    /// <summary>
-    /// Returns the total number of characters left to be read.
-    /// </summary>
-    private int TotalRemaining => BufferRemaining + UnbufferedRemaining;
+        /// <summary>
+        /// Returns the number of buffered characters left to be read.
+        /// </summary>
+        private int BufferRemaining => this._data != null ? this._data.Length - this._dataIndex : 0;
+        /// <summary>
+        /// Returns the number of unbuffered characters left to be read.
+        /// </summary>
+        private int UnbufferedRemaining => this._lastData - this._nextData;
+        /// <summary>
+        /// Returns the total number of characters left to be read.
+        /// </summary>
+        private int TotalRemaining => BufferRemaining + UnbufferedRemaining;
 
-    private readonly Scintilla _scintilla;
-    private readonly int _bufferSize;
-    private string _data;
-    private int _dataIndex;
-    private int _nextData;
-    private readonly int _lastData;
+        private readonly Scintilla _scintilla;
+        private readonly int _bufferSize;
+        private string _data;
+        private int _dataIndex;
+        private int _nextData;
+        private readonly int _lastData;
 
-    /// <summary>
-    /// Initializes a new instance of the ScintillaReader class that reads all text from the specified Scintilla control.
-    /// </summary>
-    /// <param name="scintilla">The Scintilla control from which to read.</param>
-    public ScintillaReader(Scintilla scintilla)
-        : this(scintilla, 0, scintilla.TextLength)
-    {
-    }
-    /// <summary>
-    /// Initializes a new instance of the ScintillaReader class that reads all text from the specified Scintilla control.
-    /// </summary>
-    /// <param name="scintilla">The Scintilla control from which to read.</param>
-    /// <param name="bufferSize">The number of characters to buffer at a time.</param>
-    public ScintillaReader(Scintilla scintilla, int bufferSize)
-        : this(scintilla, 0, scintilla.TextLength, bufferSize)
-    {
-    }
-    /// <summary>
-    /// Initializes a new instance of the ScintillaReader class that reads a subsection from the specified Scintilla control.
-    /// </summary>
-    /// <param name="scintilla">The Scintilla control from which to read.</param>
-    /// <param name="start">The index of the first character to read.</param>
-    /// <param name="end">The index just past the last character to read.</param>
-    public ScintillaReader(Scintilla scintilla, int start, int end)
-        : this(scintilla, start, end, DefaultBufferSize)
-    {
-    }
-    /// <summary>
-    /// Initializes a new instance of the ScintillaReader class that reads a subsection from the specified Scintilla control.
-    /// </summary>
-    /// <param name="scintilla">The Scintilla control from which to read.</param>
-    /// <param name="start">The index of the first character to read.</param>
-    /// <param name="end">The index just past the last character to read.</param>
-    /// <param name="bufferSize">The number of characters to buffer at a time.</param>
-    public ScintillaReader(Scintilla scintilla, int start, int end, int bufferSize)
-    {
-        this._scintilla = scintilla;
-        this._bufferSize = bufferSize > 0 ? bufferSize : DefaultBufferSize;
-        this._nextData = start;
-        this._lastData = end;
-        // ensure start state is valid
-        BufferNextRegion();
-    }
-
-    /// <summary>
-    /// Returns the next character to be read from the reader without actually removing it from the stream. Returns -1 if no characters are available.
-    /// </summary>
-    /// <returns>The next character from the input stream, or -1 if no more characters are available.</returns>
-    public override int Peek()
-    {
-        // _data is set to null upon EOF
-        return this._data != null ? this._data[this._dataIndex] : -1;
-    }
-    /// <summary>
-    /// Removes a character from the stream and returns it. Returns -1 if no characters are available.
-    /// </summary>
-    /// <returns>The next character from the input stream, or -1 if no more characters are available.</returns>
-    public override int Read()
-    {
-        if (this._data != null)
+        /// <summary>
+        /// Initializes a new instance of the ScintillaReader class that reads all text from the specified Scintilla control.
+        /// </summary>
+        /// <param name="scintilla">The Scintilla control from which to read.</param>
+        public ScintillaReader(Scintilla scintilla)
+            : this(scintilla, 0, scintilla.TextLength)
         {
-            // EOF not reached
-            char n = this._data[this._dataIndex++];
-            if (this._dataIndex >= this._data.Length)
-            {
-                // end of buffer reached; load next section
-                BufferNextRegion();
-            }
-
-            return n;
         }
-        else
+        /// <summary>
+        /// Initializes a new instance of the ScintillaReader class that reads all text from the specified Scintilla control.
+        /// </summary>
+        /// <param name="scintilla">The Scintilla control from which to read.</param>
+        /// <param name="bufferSize">The number of characters to buffer at a time.</param>
+        public ScintillaReader(Scintilla scintilla, int bufferSize)
+            : this(scintilla, 0, scintilla.TextLength, bufferSize)
         {
-            return -1;
         }
-    }
-    /// <summary>
-    ///  Reads a maximum of count characters from the current stream and writes the data to buffer, beginning at index.
-    /// </summary>
-    /// <param name="buffer">The buffer to receive the characters.</param>
-    /// <param name="index">The position in buffer at which to begin writing.</param>
-    /// <param name="count">The maximum number of characters to read.</param>
-    /// <returns>The actual number of characters that have been read. The number will be less than or equal to count.</returns>
-    /// <exception cref="System.ArgumentNullException">buffer is null.</exception>
-    /// <exception cref="System.ArgumentException">The buffer length minus index is less than count.</exception>
-    /// <exception cref="System.ArgumentException">index or count is negative.</exception>
-    public override int Read(char[] buffer, int index, int count)
-    {
-        return ReadBlock(buffer, index, count);
-    }
-
-    /// <summary>
-    ///  Reads a maximum of count characters from the current stream and writes the data to buffer, beginning at index.
-    /// </summary>
-    /// <param name="buffer">The buffer to receive the characters.</param>
-    /// <param name="index">The position in buffer at which to begin writing.</param>
-    /// <param name="count">The maximum number of characters to read.</param>
-    /// <returns>The actual number of characters that have been read. The number will be less than or equal to count.</returns>
-    /// <exception cref="System.ArgumentNullException">buffer is null.</exception>
-    /// <exception cref="System.ArgumentOutOfRangeException">The buffer length minus index is less than count.</exception>
-    /// <exception cref="System.ArgumentOutOfRangeException">index or count is negative.</exception>
-    public override int ReadBlock(char[] buffer, int index, int count)
-    {
-        if (this._data != null)
+        /// <summary>
+        /// Initializes a new instance of the ScintillaReader class that reads a subsection from the specified Scintilla control.
+        /// </summary>
+        /// <param name="scintilla">The Scintilla control from which to read.</param>
+        /// <param name="start">The index of the first character to read.</param>
+        /// <param name="end">The index just past the last character to read.</param>
+        public ScintillaReader(Scintilla scintilla, int start, int end)
+            : this(scintilla, start, end, DefaultBufferSize)
         {
-            int bufferRemaining = BufferRemaining;
-            if (count < bufferRemaining)
+        }
+        /// <summary>
+        /// Initializes a new instance of the ScintillaReader class that reads a subsection from the specified Scintilla control.
+        /// </summary>
+        /// <param name="scintilla">The Scintilla control from which to read.</param>
+        /// <param name="start">The index of the first character to read.</param>
+        /// <param name="end">The index just past the last character to read.</param>
+        /// <param name="bufferSize">The number of characters to buffer at a time.</param>
+        public ScintillaReader(Scintilla scintilla, int start, int end, int bufferSize)
+        {
+            this._scintilla = scintilla;
+            this._bufferSize = bufferSize > 0 ? bufferSize : DefaultBufferSize;
+            this._nextData = start;
+            this._lastData = end;
+            // ensure start state is valid
+            BufferNextRegion();
+        }
+
+        /// <summary>
+        /// Returns the next character to be read from the reader without actually removing it from the stream. Returns -1 if no characters are available.
+        /// </summary>
+        /// <returns>The next character from the input stream, or -1 if no more characters are available.</returns>
+        public override int Peek()
+        {
+            // _data is set to null upon EOF
+            return this._data != null ? this._data[this._dataIndex] : -1;
+        }
+        /// <summary>
+        /// Removes a character from the stream and returns it. Returns -1 if no characters are available.
+        /// </summary>
+        /// <returns>The next character from the input stream, or -1 if no more characters are available.</returns>
+        public override int Read()
+        {
+            if (this._data != null)
             {
-                // buffer larger than read size
-                this._data.CopyTo(this._dataIndex, buffer, index, count);
-                return count;
+                // EOF not reached
+                char n = this._data[this._dataIndex++];
+                if (this._dataIndex >= this._data.Length)
+                {
+                    // end of buffer reached; load next section
+                    BufferNextRegion();
+                }
+
+                return n;
             }
             else
             {
-                // buffer smaller or equal to read size
-                this._data.CopyTo(this._dataIndex, buffer, index, bufferRemaining);
-                if (count > bufferRemaining)
-                {
-                    // buffer is smaller; read rest
-                    string rest = this._scintilla.GetTextRange(
-                        this._nextData,
-                        Math.Min(count - bufferRemaining, UnbufferedRemaining));
-                    rest.CopyTo(0, buffer, index + bufferRemaining, rest.Length);
-                    count = bufferRemaining + rest.Length;
-                    this._nextData += rest.Length;
-                }
-                // read at least up to buffer's end; refill buffer
-                BufferNextRegion();
-                return count;
+                return -1;
             }
         }
-        else
+        /// <summary>
+        ///  Reads a maximum of count characters from the current stream and writes the data to buffer, beginning at index.
+        /// </summary>
+        /// <param name="buffer">The buffer to receive the characters.</param>
+        /// <param name="index">The position in buffer at which to begin writing.</param>
+        /// <param name="count">The maximum number of characters to read.</param>
+        /// <returns>The actual number of characters that have been read. The number will be less than or equal to count.</returns>
+        /// <exception cref="System.ArgumentNullException">buffer is null.</exception>
+        /// <exception cref="System.ArgumentException">The buffer length minus index is less than count.</exception>
+        /// <exception cref="System.ArgumentException">index or count is negative.</exception>
+        public override int Read(char[] buffer, int index, int count)
         {
-            return 0;
+            return ReadBlock(buffer, index, count);
         }
-    }
 
-    /// <summary>
-    /// Fills the buffer with the next section of text.
-    /// </summary>
-    private void BufferNextRegion()
-    {
-        if (this._nextData < this._lastData)
+        /// <summary>
+        ///  Reads a maximum of count characters from the current stream and writes the data to buffer, beginning at index.
+        /// </summary>
+        /// <param name="buffer">The buffer to receive the characters.</param>
+        /// <param name="index">The position in buffer at which to begin writing.</param>
+        /// <param name="count">The maximum number of characters to read.</param>
+        /// <returns>The actual number of characters that have been read. The number will be less than or equal to count.</returns>
+        /// <exception cref="System.ArgumentNullException">buffer is null.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The buffer length minus index is less than count.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">index or count is negative.</exception>
+        public override int ReadBlock(char[] buffer, int index, int count)
         {
-            int size = Math.Min(this._lastData - this._nextData, this._bufferSize);
-            this._data = this._scintilla.GetTextRange(this._nextData, size);
-            this._nextData += this._data.Length;
-            this._dataIndex = 0;
+            if (this._data != null)
+            {
+                int bufferRemaining = BufferRemaining;
+                if (count < bufferRemaining)
+                {
+                    // buffer larger than read size
+                    this._data.CopyTo(this._dataIndex, buffer, index, count);
+                    return count;
+                }
+                else
+                {
+                    // buffer smaller or equal to read size
+                    this._data.CopyTo(this._dataIndex, buffer, index, bufferRemaining);
+                    if (count > bufferRemaining)
+                    {
+                        // buffer is smaller; read rest
+                        string rest = this._scintilla.GetTextRange(
+                            this._nextData,
+                            Math.Min(count - bufferRemaining, UnbufferedRemaining));
+                        rest.CopyTo(0, buffer, index + bufferRemaining, rest.Length);
+                        count = bufferRemaining + rest.Length;
+                        this._nextData += rest.Length;
+                    }
+                    // read at least up to buffer's end; refill buffer
+                    BufferNextRegion();
+                    return count;
+                }
+            }
+            else
+            {
+                return 0;
+            }
         }
-        else
+
+        /// <summary>
+        /// Fills the buffer with the next section of text.
+        /// </summary>
+        private void BufferNextRegion()
         {
-            this._data = null;
+            if (this._nextData < this._lastData)
+            {
+                int size = Math.Min(this._lastData - this._nextData, this._bufferSize);
+                this._data = this._scintilla.GetTextRange(this._nextData, size);
+                this._nextData += this._data.Length;
+                this._dataIndex = 0;
+            }
+            else
+            {
+                this._data = null;
+            }
         }
     }
 }

--- a/Scintilla.NET/SearchFlags.cs
+++ b/Scintilla.NET/SearchFlags.cs
@@ -1,53 +1,54 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Specifies the how patterns are matched when performing a search in a <see cref="Scintilla" /> control.
-/// </summary>
-/// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
-[Flags]
-public enum SearchFlags
+namespace ScintillaNET
 {
     /// <summary>
-    /// Case-insensitive literal match.
+    /// Specifies the how patterns are matched when performing a search in a <see cref="Scintilla" /> control.
     /// </summary>
-    None = NativeMethods.SCFIND_NONE,
+    /// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
+    [Flags]
+    public enum SearchFlags
+    {
+        /// <summary>
+        /// Case-insensitive literal match.
+        /// </summary>
+        None = NativeMethods.SCFIND_NONE,
 
-    /// <summary>
-    /// A match only occurs with text that matches the case of the search string.
-    /// </summary>
-    MatchCase = NativeMethods.SCFIND_MATCHCASE,
+        /// <summary>
+        /// A match only occurs with text that matches the case of the search string.
+        /// </summary>
+        MatchCase = NativeMethods.SCFIND_MATCHCASE,
 
-    /// <summary>
-    /// A match only occurs if the characters before and after are not word characters as defined by <see cref="Scintilla.WordChars"/>.
-    /// </summary>
-    WholeWord = NativeMethods.SCFIND_WHOLEWORD,
+        /// <summary>
+        /// A match only occurs if the characters before and after are not word characters as defined by <see cref="Scintilla.WordChars"/>.
+        /// </summary>
+        WholeWord = NativeMethods.SCFIND_WHOLEWORD,
 
-    /// <summary>
-    /// A match only occurs if the character before is not a word character as defined by <see cref="Scintilla.WordChars"/>.
-    /// </summary>
-    WordStart = NativeMethods.SCFIND_WORDSTART,
+        /// <summary>
+        /// A match only occurs if the character before is not a word character as defined by <see cref="Scintilla.WordChars"/>.
+        /// </summary>
+        WordStart = NativeMethods.SCFIND_WORDSTART,
 
-    /// <summary>
-    /// The search string should be interpreted as a regular expression.
-    /// Uses Scintilla's base implementation unless combined with <see cref="Cxx11Regex"/>.
-    /// Regular expressions will only match ranges within a single line, never matching over multiple lines.
-    /// </summary>
-    Regex = NativeMethods.SCFIND_REGEXP,
+        /// <summary>
+        /// The search string should be interpreted as a regular expression.
+        /// Uses Scintilla's base implementation unless combined with <see cref="Cxx11Regex"/>.
+        /// Regular expressions will only match ranges within a single line, never matching over multiple lines.
+        /// </summary>
+        Regex = NativeMethods.SCFIND_REGEXP,
 
-    /// <summary>
-    /// Treat regular expression in a more POSIX compatible manner by interpreting bare '(' and ')' for tagged sections rather than "\(" and "\)".
-    /// Has no effect when <see cref="Cxx11Regex"/> is set.
-    /// </summary>
-    Posix = NativeMethods.SCFIND_POSIX,
+        /// <summary>
+        /// Treat regular expression in a more POSIX compatible manner by interpreting bare '(' and ')' for tagged sections rather than "\(" and "\)".
+        /// Has no effect when <see cref="Cxx11Regex"/> is set.
+        /// </summary>
+        Posix = NativeMethods.SCFIND_POSIX,
 
-    /// <summary>
-    /// The search string should be interpreted as a regular expression and use the C++11 &lt;regex&gt; standard library engine.
-    /// The <see cref="Scintilla.Status" /> property can queried to determine if the regular expression is invalid.
-    /// The ECMAScript flag is set on the regex object and documents will exhibit Unicode-compliant behaviour.
-    /// Regular expressions will only match ranges within a single line, never matching over multiple lines.
-    /// Must also have <see cref="Regex"/> set.
-    /// </summary>
-    Cxx11Regex = NativeMethods.SCFIND_CXX11REGEX
+        /// <summary>
+        /// The search string should be interpreted as a regular expression and use the C++11 &lt;regex&gt; standard library engine.
+        /// The <see cref="Scintilla.Status" /> property can queried to determine if the regular expression is invalid.
+        /// The ECMAScript flag is set on the regex object and documents will exhibit Unicode-compliant behaviour.
+        /// Regular expressions will only match ranges within a single line, never matching over multiple lines.
+        /// Must also have <see cref="Regex"/> set.
+        /// </summary>
+        Cxx11Regex = NativeMethods.SCFIND_CXX11REGEX
+    }
 }

--- a/Scintilla.NET/Selection.cs
+++ b/Scintilla.NET/Selection.cs
@@ -1,150 +1,151 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Represents a selection when there are multiple active selections in a <see cref="Scintilla" /> control.
-/// </summary>
-public class Selection
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-
     /// <summary>
-    /// Gets or sets the anchor position of the selection.
+    /// Represents a selection when there are multiple active selections in a <see cref="Scintilla" /> control.
     /// </summary>
-    /// <returns>The zero-based document position of the selection anchor.</returns>
-    public int Anchor
+    public class Selection
     {
-        get
-        {
-            int pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNANCHOR, new IntPtr(Index)).ToInt32();
-            if (pos <= 0)
-                return pos;
+        private readonly Scintilla scintilla;
 
-            return this.scintilla.Lines.ByteToCharPosition(pos);
-        }
-        set
+        /// <summary>
+        /// Gets or sets the anchor position of the selection.
+        /// </summary>
+        /// <returns>The zero-based document position of the selection anchor.</returns>
+        public int Anchor
         {
-            value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
-            value = this.scintilla.Lines.CharToBytePosition(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNANCHOR, new IntPtr(Index), new IntPtr(value));
-        }
-    }
+            get
+            {
+                int pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNANCHOR, new IntPtr(Index)).ToInt32();
+                if (pos <= 0)
+                    return pos;
 
-    /// <summary>
-    /// Gets or sets the amount of anchor virtual space.
-    /// </summary>
-    /// <returns>The amount of virtual space past the end of the line offsetting the selection anchor.</returns>
-    public int AnchorVirtualSpace
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNANCHORVIRTUALSPACE, new IntPtr(Index)).ToInt32();
+                return this.scintilla.Lines.ByteToCharPosition(pos);
+            }
+            set
+            {
+                value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
+                value = this.scintilla.Lines.CharToBytePosition(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNANCHOR, new IntPtr(Index), new IntPtr(value));
+            }
         }
-        set
-        {
-            value = Helpers.ClampMin(value, 0);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNANCHORVIRTUALSPACE, new IntPtr(Index), new IntPtr(value));
-        }
-    }
 
-    /// <summary>
-    /// Gets or sets the caret position of the selection.
-    /// </summary>
-    /// <returns>The zero-based document position of the selection caret.</returns>
-    public int Caret
-    {
-        get
+        /// <summary>
+        /// Gets or sets the amount of anchor virtual space.
+        /// </summary>
+        /// <returns>The amount of virtual space past the end of the line offsetting the selection anchor.</returns>
+        public int AnchorVirtualSpace
         {
-            int pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNCARET, new IntPtr(Index)).ToInt32();
-            if (pos <= 0)
-                return pos;
-
-            return this.scintilla.Lines.ByteToCharPosition(pos);
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNANCHORVIRTUALSPACE, new IntPtr(Index)).ToInt32();
+            }
+            set
+            {
+                value = Helpers.ClampMin(value, 0);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNANCHORVIRTUALSPACE, new IntPtr(Index), new IntPtr(value));
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets the caret position of the selection.
+        /// </summary>
+        /// <returns>The zero-based document position of the selection caret.</returns>
+        public int Caret
         {
-            value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
-            value = this.scintilla.Lines.CharToBytePosition(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNCARET, new IntPtr(Index), new IntPtr(value));
-        }
-    }
+            get
+            {
+                int pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNCARET, new IntPtr(Index)).ToInt32();
+                if (pos <= 0)
+                    return pos;
 
-    /// <summary>
-    /// Gets or sets the amount of caret virtual space.
-    /// </summary>
-    /// <returns>The amount of virtual space past the end of the line offsetting the selection caret.</returns>
-    public int CaretVirtualSpace
-    {
-        get
+                return this.scintilla.Lines.ByteToCharPosition(pos);
+            }
+            set
+            {
+                value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
+                value = this.scintilla.Lines.CharToBytePosition(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNCARET, new IntPtr(Index), new IntPtr(value));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the amount of caret virtual space.
+        /// </summary>
+        /// <returns>The amount of virtual space past the end of the line offsetting the selection caret.</returns>
+        public int CaretVirtualSpace
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNCARETVIRTUALSPACE, new IntPtr(Index)).ToInt32();
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNCARETVIRTUALSPACE, new IntPtr(Index)).ToInt32();
+            }
+            set
+            {
+                value = Helpers.ClampMin(value, 0);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNCARETVIRTUALSPACE, new IntPtr(Index), new IntPtr(value));
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets the end position of the selection.
+        /// </summary>
+        /// <returns>The zero-based document position where the selection ends.</returns>
+        public int End
         {
-            value = Helpers.ClampMin(value, 0);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNCARETVIRTUALSPACE, new IntPtr(Index), new IntPtr(value));
-        }
-    }
+            get
+            {
+                int pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNEND, new IntPtr(Index)).ToInt32();
+                if (pos <= 0)
+                    return pos;
 
-    /// <summary>
-    /// Gets or sets the end position of the selection.
-    /// </summary>
-    /// <returns>The zero-based document position where the selection ends.</returns>
-    public int End
-    {
-        get
+                return this.scintilla.Lines.ByteToCharPosition(pos);
+            }
+            set
+            {
+                value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
+                value = this.scintilla.Lines.CharToBytePosition(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNEND, new IntPtr(Index), new IntPtr(value));
+            }
+        }
+
+        /// <summary>
+        /// Gets the selection index.
+        /// </summary>
+        /// <returns>The zero-based selection index within the <see cref="SelectionCollection" /> that created it.</returns>
+        public int Index { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the start position of the selection.
+        /// </summary>
+        /// <returns>The zero-based document position where the selection starts.</returns>
+        public int Start
         {
-            int pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNEND, new IntPtr(Index)).ToInt32();
-            if (pos <= 0)
-                return pos;
+            get
+            {
+                int pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNSTART, new IntPtr(Index)).ToInt32();
+                if (pos <= 0)
+                    return pos;
 
-            return this.scintilla.Lines.ByteToCharPosition(pos);
+                return this.scintilla.Lines.ByteToCharPosition(pos);
+            }
+            set
+            {
+                value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
+                value = this.scintilla.Lines.CharToBytePosition(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNSTART, new IntPtr(Index), new IntPtr(value));
+            }
         }
-        set
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Selection" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this selection.</param>
+        /// <param name="index">The index of this selection within the <see cref="SelectionCollection" /> that created it.</param>
+        public Selection(Scintilla scintilla, int index)
         {
-            value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
-            value = this.scintilla.Lines.CharToBytePosition(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNEND, new IntPtr(Index), new IntPtr(value));
+            this.scintilla = scintilla;
+            Index = index;
         }
-    }
-
-    /// <summary>
-    /// Gets the selection index.
-    /// </summary>
-    /// <returns>The zero-based selection index within the <see cref="SelectionCollection" /> that created it.</returns>
-    public int Index { get; private set; }
-
-    /// <summary>
-    /// Gets or sets the start position of the selection.
-    /// </summary>
-    /// <returns>The zero-based document position where the selection starts.</returns>
-    public int Start
-    {
-        get
-        {
-            int pos = this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONNSTART, new IntPtr(Index)).ToInt32();
-            if (pos <= 0)
-                return pos;
-
-            return this.scintilla.Lines.ByteToCharPosition(pos);
-        }
-        set
-        {
-            value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
-            value = this.scintilla.Lines.CharToBytePosition(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNSTART, new IntPtr(Index), new IntPtr(value));
-        }
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Selection" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this selection.</param>
-    /// <param name="index">The index of this selection within the <see cref="SelectionCollection" /> that created it.</param>
-    public Selection(Scintilla scintilla, int index)
-    {
-        this.scintilla = scintilla;
-        Index = index;
     }
 }

--- a/Scintilla.NET/SelectionCollection.cs
+++ b/Scintilla.NET/SelectionCollection.cs
@@ -2,77 +2,78 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// A multiple selection collection.
-/// </summary>
-public class SelectionCollection : IEnumerable<Selection>
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-
     /// <summary>
-    /// Provides an enumerator that iterates through the collection.
+    /// A multiple selection collection.
     /// </summary>
-    /// <returns>An object that contains all <see cref="Selection" /> objects within the <see cref="SelectionCollection" />.</returns>
-    public IEnumerator<Selection> GetEnumerator()
+    public class SelectionCollection : IEnumerable<Selection>
     {
-        int count = Count;
-        for (int i = 0; i < count; i++)
-            yield return this[i];
+        private readonly Scintilla scintilla;
 
-        yield break;
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    /// <summary>
-    /// Gets the number of active selections.
-    /// </summary>
-    /// <returns>The number of selections in the <see cref="SelectionCollection" />.</returns>
-    public int Count
-    {
-        get
+        /// <summary>
+        /// Provides an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An object that contains all <see cref="Selection" /> objects within the <see cref="SelectionCollection" />.</returns>
+        public IEnumerator<Selection> GetEnumerator()
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONS).ToInt32();
-        }
-    }
+            int count = Count;
+            for (int i = 0; i < count; i++)
+                yield return this[i];
 
-    /// <summary>
-    /// Gets a value indicating whether all selection ranges are empty.
-    /// </summary>
-    /// <returns>true if all selection ranges are empty; otherwise, false.</returns>
-    public bool IsEmpty
-    {
-        get
+            yield break;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONEMPTY) != IntPtr.Zero;
+            return GetEnumerator();
         }
-    }
 
-    /// <summary>
-    /// Gets the <see cref="Selection" /> at the specified zero-based index.
-    /// </summary>
-    /// <param name="index">The zero-based index of the <see cref="Selection" /> to get.</param>
-    /// <returns>The <see cref="Selection" /> at the specified index.</returns>
-    public Selection this[int index]
-    {
-        get
+        /// <summary>
+        /// Gets the number of active selections.
+        /// </summary>
+        /// <returns>The number of selections in the <see cref="SelectionCollection" />.</returns>
+        public int Count
         {
-            index = Helpers.Clamp(index, 0, Count - 1);
-            return new Selection(this.scintilla, index);
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONS).ToInt32();
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SelectionCollection" /> class.
-    /// </summary>
-    /// <param name="scintilla"></param>
-    public SelectionCollection(Scintilla scintilla)
-    {
-        this.scintilla = scintilla;
+        /// <summary>
+        /// Gets a value indicating whether all selection ranges are empty.
+        /// </summary>
+        /// <returns>true if all selection ranges are empty; otherwise, false.</returns>
+        public bool IsEmpty
+        {
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_GETSELECTIONEMPTY) != IntPtr.Zero;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Selection" /> at the specified zero-based index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the <see cref="Selection" /> to get.</param>
+        /// <returns>The <see cref="Selection" /> at the specified index.</returns>
+        public Selection this[int index]
+        {
+            get
+            {
+                index = Helpers.Clamp(index, 0, Count - 1);
+                return new Selection(this.scintilla, index);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SelectionCollection" /> class.
+        /// </summary>
+        /// <param name="scintilla"></param>
+        public SelectionCollection(Scintilla scintilla)
+        {
+            this.scintilla = scintilla;
+        }
     }
 }

--- a/Scintilla.NET/Status.cs
+++ b/Scintilla.NET/Status.cs
@@ -1,27 +1,28 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Possible status codes returned by the <see cref="Scintilla.Status" /> property.
-/// </summary>
-public enum Status
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// No failures.
+    /// Possible status codes returned by the <see cref="Scintilla.Status" /> property.
     /// </summary>
-    Ok = NativeMethods.SC_STATUS_OK,
+    public enum Status
+    {
+        /// <summary>
+        /// No failures.
+        /// </summary>
+        Ok = NativeMethods.SC_STATUS_OK,
 
-    /// <summary>
-    /// Generic failure.
-    /// </summary>
-    Failure = NativeMethods.SC_STATUS_FAILURE,
+        /// <summary>
+        /// Generic failure.
+        /// </summary>
+        Failure = NativeMethods.SC_STATUS_FAILURE,
 
-    /// <summary>
-    /// Memory is exhausted.
-    /// </summary>
-    BadAlloc = NativeMethods.SC_STATUS_BADALLOC,
+        /// <summary>
+        /// Memory is exhausted.
+        /// </summary>
+        BadAlloc = NativeMethods.SC_STATUS_BADALLOC,
 
-    /// <summary>
-    /// Regular expression is invalid.
-    /// </summary>
-    WarnRegex = NativeMethods.SC_STATUS_WARN_REGEX
+        /// <summary>
+        /// Regular expression is invalid.
+        /// </summary>
+        WarnRegex = NativeMethods.SC_STATUS_WARN_REGEX
+    }
 }

--- a/Scintilla.NET/Style.cs
+++ b/Scintilla.NET/Style.cs
@@ -2,3605 +2,3606 @@ using System;
 using System.Drawing;
 using System.Text;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// A style definition in a <see cref="Scintilla" /> control.
-/// </summary>
-public class Style
+namespace ScintillaNET
 {
-    #region Constants
-
     /// <summary>
-    /// Default style index. This style is used to define properties that all styles receive when calling <see cref="Scintilla.StyleClearAll" />.
+    /// A style definition in a <see cref="Scintilla" /> control.
     /// </summary>
-    public const int Default = NativeMethods.STYLE_DEFAULT;
-
-    /// <summary>
-    /// Line number style index. This style is used for text in line number margins. The background color of this style also
-    /// sets the background color for all margins that do not have any folding mask set.
-    /// </summary>
-    public const int LineNumber = NativeMethods.STYLE_LINENUMBER;
-
-    /// <summary>
-    /// Call tip style index. Only font name, size, foreground color, background color, and character set attributes
-    /// can be used when displaying a call tip.
-    /// </summary>
-    public const int CallTip = NativeMethods.STYLE_CALLTIP;
-
-    /// <summary>
-    /// Indent guide style index. This style is used to specify the foreground and background colors of <see cref="Scintilla.IndentationGuides" />.
-    /// </summary>
-    public const int IndentGuide = NativeMethods.STYLE_INDENTGUIDE;
-
-    /// <summary>
-    /// Brace highlighting style index. This style is used on a brace character when set with the <see cref="Scintilla.BraceHighlight" /> method
-    /// or the indentation guide when used with the <see cref="Scintilla.HighlightGuide" /> property.
-    /// </summary>
-    public const int BraceLight = NativeMethods.STYLE_BRACELIGHT;
-
-    /// <summary>
-    /// Bad brace style index. This style is used on an unmatched brace character when set with the <see cref="Scintilla.BraceBadLight" /> method.
-    /// </summary>
-    public const int BraceBad = NativeMethods.STYLE_BRACEBAD;
-
-    /// <summary>
-    /// Fold text tag style index. This is the style used for drawing text tags attached to folded text when
-    /// <see cref="Scintilla.FoldDisplayTextSetStyle" /> and <see cref="Line.ToggleFoldShowText" /> are used.
-    /// </summary>
-    public const int FoldDisplayText = NativeMethods.STYLE_FOLDDISPLAYTEXT;
-
-    #endregion Constants
-
-    #region Fields
-
-    private readonly Scintilla scintilla;
-
-    #endregion Fields
-
-    #region Methods
-
-    /// <summary>
-    /// Copies the current style to another style.
-    /// </summary>
-    /// <param name="destination">The <see cref="Style" /> to which the current style should be copied.</param>
-    public void CopyTo(Style destination)
+    public class Style
     {
-        if (destination == null)
-            return;
+        #region Constants
 
-        destination.BackColor = BackColor;
-        // destination.Bold = Bold;
-        destination.Case = Case;
-        destination.FillLine = FillLine;
-        destination.Font = Font;
-        destination.ForeColor = ForeColor;
-        destination.Hotspot = Hotspot;
-        destination.Italic = Italic;
-        destination.Size = Size;
-        destination.SizeF = SizeF;
-        destination.Underline = Underline;
-        destination.Visible = Visible;
-        destination.Weight = Weight;
-    }
+        /// <summary>
+        /// Default style index. This style is used to define properties that all styles receive when calling <see cref="Scintilla.StyleClearAll" />.
+        /// </summary>
+        public const int Default = NativeMethods.STYLE_DEFAULT;
 
-    #endregion Methods
+        /// <summary>
+        /// Line number style index. This style is used for text in line number margins. The background color of this style also
+        /// sets the background color for all margins that do not have any folding mask set.
+        /// </summary>
+        public const int LineNumber = NativeMethods.STYLE_LINENUMBER;
 
-    #region Properties
+        /// <summary>
+        /// Call tip style index. Only font name, size, foreground color, background color, and character set attributes
+        /// can be used when displaying a call tip.
+        /// </summary>
+        public const int CallTip = NativeMethods.STYLE_CALLTIP;
 
-    /// <summary>
-    /// Gets or sets the background color of the style.
-    /// </summary>
-    /// <returns>A Color object representing the style background color. The default is White.</returns>
-    /// <remarks>Alpha color values are ignored.</remarks>
-    public Color BackColor
-    {
-        get
-        {
-            int color = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETBACK, new IntPtr(Index), IntPtr.Zero).ToInt32();
-            return HelperMethods.FromWin32ColorOpaque(color);
-        }
-        set
-        {
-            if (value.IsEmpty)
-                value = Color.White;
+        /// <summary>
+        /// Indent guide style index. This style is used to specify the foreground and background colors of <see cref="Scintilla.IndentationGuides" />.
+        /// </summary>
+        public const int IndentGuide = NativeMethods.STYLE_INDENTGUIDE;
 
-            int color = HelperMethods.ToWin32ColorOpaque(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETBACK, new IntPtr(Index), new IntPtr(color));
-        }
-    }
+        /// <summary>
+        /// Brace highlighting style index. This style is used on a brace character when set with the <see cref="Scintilla.BraceHighlight" /> method
+        /// or the indentation guide when used with the <see cref="Scintilla.HighlightGuide" /> property.
+        /// </summary>
+        public const int BraceLight = NativeMethods.STYLE_BRACELIGHT;
 
-    /// <summary>
-    /// Gets or sets whether the style font is bold.
-    /// </summary>
-    /// <returns>true if bold; otherwise, false. The default is false.</returns>
-    /// <remarks>Setting this property affects the <see cref="Weight" /> property.</remarks>
-    public bool Bold
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETBOLD, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
-        }
-        set
-        {
-            IntPtr bold = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETBOLD, new IntPtr(Index), bold);
-        }
-    }
+        /// <summary>
+        /// Bad brace style index. This style is used on an unmatched brace character when set with the <see cref="Scintilla.BraceBadLight" /> method.
+        /// </summary>
+        public const int BraceBad = NativeMethods.STYLE_BRACEBAD;
 
-    /// <summary>
-    /// Gets or sets the casing used to display the styled text.
-    /// </summary>
-    /// <returns>One of the <see cref="StyleCase" /> enum values. The default is <see cref="StyleCase.Mixed" />.</returns>
-    /// <remarks>This does not affect how text is stored, only displayed.</remarks>
-    public StyleCase Case
-    {
-        get
-        {
-            int @case = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETCASE, new IntPtr(Index), IntPtr.Zero).ToInt32();
-            return (StyleCase)@case;
-        }
-        set
-        {
-            // Just an excuse to use @... syntax
-            int @case = (int)value;
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETCASE, new IntPtr(Index), new IntPtr(@case));
-        }
-    }
+        /// <summary>
+        /// Fold text tag style index. This is the style used for drawing text tags attached to folded text when
+        /// <see cref="Scintilla.FoldDisplayTextSetStyle" /> and <see cref="Line.ToggleFoldShowText" /> are used.
+        /// </summary>
+        public const int FoldDisplayText = NativeMethods.STYLE_FOLDDISPLAYTEXT;
 
-    /// <summary>
-    /// This is an experimental and incompletely implemented style attribute. The default setting is changeable set true
-    /// but when set false it makes text read-only. The user can not move the caret within not-changeable text and
-    /// not-changeable text may not be deleted by the user. The application may delete not-changeable text by calling
-    /// <see cref="Scintilla.DeleteRange(int, int)"/>.
-    /// </summary>
-    /// <returns>false to make the text read-only, true otherwise. The default is true.</returns>
-    public bool Changeable
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETCHANGEABLE, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
-        }
-        set
-        {
-            IntPtr changeable = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETCHANGEABLE, new IntPtr(Index), changeable);
-        }
-    }
+        #endregion Constants
 
-    /// <summary>
-    /// Gets or sets whether the remainder of the line is filled with the <see cref="BackColor" />
-    /// when this style is used on the last character of a line.
-    /// </summary>
-    /// <returns>true to fill the line; otherwise, false. The default is false.</returns>
-    public bool FillLine
-    {
-        get
-        {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETEOLFILLED, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
-        }
-        set
-        {
-            IntPtr fillLine = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETEOLFILLED, new IntPtr(Index), fillLine);
-        }
-    }
+        #region Fields
 
-    /// <summary>
-    /// Gets or sets the style font name.
-    /// </summary>
-    /// <returns>The style font name. The default is Verdana.</returns>
-    /// <remarks>Scintilla caches fonts by name so font names and casing should be consistent.</remarks>
-    public string Font
-    {
-        get
+        private readonly Scintilla scintilla;
+
+        #endregion Fields
+
+        #region Methods
+
+        /// <summary>
+        /// Copies the current style to another style.
+        /// </summary>
+        /// <param name="destination">The <see cref="Style" /> to which the current style should be copied.</param>
+        public void CopyTo(Style destination)
         {
-            int length = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFONT, new IntPtr(Index), IntPtr.Zero).ToInt32();
-            byte[] font = new byte[length];
-            unsafe
+            if (destination == null)
+                return;
+
+            destination.BackColor = BackColor;
+            // destination.Bold = Bold;
+            destination.Case = Case;
+            destination.FillLine = FillLine;
+            destination.Font = Font;
+            destination.ForeColor = ForeColor;
+            destination.Hotspot = Hotspot;
+            destination.Italic = Italic;
+            destination.Size = Size;
+            destination.SizeF = SizeF;
+            destination.Underline = Underline;
+            destination.Visible = Visible;
+            destination.Weight = Weight;
+        }
+
+        #endregion Methods
+
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the background color of the style.
+        /// </summary>
+        /// <returns>A Color object representing the style background color. The default is White.</returns>
+        /// <remarks>Alpha color values are ignored.</remarks>
+        public Color BackColor
+        {
+            get
             {
-                fixed (byte* bp = font)
-                    this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFONT, new IntPtr(Index), new IntPtr(bp));
+                int color = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETBACK, new IntPtr(Index), IntPtr.Zero).ToInt32();
+                return HelperMethods.FromWin32ColorOpaque(color);
             }
-
-            string name = Encoding.UTF8.GetString(font, 0, length);
-            return name;
-        }
-        set
-        {
-            if (string.IsNullOrEmpty(value))
-                value = "Verdana";
-
-            // Scintilla expects UTF-8
-            byte[] font = Helpers.GetBytes(value, Encoding.UTF8, true);
-            unsafe
+            set
             {
-                fixed (byte* bp = font)
-                    this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETFONT, new IntPtr(Index), new IntPtr(bp));
+                if (value.IsEmpty)
+                    value = Color.White;
+
+                int color = HelperMethods.ToWin32ColorOpaque(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETBACK, new IntPtr(Index), new IntPtr(color));
             }
         }
-    }
 
-    /// <summary>
-    /// Gets or sets the foreground color of the style.
-    /// </summary>
-    /// <returns>A Color object representing the style foreground color. The default is Black.</returns>
-    /// <remarks>Alpha color values are ignored.</remarks>
-    public Color ForeColor
-    {
-        get
+        /// <summary>
+        /// Gets or sets whether the style font is bold.
+        /// </summary>
+        /// <returns>true if bold; otherwise, false. The default is false.</returns>
+        /// <remarks>Setting this property affects the <see cref="Weight" /> property.</remarks>
+        public bool Bold
         {
-            int color = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFORE, new IntPtr(Index), IntPtr.Zero).ToInt32();
-            return HelperMethods.FromWin32ColorOpaque(color);
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETBOLD, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr bold = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETBOLD, new IntPtr(Index), bold);
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets the casing used to display the styled text.
+        /// </summary>
+        /// <returns>One of the <see cref="StyleCase" /> enum values. The default is <see cref="StyleCase.Mixed" />.</returns>
+        /// <remarks>This does not affect how text is stored, only displayed.</remarks>
+        public StyleCase Case
         {
-            if (value.IsEmpty)
-                value = Color.Black;
-
-            int color = HelperMethods.ToWin32ColorOpaque(value);
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETFORE, new IntPtr(Index), new IntPtr(color));
+            get
+            {
+                int @case = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETCASE, new IntPtr(Index), IntPtr.Zero).ToInt32();
+                return (StyleCase)@case;
+            }
+            set
+            {
+                // Just an excuse to use @... syntax
+                int @case = (int)value;
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETCASE, new IntPtr(Index), new IntPtr(@case));
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets or sets whether hovering the mouse over the style text exhibits hyperlink behavior.
-    /// </summary>
-    /// <returns>true to use hyperlink behavior; otherwise, false. The default is false.</returns>
-    public bool Hotspot
-    {
-        get
+        /// <summary>
+        /// This is an experimental and incompletely implemented style attribute. The default setting is changeable set true
+        /// but when set false it makes text read-only. The user can not move the caret within not-changeable text and
+        /// not-changeable text may not be deleted by the user. The application may delete not-changeable text by calling
+        /// <see cref="Scintilla.DeleteRange(int, int)"/>.
+        /// </summary>
+        /// <returns>false to make the text read-only, true otherwise. The default is true.</returns>
+        public bool Changeable
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETHOTSPOT, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETCHANGEABLE, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr changeable = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETCHANGEABLE, new IntPtr(Index), changeable);
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets whether the remainder of the line is filled with the <see cref="BackColor" />
+        /// when this style is used on the last character of a line.
+        /// </summary>
+        /// <returns>true to fill the line; otherwise, false. The default is false.</returns>
+        public bool FillLine
         {
-            IntPtr hotspot = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETHOTSPOT, new IntPtr(Index), hotspot);
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETEOLFILLED, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr fillLine = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETEOLFILLED, new IntPtr(Index), fillLine);
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets the zero-based style definition index.
-    /// </summary>
-    /// <returns>The style definition index within the <see cref="StyleCollection" />.</returns>
-    public int Index { get; private set; }
-
-    /// <summary>
-    /// Gets or sets whether the style font is italic.
-    /// </summary>
-    /// <returns>true if italic; otherwise, false. The default is false.</returns>
-    public bool Italic
-    {
-        get
+        /// <summary>
+        /// Gets or sets the style font name.
+        /// </summary>
+        /// <returns>The style font name. The default is Verdana.</returns>
+        /// <remarks>Scintilla caches fonts by name so font names and casing should be consistent.</remarks>
+        public string Font
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETITALIC, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            get
+            {
+                int length = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFONT, new IntPtr(Index), IntPtr.Zero).ToInt32();
+                byte[] font = new byte[length];
+                unsafe
+                {
+                    fixed (byte* bp = font)
+                        this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFONT, new IntPtr(Index), new IntPtr(bp));
+                }
+
+                string name = Encoding.UTF8.GetString(font, 0, length);
+                return name;
+            }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                    value = "Verdana";
+
+                // Scintilla expects UTF-8
+                byte[] font = Helpers.GetBytes(value, Encoding.UTF8, true);
+                unsafe
+                {
+                    fixed (byte* bp = font)
+                        this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETFONT, new IntPtr(Index), new IntPtr(bp));
+                }
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets the foreground color of the style.
+        /// </summary>
+        /// <returns>A Color object representing the style foreground color. The default is Black.</returns>
+        /// <remarks>Alpha color values are ignored.</remarks>
+        public Color ForeColor
         {
-            IntPtr italic = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETITALIC, new IntPtr(Index), italic);
-        }
-    }
+            get
+            {
+                int color = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETFORE, new IntPtr(Index), IntPtr.Zero).ToInt32();
+                return HelperMethods.FromWin32ColorOpaque(color);
+            }
+            set
+            {
+                if (value.IsEmpty)
+                    value = Color.Black;
 
-    /// <summary>
-    /// Gets or sets the size of the style font in points.
-    /// </summary>
-    /// <returns>The size of the style font as a whole number of points. The default is 8.</returns>
-    public int Size
-    {
-        get
+                int color = HelperMethods.ToWin32ColorOpaque(value);
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETFORE, new IntPtr(Index), new IntPtr(color));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether hovering the mouse over the style text exhibits hyperlink behavior.
+        /// </summary>
+        /// <returns>true to use hyperlink behavior; otherwise, false. The default is false.</returns>
+        public bool Hotspot
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETSIZE, new IntPtr(Index), IntPtr.Zero).ToInt32();
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETHOTSPOT, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr hotspot = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETHOTSPOT, new IntPtr(Index), hotspot);
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets the zero-based style definition index.
+        /// </summary>
+        /// <returns>The style definition index within the <see cref="StyleCollection" />.</returns>
+        public int Index { get; private set; }
+
+        /// <summary>
+        /// Gets or sets whether the style font is italic.
+        /// </summary>
+        /// <returns>true if italic; otherwise, false. The default is false.</returns>
+        public bool Italic
         {
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETSIZE, new IntPtr(Index), new IntPtr(value));
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETITALIC, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr italic = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETITALIC, new IntPtr(Index), italic);
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets or sets the size of the style font in fractoinal points.
-    /// </summary>
-    /// <returns>The size of the style font in fractional number of points. The default is 8.</returns>
-    public float SizeF
-    {
-        get
+        /// <summary>
+        /// Gets or sets the size of the style font in points.
+        /// </summary>
+        /// <returns>The size of the style font as a whole number of points. The default is 8.</returns>
+        public int Size
         {
-            int fraction = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETSIZEFRACTIONAL, new IntPtr(Index), IntPtr.Zero).ToInt32();
-            return (float)fraction / NativeMethods.SC_FONT_SIZE_MULTIPLIER;
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETSIZE, new IntPtr(Index), IntPtr.Zero).ToInt32();
+            }
+            set
+            {
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETSIZE, new IntPtr(Index), new IntPtr(value));
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets the size of the style font in fractoinal points.
+        /// </summary>
+        /// <returns>The size of the style font in fractional number of points. The default is 8.</returns>
+        public float SizeF
         {
-            int fraction = (int)(value * NativeMethods.SC_FONT_SIZE_MULTIPLIER);
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETSIZEFRACTIONAL, new IntPtr(Index), new IntPtr(fraction));
+            get
+            {
+                int fraction = this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETSIZEFRACTIONAL, new IntPtr(Index), IntPtr.Zero).ToInt32();
+                return (float)fraction / NativeMethods.SC_FONT_SIZE_MULTIPLIER;
+            }
+            set
+            {
+                int fraction = (int)(value * NativeMethods.SC_FONT_SIZE_MULTIPLIER);
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETSIZEFRACTIONAL, new IntPtr(Index), new IntPtr(fraction));
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets or sets whether the style is underlined.
-    /// </summary>
-    /// <returns>true if underlined; otherwise, false. The default is false.</returns>
-    public bool Underline
-    {
-        get
+        /// <summary>
+        /// Gets or sets whether the style is underlined.
+        /// </summary>
+        /// <returns>true if underlined; otherwise, false. The default is false.</returns>
+        public bool Underline
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETUNDERLINE, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETUNDERLINE, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr underline = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETUNDERLINE, new IntPtr(Index), underline);
+            }
         }
-        set
+
+        /// <summary>
+        /// Gets or sets whether the style text is visible.
+        /// </summary>
+        /// <returns>true to display the style text; otherwise, false. The default is true.</returns>
+        public bool Visible
         {
-            IntPtr underline = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETUNDERLINE, new IntPtr(Index), underline);
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETVISIBLE, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            }
+            set
+            {
+                IntPtr visible = value ? new IntPtr(1) : IntPtr.Zero;
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETVISIBLE, new IntPtr(Index), visible);
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets or sets whether the style text is visible.
-    /// </summary>
-    /// <returns>true to display the style text; otherwise, false. The default is true.</returns>
-    public bool Visible
-    {
-        get
+        /// <summary>
+        /// Gets or sets the style font weight.
+        /// </summary>
+        /// <returns>The font weight. The default is 400.</returns>
+        /// <remarks>Setting this property affects the <see cref="Bold" /> property.</remarks>
+        public int Weight
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETVISIBLE, new IntPtr(Index), IntPtr.Zero) != IntPtr.Zero;
+            get
+            {
+                return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETWEIGHT, new IntPtr(Index), IntPtr.Zero).ToInt32();
+            }
+            set
+            {
+                this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETWEIGHT, new IntPtr(Index), new IntPtr(value));
+            }
         }
-        set
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instances of the <see cref="Style" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this style.</param>
+        /// <param name="index">The index of this style within the <see cref="StyleCollection" /> that created it.</param>
+        public Style(Scintilla scintilla, int index)
         {
-            IntPtr visible = value ? new IntPtr(1) : IntPtr.Zero;
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETVISIBLE, new IntPtr(Index), visible);
+            this.scintilla = scintilla;
+            Index = index;
         }
-    }
 
-    /// <summary>
-    /// Gets or sets the style font weight.
-    /// </summary>
-    /// <returns>The font weight. The default is 400.</returns>
-    /// <remarks>Setting this property affects the <see cref="Bold" /> property.</remarks>
-    public int Weight
-    {
-        get
+        #endregion Constructors
+
+        #region Ada
+
+        /// <summary>
+        /// Style constants for use with the Ada lexer.
+        /// </summary>
+        public static class Ada
         {
-            return this.scintilla.DirectMessage(NativeMethods.SCI_STYLEGETWEIGHT, new IntPtr(Index), IntPtr.Zero).ToInt32();
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_ADA_DEFAULT;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_ADA_COMMENTLINE;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_ADA_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_ADA_WORD;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_ADA_STRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_ADA_CHARACTER;
+
+            /// <summary>
+            /// Delimiter style index.
+            /// </summary>
+            public const int Delimiter = NativeMethods.SCE_ADA_DELIMITER;
+
+            /// <summary>
+            /// Label style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_ADA_LABEL;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_ADA_IDENTIFIER;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_ADA_STRINGEOL;
+
+            /// <summary>
+            /// Unclosed character EOL style index.
+            /// </summary>
+            public const int CharacterEol = NativeMethods.SCE_ADA_CHARACTEREOL;
+
+            /// <summary>
+            /// Illegal identifier or keyword style index.
+            /// </summary>
+            public const int Illegal = NativeMethods.SCE_ADA_ILLEGAL;
         }
-        set
+
+        #endregion Ada
+
+        #region Asm
+
+        /// <summary>
+        /// Style constants for use with the Asm lexer.
+        /// </summary>
+        public static class Asm
         {
-            this.scintilla.DirectMessage(NativeMethods.SCI_STYLESETWEIGHT, new IntPtr(Index), new IntPtr(value));
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_ASM_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_ASM_COMMENT;
+
+            /// <summary>
+            /// Comment block style index.
+            /// </summary>
+            public const int CommentBlock = NativeMethods.SCE_ASM_COMMENTBLOCK;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_ASM_NUMBER;
+
+            /// <summary>
+            /// Math instruction (keword list 1) style index.
+            /// </summary>
+            public const int MathInstruction = NativeMethods.SCE_ASM_MATHINSTRUCTION;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_ASM_STRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_ASM_CHARACTER;
+
+            /// <summary>
+            /// CPU instruction (keyword list 0) style index.
+            /// </summary>
+            public const int CpuInstruction = NativeMethods.SCE_ASM_CPUINSTRUCTION;
+
+            /// <summary>
+            /// Register (keyword list 2) style index.
+            /// </summary>
+            public const int Register = NativeMethods.SCE_ASM_REGISTER;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_ASM_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_ASM_IDENTIFIER;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_ASM_STRINGEOL;
+
+            /// <summary>
+            /// Directive (keyword list 3) string style index.
+            /// </summary>
+            public const int Directive = NativeMethods.SCE_ASM_DIRECTIVE;
+
+            /// <summary>
+            /// Directive operand (keyword list 4) style index.
+            /// </summary>
+            public const int DirectiveOperand = NativeMethods.SCE_ASM_DIRECTIVEOPERAND;
+
+            /// <summary>
+            /// Extended instruction (keyword list 5) style index.
+            /// </summary>
+            public const int ExtInstruction = NativeMethods.SCE_ASM_EXTINSTRUCTION;
+
+            /// <summary>
+            /// Comment directive style index.
+            /// </summary>
+            public const int CommentDirective = NativeMethods.SCE_ASM_COMMENTDIRECTIVE;
         }
+
+        #endregion Asm
+
+        #region BlitzBasic
+
+        /// <summary>
+        /// Style constants for use with the BlitzBasic lexer.
+        /// </summary>
+        public static class BlitzBasic
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_B_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_B_COMMENT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_B_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_B_KEYWORD;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_B_STRING;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_B_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
+
+            /// <summary>
+            /// Date style index.
+            /// </summary>
+            public const int Date = NativeMethods.SCE_B_DATE;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
+
+            /// <summary>
+            /// Keyword list 2 (index 1) style index.
+            /// </summary>
+            public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
+
+            /// <summary>
+            /// Keyword list 3 (index 2) style index.
+            /// </summary>
+            public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
+
+            /// <summary>
+            /// Keyword list 4 (index 3) style index.
+            /// </summary>
+            public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
+
+            /// <summary>
+            /// Constant style index.
+            /// </summary>
+            public const int Constant = NativeMethods.SCE_B_CONSTANT;
+
+            /// <summary>
+            /// Inline assembler style index.
+            /// </summary>
+            public const int Asm = NativeMethods.SCE_B_ASM;
+
+            /// <summary>
+            /// Label style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_B_LABEL;
+
+            /// <summary>
+            /// Error style index.
+            /// </summary>
+            public const int Error = NativeMethods.SCE_B_ERROR;
+
+            /// <summary>
+            /// Hexadecimal number style index.
+            /// </summary>
+            public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
+
+            /// <summary>
+            /// Binary number style index.
+            /// </summary>
+            public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
+
+            /// <summary>
+            /// Block comment style index.
+            /// </summary>
+            public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
+
+            /// <summary>
+            /// Documentation line style index.
+            /// </summary>
+            public const int DocLine = NativeMethods.SCE_B_DOCLINE;
+
+            /// <summary>
+            /// Documentation block style index.
+            /// </summary>
+            public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
+
+            /// <summary>
+            /// Documentation keyword style index.
+            /// </summary>
+            public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
+        }
+
+        #endregion BlitzBasic
+
+        #region Batch
+
+        /// <summary>
+        /// Style constants for use with the Batch lexer.
+        /// </summary>
+        public static class Batch
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_BAT_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_BAT_COMMENT;
+
+            /// <summary>
+            /// Keyword (list 0) style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_BAT_WORD;
+
+            /// <summary>
+            /// Label style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_BAT_LABEL;
+
+            /// <summary>
+            /// Hide (@ECHO OFF/ON) style index.
+            /// </summary>
+            public const int Hide = NativeMethods.SCE_BAT_HIDE;
+
+            /// <summary>
+            /// External command (keyword list 1) style index.
+            /// </summary>
+            public const int Command = NativeMethods.SCE_BAT_COMMAND;
+
+            /// <summary>
+            /// Identifier string style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_BAT_IDENTIFIER;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_BAT_OPERATOR;
+        }
+
+        #endregion Batch
+
+        #region Clw
+
+        /// <summary>
+        /// Style constants for use with the Clw lexer.
+        /// </summary>
+        public static class CLW
+        {
+            /// <summary>
+            /// Attributes style index
+            /// </summary>
+            public const int Attributes = NativeMethods.SCE_CLW_ATTRIBUTE;
+
+            /// <summary>
+            /// Built in procedures function style index.
+            /// </summary>
+            public const int BuiltInProceduresFunction = NativeMethods.SCE_CLW_BUILTIN_PROCEDURES_FUNCTION;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_CLW_COMMENT;
+
+            /// <summary>
+            /// Compiler directive style index
+            /// </summary>
+            public const int CompilerDirective = NativeMethods.SCE_CLW_COMPILER_DIRECTIVE;
+
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_CLW_DEFAULT;
+
+            /// <summary>
+            /// Depreciated style index
+            /// </summary>
+            public const int Depreciated = NativeMethods.SCE_CLW_DEPRECATED;
+
+            /// <summary>
+            /// Error style index
+            /// </summary>
+            public const int Error = NativeMethods.SCE_CLW_ERROR;
+
+            /// <summary>
+            /// Integer Constant style index.
+            /// </summary>
+            public const int IntegerConstant = NativeMethods.SCE_CLW_INTEGER_CONSTANT;
+
+            /// <summary>
+            /// Keyword style index
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_CLW_KEYWORD;
+
+            /// <summary>
+            /// Label string style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_CLW_LABEL;
+
+            /// <summary>
+            /// Real Constant style index.
+            /// </summary>
+            public const int PictureString = NativeMethods.SCE_CLW_PICTURE_STRING;
+
+            /// <summary>
+            /// Real Constant style index.
+            /// </summary>
+            public const int RealConstant = NativeMethods.SCE_CLW_REAL_CONSTANT;
+
+            /// <summary>
+            /// Runtime expressions style index
+            /// </summary>
+            public const int RuntimeExpressions = NativeMethods.SCE_CLW_RUNTIME_EXPRESSIONS;
+
+            /// <summary>
+            /// Standard equates style index
+            /// </summary>
+            public const int StandardEquates = NativeMethods.SCE_CLW_STANDARD_EQUATE;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_CLW_STRING;
+
+            /// <summary>
+            /// Structure data type style index.
+            /// </summary>
+            public const int StructureDataTypes = NativeMethods.SCE_CLW_STRUCTURE_DATA_TYPE;
+
+            /// <summary>
+            /// User Identifier style index.
+            /// </summary>
+            public const int UserIdentifier = NativeMethods.SCE_CLW_USER_IDENTIFIER;
+        }
+
+        #endregion Clw
+
+        #region Cpp
+
+        /// <summary>
+        /// Style constants for use with the Cpp lexer.
+        /// </summary>
+        public static class Cpp
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_C_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_C_COMMENT;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_C_COMMENTLINE;
+
+            /// <summary>
+            /// Documentation comment style index.
+            /// </summary>
+            public const int CommentDoc = NativeMethods.SCE_C_COMMENTDOC;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_C_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_C_WORD;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_C_STRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_C_CHARACTER;
+
+            /// <summary>
+            /// UUID style index.
+            /// </summary>
+            public const int Uuid = NativeMethods.SCE_C_UUID;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_C_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_C_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_C_IDENTIFIER;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_C_STRINGEOL;
+
+            /// <summary>
+            /// Verbatim string style index.
+            /// </summary>
+            public const int Verbatim = NativeMethods.SCE_C_VERBATIM;
+
+            /// <summary>
+            /// Regular expression style index.
+            /// </summary>
+            public const int Regex = NativeMethods.SCE_C_REGEX;
+
+            /// <summary>
+            /// Documentation comment line style index.
+            /// </summary>
+            public const int CommentLineDoc = NativeMethods.SCE_C_COMMENTLINEDOC;
+
+            /// <summary>
+            /// Keyword style 2 index.
+            /// </summary>
+            public const int Word2 = NativeMethods.SCE_C_WORD2;
+
+            /// <summary>
+            /// Comment keyword style index.
+            /// </summary>
+            public const int CommentDocKeyword = NativeMethods.SCE_C_COMMENTDOCKEYWORD;
+
+            /// <summary>
+            /// Comment keyword error style index.
+            /// </summary>
+            public const int CommentDocKeywordError = NativeMethods.SCE_C_COMMENTDOCKEYWORDERROR;
+
+            /// <summary>
+            /// Global class style index.
+            /// </summary>
+            public const int GlobalClass = NativeMethods.SCE_C_GLOBALCLASS;
+
+            /// <summary>
+            /// Raw string style index.
+            /// </summary>
+            public const int StringRaw = NativeMethods.SCE_C_STRINGRAW;
+
+            /// <summary>
+            /// Triple-quoted string style index.
+            /// </summary>
+            public const int TripleVerbatim = NativeMethods.SCE_C_TRIPLEVERBATIM;
+
+            /// <summary>
+            /// Hash-quoted string style index.
+            /// </summary>
+            public const int HashQuotedString = NativeMethods.SCE_C_HASHQUOTEDSTRING;
+
+            /// <summary>
+            /// Preprocessor comment style index.
+            /// </summary>
+            public const int PreprocessorComment = NativeMethods.SCE_C_PREPROCESSORCOMMENT;
+
+            /// <summary>
+            /// Preprocessor documentation comment style index.
+            /// </summary>
+            public const int PreprocessorCommentDoc = NativeMethods.SCE_C_PREPROCESSORCOMMENTDOC;
+
+            /// <summary>
+            /// User-defined literal style index.
+            /// </summary>
+            public const int UserLiteral = NativeMethods.SCE_C_USERLITERAL;
+
+            /// <summary>
+            /// Task marker style index.
+            /// </summary>
+            public const int TaskMarker = NativeMethods.SCE_C_TASKMARKER;
+
+            /// <summary>
+            /// Escape sequence style index.
+            /// </summary>
+            public const int EscapeSequence = NativeMethods.SCE_C_ESCAPESEQUENCE;
+        }
+
+        #endregion Cpp
+
+        #region Css
+
+        /// <summary>
+        /// Style constants for use with the Css lexer.
+        /// </summary>
+        public static class Css
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_CSS_DEFAULT;
+
+            /// <summary>
+            /// Tag style index.
+            /// </summary>
+            public const int Tag = NativeMethods.SCE_CSS_TAG;
+
+            /// <summary>
+            /// Class style index.
+            /// </summary>
+            public const int Class = NativeMethods.SCE_CSS_CLASS;
+
+            /// <summary>
+            /// Pseudo class style index.
+            /// </summary>
+            public const int PseudoClass = NativeMethods.SCE_CSS_PSEUDOCLASS;
+
+            /// <summary>
+            /// Unknown pseudo class style index.
+            /// </summary>
+            public const int UnknownPseudoClass = NativeMethods.SCE_CSS_UNKNOWN_PSEUDOCLASS;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_CSS_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_CSS_IDENTIFIER;
+
+            /// <summary>
+            /// Unknown identifier style index.
+            /// </summary>
+            public const int UnknownIdentifier = NativeMethods.SCE_CSS_UNKNOWN_IDENTIFIER;
+
+            /// <summary>
+            /// Value style index.
+            /// </summary>
+            public const int Value = NativeMethods.SCE_CSS_VALUE;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_CSS_COMMENT;
+
+            /// <summary>
+            /// ID style index.
+            /// </summary>
+            public const int Id = NativeMethods.SCE_CSS_ID;
+
+            /// <summary>
+            /// Important style index.
+            /// </summary>
+            public const int Important = NativeMethods.SCE_CSS_IMPORTANT;
+
+            /// <summary>
+            /// Directive style index.
+            /// </summary>
+            public const int Directive = NativeMethods.SCE_CSS_DIRECTIVE;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int DoubleString = NativeMethods.SCE_CSS_DOUBLESTRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int SingleString = NativeMethods.SCE_CSS_SINGLESTRING;
+
+            /// <summary>
+            /// Identifier style 2 index.
+            /// </summary>
+            public const int Identifier2 = NativeMethods.SCE_CSS_IDENTIFIER2;
+
+            /// <summary>
+            /// Attribute style index.
+            /// </summary>
+            public const int Attribute = NativeMethods.SCE_CSS_ATTRIBUTE;
+
+            /// <summary>
+            /// Identifier style 3 index.
+            /// </summary>
+            public const int Identifier3 = NativeMethods.SCE_CSS_IDENTIFIER3;
+
+            /// <summary>
+            /// Pseudo element style index.
+            /// </summary>
+            public const int PseudoElement = NativeMethods.SCE_CSS_PSEUDOELEMENT;
+
+            /// <summary>
+            /// Extended identifier style index.
+            /// </summary>
+            public const int ExtendedIdentifier = NativeMethods.SCE_CSS_EXTENDED_IDENTIFIER;
+
+            /// <summary>
+            /// Extended pseudo class style index.
+            /// </summary>
+            public const int ExtendedPseudoClass = NativeMethods.SCE_CSS_EXTENDED_PSEUDOCLASS;
+
+            /// <summary>
+            /// Extended pseudo element style index.
+            /// </summary>
+            public const int ExtendedPseudoElement = NativeMethods.SCE_CSS_EXTENDED_PSEUDOELEMENT;
+
+            /// <summary>
+            /// Media style index.
+            /// </summary>
+            public const int Media = NativeMethods.SCE_CSS_MEDIA;
+
+            /// <summary>
+            /// Variable style index.
+            /// </summary>
+            public const int Variable = NativeMethods.SCE_CSS_VARIABLE;
+        }
+
+        #endregion Css
+
+        #region Fortran
+
+        /// <summary>
+        /// Style constants for use with the Fortran lexer.
+        /// </summary>
+        public static class Fortran
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_F_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_F_COMMENT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_F_NUMBER;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int String1 = NativeMethods.SCE_F_STRING1;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String2 = NativeMethods.SCE_F_STRING2;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_F_STRINGEOL;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_F_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_F_IDENTIFIER;
+
+            /// <summary>
+            /// Keyword (list 0) style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_F_WORD;
+
+            /// <summary>
+            /// Keyword 2 (list 1) style index.
+            /// </summary>
+            public const int Word2 = NativeMethods.SCE_F_WORD2;
+
+            /// <summary>
+            /// Keyword 3 (list 2) style index.
+            /// </summary>
+            public const int Word3 = NativeMethods.SCE_F_WORD3;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_F_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator 2 style index.
+            /// </summary>
+            public const int Operator2 = NativeMethods.SCE_F_OPERATOR2;
+
+            /// <summary>
+            /// Label string style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_F_LABEL;
+
+            /// <summary>
+            /// Continuation style index.
+            /// </summary>
+            public const int Continuation = NativeMethods.SCE_F_CONTINUATION;
+        }
+
+        #endregion Fortran
+
+        #region FreeBasic
+
+        /// <summary>
+        /// Style constants for use with the FreeBasic lexer.
+        /// </summary>
+        public static class FreeBasic
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_B_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_B_COMMENT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_B_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_B_KEYWORD;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_B_STRING;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_B_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
+
+            /// <summary>
+            /// Date style index.
+            /// </summary>
+            public const int Date = NativeMethods.SCE_B_DATE;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
+
+            /// <summary>
+            /// Keyword list 2 (index 1) style index.
+            /// </summary>
+            public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
+
+            /// <summary>
+            /// Keyword list 3 (index 2) style index.
+            /// </summary>
+            public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
+
+            /// <summary>
+            /// Keyword list 4 (index 3) style index.
+            /// </summary>
+            public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
+
+            /// <summary>
+            /// Constant style index.
+            /// </summary>
+            public const int Constant = NativeMethods.SCE_B_CONSTANT;
+
+            /// <summary>
+            /// Inline assembler style index.
+            /// </summary>
+            public const int Asm = NativeMethods.SCE_B_ASM;
+
+            /// <summary>
+            /// Label style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_B_LABEL;
+
+            /// <summary>
+            /// Error style index.
+            /// </summary>
+            public const int Error = NativeMethods.SCE_B_ERROR;
+
+            /// <summary>
+            /// Hexadecimal number style index.
+            /// </summary>
+            public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
+
+            /// <summary>
+            /// Binary number style index.
+            /// </summary>
+            public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
+
+            /// <summary>
+            /// Block comment style index.
+            /// </summary>
+            public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
+
+            /// <summary>
+            /// Documentation line style index.
+            /// </summary>
+            public const int DocLine = NativeMethods.SCE_B_DOCLINE;
+
+            /// <summary>
+            /// Documentation block style index.
+            /// </summary>
+            public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
+
+            /// <summary>
+            /// Documentation keyword style index.
+            /// </summary>
+            public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
+        }
+
+        #endregion FreeBasic
+
+        #region Html
+
+        /// <summary>
+        /// Style constants for use with the Html lexer.
+        /// </summary>
+        public static class Html
+        {
+            /// <summary>
+            /// Content style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_H_DEFAULT;
+
+            /// <summary>
+            /// Tag style index.
+            /// </summary>
+            public const int Tag = NativeMethods.SCE_H_TAG;
+
+            /// <summary>
+            /// Unknown tag style index.
+            /// </summary>
+            public const int TagUnknown = NativeMethods.SCE_H_TAGUNKNOWN;
+
+            /// <summary>
+            /// Attribute style index.
+            /// </summary>
+            public const int Attribute = NativeMethods.SCE_H_ATTRIBUTE;
+
+            /// <summary>
+            /// Unknown attribute style index.
+            /// </summary>
+            public const int AttributeUnknown = NativeMethods.SCE_H_ATTRIBUTEUNKNOWN;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_H_NUMBER;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int DoubleString = NativeMethods.SCE_H_DOUBLESTRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int SingleString = NativeMethods.SCE_H_SINGLESTRING;
+
+            /// <summary>
+            /// Other tag content (not elements or attributes) style index.
+            /// </summary>
+            public const int Other = NativeMethods.SCE_H_OTHER;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_H_COMMENT;
+
+            /// <summary>
+            /// Entity ($nnn;) name style index.
+            /// </summary>
+            public const int Entity = NativeMethods.SCE_H_ENTITY;
+
+            /// <summary>
+            /// End-tag style index.
+            /// </summary>
+            public const int TagEnd = NativeMethods.SCE_H_TAGEND;
+
+            /// <summary>
+            /// Start of XML declaration (&lt;?xml&gt;) style index.
+            /// </summary>
+            public const int XmlStart = NativeMethods.SCE_H_XMLSTART;
+
+            /// <summary>
+            /// End of XML declaration (?&gt;) style index.
+            /// </summary>
+            public const int XmlEnd = NativeMethods.SCE_H_XMLEND;
+
+            /// <summary>
+            /// Script tag (&lt;script&gt;) style index.
+            /// </summary>
+            public const int Script = NativeMethods.SCE_H_SCRIPT;
+
+            /// <summary>
+            /// ASP-like script engine block (&lt;%) style index.
+            /// </summary>
+            public const int Asp = NativeMethods.SCE_H_ASP;
+
+            /// <summary>
+            /// ASP-like language declaration (&lt;%@) style index.
+            /// </summary>
+            public const int AspAt = NativeMethods.SCE_H_ASPAT;
+
+            /// <summary>
+            /// CDATA section style index.
+            /// </summary>
+            public const int CData = NativeMethods.SCE_H_CDATA;
+
+            /// <summary>
+            /// Question mark style index.
+            /// </summary>
+            public const int Question = NativeMethods.SCE_H_QUESTION;
+
+            /// <summary>
+            /// Value style index.
+            /// </summary>
+            public const int Value = NativeMethods.SCE_H_VALUE;
+
+            /// <summary>
+            /// Script engine comment (&lt;%--) style index.
+            /// </summary>
+            public const int XcComment = NativeMethods.SCE_H_XCCOMMENT;
+        }
+
+        #endregion Html
+
+        #region JavaScript
+
+        /// <summary>
+        /// Embedded JavaScript style constants for use with the JavaScript lexer.
+        /// </summary>
+        public static class JavaScript
+        {
+            /// <summary>
+            /// Start style index (allows EOL filled background to not start on same line as SCRIPT tag).
+            /// </summary>
+            public const int Start = NativeMethods.SCE_HJ_START;
+
+            /// <summary>
+            /// Default style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_HJ_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_HJ_COMMENT;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_HJ_COMMENTLINE;
+
+            /// <summary>
+            /// Doc comment style index.
+            /// </summary>
+            public const int CommentDoc = NativeMethods.SCE_HJ_COMMENTDOC;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_HJ_NUMBER;
+
+            /// <summary>
+            /// Word style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_HJ_WORD;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_HJ_KEYWORD;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int DoubleString = NativeMethods.SCE_HJ_DOUBLESTRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int SingleString = NativeMethods.SCE_HJ_SINGLESTRING;
+
+            /// <summary>
+            /// Symbols style index.
+            /// </summary>
+            public const int Symbols = NativeMethods.SCE_HJ_SYMBOLS;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_HJ_STRINGEOL;
+
+            /// <summary>
+            /// Regular expression style index.
+            /// </summary>
+            public const int Regex = NativeMethods.SCE_HJ_REGEX;
+        }
+
+        #endregion JavaScript
+
+        #region Json
+
+        /// <summary>
+        /// Style constants for use with the Json lexer.
+        /// </summary>
+        public static class Json
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_JSON_DEFAULT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_JSON_NUMBER;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_JSON_STRING;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_JSON_STRINGEOL;
+
+            /// <summary>
+            /// Property name style index.
+            /// </summary>
+            public const int PropertyName = NativeMethods.SCE_JSON_PROPERTYNAME;
+
+            /// <summary>
+            /// Escape sequence style index.
+            /// </summary>
+            public const int EscapeSequence = NativeMethods.SCE_JSON_ESCAPESEQUENCE;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int LineComment = NativeMethods.SCE_JSON_LINECOMMENT;
+
+            /// <summary>
+            /// Block comment style index.
+            /// </summary>
+            public const int BlockComment = NativeMethods.SCE_JSON_BLOCKCOMMENT;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_JSON_OPERATOR;
+
+            /// <summary>
+            /// URI style index.
+            /// </summary>
+            public const int Uri = NativeMethods.SCE_JSON_URI;
+
+            /// <summary>
+            /// Compact Internationalized Resource Identifier (IRI) style index.
+            /// </summary>
+            public const int CompactIRI = NativeMethods.SCE_JSON_COMPACTIRI;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_JSON_KEYWORD;
+
+            /// <summary>
+            /// Linked data (LD) keyword style index.
+            /// </summary>
+            public const int LdKeyword = NativeMethods.SCE_JSON_LDKEYWORD;
+
+            /// <summary>
+            /// Error style index.
+            /// </summary>
+            public const int Error = NativeMethods.SCE_JSON_ERROR;
+        }
+
+        #endregion Json
+
+        #region Lisp
+
+        /// <summary>
+        /// Style constants for use with the Lisp lexer.
+        /// </summary>
+        public static class Lisp
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_LISP_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_LISP_COMMENT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_LISP_NUMBER;
+
+            /// <summary>
+            /// Functions and special operators (list 0) style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_LISP_KEYWORD;
+
+            /// <summary>
+            /// Keywords (list 1) style index.
+            /// </summary>
+            public const int KeywordKw = NativeMethods.SCE_LISP_KEYWORD_KW;
+
+            /// <summary>
+            /// Symbol style index.
+            /// </summary>
+            public const int Symbol = NativeMethods.SCE_LISP_SYMBOL;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_LISP_STRING;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_LISP_STRINGEOL;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_LISP_IDENTIFIER;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_LISP_OPERATOR;
+
+            /// <summary>
+            /// Special character style index.
+            /// </summary>
+            public const int Special = NativeMethods.SCE_LISP_SPECIAL;
+
+            /// <summary>
+            /// Multi-line comment style index.
+            /// </summary>
+            public const int MultiComment = NativeMethods.SCE_LISP_MULTI_COMMENT;
+        }
+
+        #endregion Lisp
+
+        #region Lua
+
+        /// <summary>
+        /// Style constants for use with the Lua lexer.
+        /// </summary>
+        public static class Lua
+        {
+            /// <summary>
+            /// Default style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_LUA_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_LUA_COMMENT;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_LUA_COMMENTLINE;
+
+            /// <summary>
+            /// Documentation comment style index.
+            /// </summary>
+            public const int CommentDoc = NativeMethods.SCE_LUA_COMMENTDOC;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_LUA_NUMBER;
+
+            /// <summary>
+            /// Keyword list 1 (index 0) style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_LUA_WORD;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_LUA_STRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_LUA_CHARACTER;
+
+            /// <summary>
+            /// Literal string style index.
+            /// </summary>
+            public const int LiteralString = NativeMethods.SCE_LUA_LITERALSTRING;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_LUA_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_LUA_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_LUA_IDENTIFIER;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_LUA_STRINGEOL;
+
+            /// <summary>
+            /// Keywords list 2 (index 1) style index.
+            /// </summary>
+            public const int Word2 = NativeMethods.SCE_LUA_WORD2;
+
+            /// <summary>
+            /// Keywords list 3 (index 2) style index.
+            /// </summary>
+            public const int Word3 = NativeMethods.SCE_LUA_WORD3;
+
+            /// <summary>
+            /// Keywords list 4 (index 3) style index.
+            /// </summary>
+            public const int Word4 = NativeMethods.SCE_LUA_WORD4;
+
+            /// <summary>
+            /// Keywords list 5 (index 4) style index.
+            /// </summary>
+            public const int Word5 = NativeMethods.SCE_LUA_WORD5;
+
+            /// <summary>
+            /// Keywords list 6 (index 5) style index.
+            /// </summary>
+            public const int Word6 = NativeMethods.SCE_LUA_WORD6;
+
+            /// <summary>
+            /// Keywords list 7 (index 6) style index.
+            /// </summary>
+            public const int Word7 = NativeMethods.SCE_LUA_WORD7;
+
+            /// <summary>
+            /// Keywords list 8 (index 7) style index.
+            /// </summary>
+            public const int Word8 = NativeMethods.SCE_LUA_WORD8;
+
+            /// <summary>
+            /// Label style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_LUA_LABEL;
+        }
+
+        #endregion Lua
+
+        #region Matlab
+
+        /// <summary>
+        /// Style constants for use with the Matlab lexer.
+        /// </summary>
+        public static class Matlab
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_MATLAB_DEFAULT;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_MATLAB_COMMENT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_MATLAB_NUMBER;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_MATLAB_STRING;
+
+            /// <summary>
+            /// Command style index.
+            /// </summary>
+            public const int Command = NativeMethods.SCE_MATLAB_COMMAND;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_MATLAB_KEYWORD;
+
+            /// <summary>
+            /// Double quote string style index.
+            /// </summary>
+            public const int DoubleQuoteString = NativeMethods.SCE_MATLAB_DOUBLEQUOTESTRING;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_MATLAB_IDENTIFIER;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_MATLAB_OPERATOR;
+        }
+
+        #endregion Matlab
+
+        #region Pascal
+
+        /// <summary>
+        /// Style constants for use with the Pascal lexer.
+        /// </summary>
+        public static class Pascal
+        {
+            /// <summary>
+            /// Default style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_PAS_DEFAULT;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_PAS_IDENTIFIER;
+
+            /// <summary>
+            /// Comment style '{' index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_PAS_COMMENT;
+
+            /// <summary>
+            /// Comment style 2 "(*" index.
+            /// </summary>
+            public const int Comment2 = NativeMethods.SCE_PAS_COMMENT2;
+
+            /// <summary>
+            /// Comment line style "//" index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_PAS_COMMENTLINE;
+
+            /// <summary>
+            /// Preprocessor style "{$" index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_PAS_PREPROCESSOR;
+
+            /// <summary>
+            /// Preprocessor style 2 "(*$" index.
+            /// </summary>
+            public const int Preprocessor2 = NativeMethods.SCE_PAS_PREPROCESSOR2;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_PAS_NUMBER;
+
+            /// <summary>
+            /// Hexadecimal number style index.
+            /// </summary>
+            public const int HexNumber = NativeMethods.SCE_PAS_HEXNUMBER;
+
+            /// <summary>
+            /// Word (keyword set 0) style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_PAS_WORD;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_PAS_STRING;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_PAS_STRINGEOL;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_PAS_CHARACTER;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_PAS_OPERATOR;
+
+            /// <summary>
+            /// Assembly style index.
+            /// </summary>
+            public const int Asm = NativeMethods.SCE_PAS_ASM;
+        }
+
+        #endregion Pascal
+
+        #region Perl
+
+        /// <summary>
+        /// Style constants for use with the Perl lexer.
+        /// </summary>
+        public static class Perl
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_PL_DEFAULT;
+
+            /// <summary>
+            /// Error style index.
+            /// </summary>
+            public const int Error = NativeMethods.SCE_PL_ERROR;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_PL_COMMENTLINE;
+
+            /// <summary>
+            /// POD style index.
+            /// </summary>
+            public const int Pod = NativeMethods.SCE_PL_POD;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_PL_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_PL_WORD;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_PL_STRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_PL_CHARACTER;
+
+            /// <summary>
+            /// Punctuation style index.
+            /// </summary>
+            public const int Punctuation = NativeMethods.SCE_PL_PUNCTUATION;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_PL_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_PL_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_PL_IDENTIFIER;
+
+            /// <summary>
+            /// Scalar style index.
+            /// </summary>
+            public const int Scalar = NativeMethods.SCE_PL_SCALAR;
+
+            /// <summary>
+            /// Array style index.
+            /// </summary>
+            public const int Array = NativeMethods.SCE_PL_ARRAY;
+
+            /// <summary>
+            /// Hash style index.
+            /// </summary>
+            public const int Hash = NativeMethods.SCE_PL_HASH;
+
+            /// <summary>
+            /// Symbol table style index.
+            /// </summary>
+            public const int SymbolTable = NativeMethods.SCE_PL_SYMBOLTABLE;
+
+            /// <summary>
+            /// Variable indexer index.
+            /// </summary>
+            public const int VariableIndexer = NativeMethods.SCE_PL_VARIABLE_INDEXER;
+
+            /// <summary>
+            /// Regular expression style index.
+            /// </summary>
+            public const int Regex = NativeMethods.SCE_PL_REGEX;
+
+            /// <summary>
+            /// RegSubst style index.
+            /// </summary>
+            public const int RegSubst = NativeMethods.SCE_PL_REGSUBST;
+
+            // public const int LongQuote = NativeMethods.SCE_PL_LONGQUOTE;
+
+            /// <summary>
+            /// Backtick (grave accent, backquote) style index.
+            /// </summary>
+            public const int BackTicks = NativeMethods.SCE_PL_BACKTICKS;
+
+            /// <summary>
+            /// Data section style index.
+            /// </summary>
+            public const int DataSection = NativeMethods.SCE_PL_DATASECTION;
+
+            /// <summary>
+            /// HereDoc delimiter style index.
+            /// </summary>
+            public const int HereDelim = NativeMethods.SCE_PL_HERE_DELIM;
+
+            /// <summary>
+            /// HereDoc single-quote style index.
+            /// </summary>
+            public const int HereQ = NativeMethods.SCE_PL_HERE_Q;
+
+            /// <summary>
+            /// HereDoc double-quote style index.
+            /// </summary>
+            public const int HereQq = NativeMethods.SCE_PL_HERE_QQ;
+
+            /// <summary>
+            /// HereDoc backtick style index.
+            /// </summary>
+            public const int HereQx = NativeMethods.SCE_PL_HERE_QX;
+
+            /// <summary>
+            /// Q quote style index.
+            /// </summary>
+            public const int StringQ = NativeMethods.SCE_PL_STRING_Q;
+
+            /// <summary>
+            /// QQ quote style index.
+            /// </summary>
+            public const int StringQq = NativeMethods.SCE_PL_STRING_QQ;
+
+            /// <summary>
+            /// QZ quote style index.
+            /// </summary>
+            public const int StringQx = NativeMethods.SCE_PL_STRING_QX;
+
+            /// <summary>
+            /// QR quote style index.
+            /// </summary>
+            public const int StringQr = NativeMethods.SCE_PL_STRING_QR;
+
+            /// <summary>
+            /// QW quote style index.
+            /// </summary>
+            public const int StringQw = NativeMethods.SCE_PL_STRING_QW;
+
+            /// <summary>
+            /// POD verbatim style index.
+            /// </summary>
+            public const int PodVerb = NativeMethods.SCE_PL_POD_VERB;
+
+            /// <summary>
+            /// Subroutine prototype style index.
+            /// </summary>
+            public const int SubPrototype = NativeMethods.SCE_PL_SUB_PROTOTYPE;
+
+            /// <summary>
+            /// Format identifier style index.
+            /// </summary>
+            public const int FormatIdent = NativeMethods.SCE_PL_FORMAT_IDENT;
+
+            /// <summary>
+            /// Format style index.
+            /// </summary>
+            public const int Format = NativeMethods.SCE_PL_FORMAT;
+
+            /// <summary>
+            /// String variable style index.
+            /// </summary>
+            public const int StringVar = NativeMethods.SCE_PL_STRING_VAR;
+
+            /// <summary>
+            /// XLAT style index.
+            /// </summary>
+            public const int XLat = NativeMethods.SCE_PL_XLAT;
+
+            /// <summary>
+            /// Regular expression variable style index.
+            /// </summary>
+            public const int RegexVar = NativeMethods.SCE_PL_REGEX_VAR;
+
+            /// <summary>
+            /// RegSubst variable style index.
+            /// </summary>
+            public const int RegSubstVar = NativeMethods.SCE_PL_REGSUBST_VAR;
+
+            /// <summary>
+            /// Backticks variable style index.
+            /// </summary>
+            public const int BackticksVar = NativeMethods.SCE_PL_BACKTICKS_VAR;
+
+            /// <summary>
+            /// HereDoc QQ quote variable style index.
+            /// </summary>
+            public const int HereQqVar = NativeMethods.SCE_PL_HERE_QQ_VAR;
+
+            /// <summary>
+            /// HereDoc QX quote variable style index.
+            /// </summary>
+            public const int HereQxVar = NativeMethods.SCE_PL_HERE_QX_VAR;
+
+            /// <summary>
+            /// QQ quote variable style index.
+            /// </summary>
+            public const int StringQqVar = NativeMethods.SCE_PL_STRING_QQ_VAR;
+
+            /// <summary>
+            /// QX quote variable style index.
+            /// </summary>
+            public const int StringQxVar = NativeMethods.SCE_PL_STRING_QX_VAR;
+
+            /// <summary>
+            /// QR quote variable style index.
+            /// </summary>
+            public const int StringQrVar = NativeMethods.SCE_PL_STRING_QR_VAR;
+        }
+
+        #endregion Perl
+
+        #region PhpScript
+
+        /// <summary>
+        /// Style constants for use with the PhpScript lexer.
+        /// </summary>
+        public static class PhpScript
+        {
+            /// <summary>
+            /// Complex Variable style index.
+            /// </summary>
+            public const int ComplexVariable = NativeMethods.SCE_HPHP_COMPLEX_VARIABLE;
+
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_HPHP_DEFAULT;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int HString = NativeMethods.SCE_HPHP_HSTRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int SimpleString = NativeMethods.SCE_HPHP_SIMPLESTRING;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_HPHP_WORD;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_HPHP_NUMBER;
+
+            /// <summary>
+            /// Variable style index.
+            /// </summary>
+            public const int Variable = NativeMethods.SCE_HPHP_VARIABLE;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_HPHP_COMMENT;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_HPHP_COMMENTLINE;
+
+            /// <summary>
+            /// Double-quoted string variable style index.
+            /// </summary>
+            public const int HStringVariable = NativeMethods.SCE_HPHP_HSTRING_VARIABLE;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_HPHP_OPERATOR;
+        }
+
+        #endregion PhpScript
+
+        #region PowerShell
+
+        /// <summary>
+        /// Style constants for use with the PowerShell lexer.
+        /// </summary>
+        public static class PowerShell
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_POWERSHELL_DEFAULT;
+
+            /// <summary>
+            /// Line comment style index
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_POWERSHELL_COMMENT;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_POWERSHELL_STRING;
+
+            /// <summary>
+            /// Character style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_POWERSHELL_CHARACTER;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_POWERSHELL_NUMBER;
+
+            /// <summary>
+            /// Variable style index.
+            /// </summary>
+            public const int Variable = NativeMethods.SCE_POWERSHELL_VARIABLE;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_POWERSHELL_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_POWERSHELL_IDENTIFIER;
+
+            /// <summary>
+            /// Keyword (set 0) style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_POWERSHELL_KEYWORD;
+
+            /// <summary>
+            /// Cmdlet (set 1) style index.
+            /// </summary>
+            public const int Cmdlet = NativeMethods.SCE_POWERSHELL_CMDLET;
+
+            /// <summary>
+            /// Alias (set 2) style index.
+            /// </summary>
+            public const int Alias = NativeMethods.SCE_POWERSHELL_ALIAS;
+
+            /// <summary>
+            /// Function (set 3) style index.
+            /// </summary>
+            public const int Function = NativeMethods.SCE_POWERSHELL_FUNCTION;
+
+            /// <summary>
+            /// User word (set 4) style index.
+            /// </summary>
+            public const int User1 = NativeMethods.SCE_POWERSHELL_USER1;
+
+            /// <summary>
+            /// Multi-line comment style index.
+            /// </summary>
+            public const int CommentStream = NativeMethods.SCE_POWERSHELL_COMMENTSTREAM;
+
+            /// <summary>
+            /// Here string style index.
+            /// </summary>
+            public const int HereString = NativeMethods.SCE_POWERSHELL_HERE_STRING;
+
+            /// <summary>
+            /// Here character style index.
+            /// </summary>
+            public const int HereCharacter = NativeMethods.SCE_POWERSHELL_HERE_CHARACTER;
+
+            /// <summary>
+            /// Comment based help keyword style index.
+            /// </summary>
+            public const int CommentDocKeyword = NativeMethods.SCE_POWERSHELL_COMMENTDOCKEYWORD;
+        }
+
+        #endregion PowerShell
+
+        #region Properties
+
+        /// <summary>
+        /// Style constants for use with the Properties lexer.
+        /// </summary>
+        public static class Properties
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_PROPS_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_PROPS_COMMENT;
+
+            /// <summary>
+            /// Section style index.
+            /// </summary>
+            public const int Section = NativeMethods.SCE_PROPS_SECTION;
+
+            /// <summary>
+            /// Assignment operator index.
+            /// </summary>
+            public const int Assignment = NativeMethods.SCE_PROPS_ASSIGNMENT;
+
+            /// <summary>
+            /// Default (registry-only) value index.
+            /// </summary>
+            public const int DefVal = NativeMethods.SCE_PROPS_DEFVAL;
+
+            /// <summary>
+            /// Key style index.
+            /// </summary>
+            public const int Key = NativeMethods.SCE_PROPS_KEY;
+        }
+
+        #endregion Properties
+
+        #region PureBasic
+
+        /// <summary>
+        /// Style constants for use with the PureBasic lexer.
+        /// </summary>
+        public static class PureBasic
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_B_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_B_COMMENT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_B_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_B_KEYWORD;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_B_STRING;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_B_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
+
+            /// <summary>
+            /// Date style index.
+            /// </summary>
+            public const int Date = NativeMethods.SCE_B_DATE;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
+
+            /// <summary>
+            /// Keyword list 2 (index 1) style index.
+            /// </summary>
+            public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
+
+            /// <summary>
+            /// Keyword list 3 (index 2) style index.
+            /// </summary>
+            public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
+
+            /// <summary>
+            /// Keyword list 4 (index 3) style index.
+            /// </summary>
+            public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
+
+            /// <summary>
+            /// Constant style index.
+            /// </summary>
+            public const int Constant = NativeMethods.SCE_B_CONSTANT;
+
+            /// <summary>
+            /// Inline assembler style index.
+            /// </summary>
+            public const int Asm = NativeMethods.SCE_B_ASM;
+
+            /// <summary>
+            /// Label style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_B_LABEL;
+
+            /// <summary>
+            /// Error style index.
+            /// </summary>
+            public const int Error = NativeMethods.SCE_B_ERROR;
+
+            /// <summary>
+            /// Hexadecimal number style index.
+            /// </summary>
+            public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
+
+            /// <summary>
+            /// Binary number style index.
+            /// </summary>
+            public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
+
+            /// <summary>
+            /// Block comment style index.
+            /// </summary>
+            public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
+
+            /// <summary>
+            /// Documentation line style index.
+            /// </summary>
+            public const int DocLine = NativeMethods.SCE_B_DOCLINE;
+
+            /// <summary>
+            /// Documentation block style index.
+            /// </summary>
+            public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
+
+            /// <summary>
+            /// Documentation keyword style index.
+            /// </summary>
+            public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
+        }
+
+        #endregion PureBasic
+
+        #region Python
+
+        /// <summary>
+        /// Style constants for use with the Python lexer.
+        /// </summary>
+        public static class Python
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_P_DEFAULT;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_P_COMMENTLINE;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_P_NUMBER;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_P_STRING;
+
+            /// <summary>
+            /// Single-quote style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_P_CHARACTER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_P_WORD;
+
+            /// <summary>
+            /// Triple single-quote style index.
+            /// </summary>
+            public const int Triple = NativeMethods.SCE_P_TRIPLE;
+
+            /// <summary>
+            /// Triple double-quote style index.
+            /// </summary>
+            public const int TripleDouble = NativeMethods.SCE_P_TRIPLEDOUBLE;
+
+            /// <summary>
+            /// Class name style index.
+            /// </summary>
+            public const int ClassName = NativeMethods.SCE_P_CLASSNAME;
+
+            /// <summary>
+            /// Function or method name style index.
+            /// </summary>
+            public const int DefName = NativeMethods.SCE_P_DEFNAME;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_P_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_P_IDENTIFIER;
+
+            /// <summary>
+            /// Block comment style index.
+            /// </summary>
+            public const int CommentBlock = NativeMethods.SCE_P_COMMENTBLOCK;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_P_STRINGEOL;
+
+            /// <summary>
+            /// Keyword style 2 index.
+            /// </summary>
+            public const int Word2 = NativeMethods.SCE_P_WORD2;
+
+            /// <summary>
+            /// Decorator style index.
+            /// </summary>
+            public const int Decorator = NativeMethods.SCE_P_DECORATOR;
+        }
+
+        #endregion Python
+
+        #region Ruby
+
+        /// <summary>
+        /// Style constants for use with the Ruby lexer.
+        /// </summary>
+        public static class Ruby
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_RB_DEFAULT;
+
+            /// <summary>
+            /// Error style index.
+            /// </summary>
+            public const int Error = NativeMethods.SCE_RB_ERROR;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_RB_COMMENTLINE;
+
+            /// <summary>
+            /// POD style index.
+            /// </summary>
+            public const int Pod = NativeMethods.SCE_RB_POD;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_RB_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_RB_WORD;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_RB_STRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_RB_CHARACTER;
+
+            /// <summary>
+            /// Class name style index.
+            /// </summary>
+            public const int ClassName = NativeMethods.SCE_RB_CLASSNAME;
+
+            /// <summary>
+            /// Definition style index.
+            /// </summary>
+            public const int DefName = NativeMethods.SCE_RB_DEFNAME;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_RB_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_RB_IDENTIFIER;
+
+            /// <summary>
+            /// Regular expression style index.
+            /// </summary>
+            public const int Regex = NativeMethods.SCE_RB_REGEX;
+
+            /// <summary>
+            /// Global style index.
+            /// </summary>
+            public const int Global = NativeMethods.SCE_RB_GLOBAL;
+
+            /// <summary>
+            /// Symbol style index.
+            /// </summary>
+            public const int Symbol = NativeMethods.SCE_RB_SYMBOL;
+
+            /// <summary>
+            /// Module name style index.
+            /// </summary>
+            public const int ModuleName = NativeMethods.SCE_RB_MODULE_NAME;
+
+            /// <summary>
+            /// Instance variable style index.
+            /// </summary>
+            public const int InstanceVar = NativeMethods.SCE_RB_INSTANCE_VAR;
+
+            /// <summary>
+            /// Class variable style index.
+            /// </summary>
+            public const int ClassVar = NativeMethods.SCE_RB_CLASS_VAR;
+
+            /// <summary>
+            /// Backticks style index.
+            /// </summary>
+            public const int BackTicks = NativeMethods.SCE_RB_BACKTICKS;
+
+            /// <summary>
+            /// Data section style index.
+            /// </summary>
+            public const int DataSection = NativeMethods.SCE_RB_DATASECTION;
+
+            /// <summary>
+            /// HereDoc delimiter style index.
+            /// </summary>
+            public const int HereDelim = NativeMethods.SCE_RB_HERE_DELIM;
+
+            /// <summary>
+            /// HereDoc Q quote style index.
+            /// </summary>
+            public const int HereQ = NativeMethods.SCE_RB_HERE_Q;
+
+            /// <summary>
+            /// HereDoc QQ quote style index.
+            /// </summary>
+            public const int HereQq = NativeMethods.SCE_RB_HERE_QQ;
+
+            /// <summary>
+            /// HereDoc QX quote style index.
+            /// </summary>
+            public const int HereQx = NativeMethods.SCE_RB_HERE_QX;
+
+            /// <summary>
+            /// Q quote string style index.
+            /// </summary>
+            public const int StringQ = NativeMethods.SCE_RB_STRING_Q;
+
+            /// <summary>
+            /// QQ quote string style index.
+            /// </summary>
+            public const int StringQq = NativeMethods.SCE_RB_STRING_QQ;
+
+            /// <summary>
+            /// QX quote string style index.
+            /// </summary>
+            public const int StringQx = NativeMethods.SCE_RB_STRING_QX;
+
+            /// <summary>
+            /// QR quote string style index.
+            /// </summary>
+            public const int StringQr = NativeMethods.SCE_RB_STRING_QR;
+
+            /// <summary>
+            /// QW quote style index.
+            /// </summary>
+            public const int StringQw = NativeMethods.SCE_RB_STRING_QW;
+
+            /// <summary>
+            /// Demoted keyword style index.
+            /// </summary>
+            public const int WordDemoted = NativeMethods.SCE_RB_WORD_DEMOTED;
+
+            /// <summary>
+            /// Standard-in style index.
+            /// </summary>
+            public const int StdIn = NativeMethods.SCE_RB_STDIN;
+
+            /// <summary>
+            /// Standard-out style index.
+            /// </summary>
+            public const int StdOut = NativeMethods.SCE_RB_STDOUT;
+
+            /// <summary>
+            /// Standard-error style index.
+            /// </summary>
+            public const int StdErr = NativeMethods.SCE_RB_STDERR;
+
+            // public const int UpperBound = NativeMethods.SCE_RB_UPPER_BOUND;
+        }
+
+        #endregion Ruby
+
+        #region Smalltalk
+
+        /// <summary>
+        /// Style constants for use with the Smalltalk lexer.
+        /// </summary>
+        public static class Smalltalk
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_ST_DEFAULT;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_ST_STRING;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_ST_NUMBER;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_ST_COMMENT;
+
+            /// <summary>
+            /// Symbol style index.
+            /// </summary>
+            public const int Symbol = NativeMethods.SCE_ST_SYMBOL;
+
+            /// <summary>
+            /// Binary style index.
+            /// </summary>
+            public const int Binary = NativeMethods.SCE_ST_BINARY;
+
+            /// <summary>
+            /// Bool style index.
+            /// </summary>
+            public const int Bool = NativeMethods.SCE_ST_BOOL;
+
+            /// <summary>
+            /// Self style index.
+            /// </summary>
+            public const int Self = NativeMethods.SCE_ST_SELF;
+
+            /// <summary>
+            /// Super style index.
+            /// </summary>
+            public const int Super = NativeMethods.SCE_ST_SUPER;
+
+            /// <summary>
+            /// NIL style index.
+            /// </summary>
+            public const int Nil = NativeMethods.SCE_ST_NIL;
+
+            /// <summary>
+            /// Global style index.
+            /// </summary>
+            public const int Global = NativeMethods.SCE_ST_GLOBAL;
+
+            /// <summary>
+            /// Return style index.
+            /// </summary>
+            public const int Return = NativeMethods.SCE_ST_RETURN;
+
+            /// <summary>
+            /// Special style index.
+            /// </summary>
+            public const int Special = NativeMethods.SCE_ST_SPECIAL;
+
+            /// <summary>
+            /// KWS End style index.
+            /// </summary>
+            public const int KwsEnd = NativeMethods.SCE_ST_KWSEND;
+
+            /// <summary>
+            /// Assign style index.
+            /// </summary>
+            public const int Assign = NativeMethods.SCE_ST_ASSIGN;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_ST_CHARACTER;
+
+            /// <summary>
+            /// Special selector style index.
+            /// </summary>
+            public const int SpecSel = NativeMethods.SCE_ST_SPEC_SEL;
+        }
+
+        #endregion Smalltalk
+
+        #region Sql
+
+        /// <summary>
+        /// Style constants for use with the Sql lexer.
+        /// </summary>
+        public static class Sql
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_SQL_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_SQL_COMMENT;
+
+            /// <summary>
+            /// Line comment style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_SQL_COMMENTLINE;
+
+            /// <summary>
+            /// Documentation comment style index.
+            /// </summary>
+            public const int CommentDoc = NativeMethods.SCE_SQL_COMMENTDOC;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_SQL_NUMBER;
+
+            /// <summary>
+            /// Keyword list 1 (index 0) style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_SQL_WORD;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_SQL_STRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int Character = NativeMethods.SCE_SQL_CHARACTER;
+
+            /// <summary>
+            /// Keyword from the SQL*Plus list (index 3) style index.
+            /// </summary>
+            public const int SqlPlus = NativeMethods.SCE_SQL_SQLPLUS;
+
+            /// <summary>
+            /// SQL*Plus prompt style index.
+            /// </summary>
+            public const int SqlPlusPrompt = NativeMethods.SCE_SQL_SQLPLUS_PROMPT;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_SQL_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_SQL_IDENTIFIER;
+
+            /// <summary>
+            /// SQL*Plus comment style index.
+            /// </summary>
+            public const int SqlPlusComment = NativeMethods.SCE_SQL_SQLPLUS_COMMENT;
+
+            /// <summary>
+            /// Documentation line comment style index.
+            /// </summary>
+            public const int CommentLineDoc = NativeMethods.SCE_SQL_COMMENTLINEDOC;
+
+            /// <summary>
+            /// Keyword list 2 (index 1) style index.
+            /// </summary>
+            public const int Word2 = NativeMethods.SCE_SQL_WORD2;
+
+            /// <summary>
+            /// Documentation (Doxygen) keyword style index.
+            /// </summary>
+            public const int CommentDocKeyword = NativeMethods.SCE_SQL_COMMENTDOCKEYWORD;
+
+            /// <summary>
+            /// Documentation (Doxygen) keyword error style index.
+            /// </summary>
+            public const int CommentDocKeywordError = NativeMethods.SCE_SQL_COMMENTDOCKEYWORDERROR;
+
+            /// <summary>
+            /// Keyword user-list 1 (index 4) style index.
+            /// </summary>
+            public const int User1 = NativeMethods.SCE_SQL_USER1;
+
+            /// <summary>
+            /// Keyword user-list 2 (index 5) style index.
+            /// </summary>
+            public const int User2 = NativeMethods.SCE_SQL_USER2;
+
+            /// <summary>
+            /// Keyword user-list 3 (index 6) style index.
+            /// </summary>
+            public const int User3 = NativeMethods.SCE_SQL_USER3;
+
+            /// <summary>
+            /// Keyword user-list 4 (index 7) style index.
+            /// </summary>
+            public const int User4 = NativeMethods.SCE_SQL_USER4;
+
+            /// <summary>
+            /// Quoted identifier style index.
+            /// </summary>
+            public const int QuotedIdentifier = NativeMethods.SCE_SQL_QUOTEDIDENTIFIER;
+
+            /// <summary>
+            /// Q operator style index.
+            /// </summary>
+            public const int QOperator = NativeMethods.SCE_SQL_QOPERATOR;
+        }
+
+        #endregion Sql
+
+        #region Markdown
+
+        /// <summary>
+        /// Style constants for use with the Markdown lexer.
+        /// </summary>
+        public static class Markdown
+        {
+            /// <summary>
+            /// Default text style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_MARKDOWN_DEFAULT;
+
+            /// <summary>
+            /// Line begin style index.
+            /// </summary>
+            public const int LineBegin = NativeMethods.SCE_MARKDOWN_LINE_BEGIN;
+
+            /// <summary>
+            /// Strong type 1 style index.
+            /// </summary>
+            public const int Strong1 = NativeMethods.SCE_MARKDOWN_STRONG1;
+
+            /// <summary>
+            /// Strong type 2 style index.
+            /// </summary>
+            public const int Strong2 = NativeMethods.SCE_MARKDOWN_STRONG2;
+
+            /// <summary>
+            /// Empasis type 1 style index.
+            /// </summary>
+            public const int Em1 = NativeMethods.SCE_MARKDOWN_EM1;
+
+            /// <summary>
+            /// Empasis type 2 style index.
+            /// </summary>
+            public const int Em2 = NativeMethods.SCE_MARKDOWN_EM2;
+
+            /// <summary>
+            /// Header type 1 style index.
+            /// </summary>
+            public const int Header1 = NativeMethods.SCE_MARKDOWN_HEADER1;
+
+            /// <summary>
+            /// Header type 2 style index.
+            /// </summary>
+            public const int Header2 = NativeMethods.SCE_MARKDOWN_HEADER2;
+
+            /// <summary>
+            /// Header type 3 style index.
+            /// </summary>
+            public const int Header3 = NativeMethods.SCE_MARKDOWN_HEADER3;
+
+            /// <summary>
+            /// Header type 4 style index.
+            /// </summary>
+            public const int Header4 = NativeMethods.SCE_MARKDOWN_HEADER4;
+
+            /// <summary>
+            /// Header type 5 style index.
+            /// </summary>
+            public const int Header5 = NativeMethods.SCE_MARKDOWN_HEADER5;
+
+            /// <summary>
+            /// Header type 6 style index.
+            /// </summary>
+            public const int Header6 = NativeMethods.SCE_MARKDOWN_HEADER6;
+
+            /// <summary>
+            /// Pre char style index.
+            /// </summary>
+            public const int PreChar = NativeMethods.SCE_MARKDOWN_PRECHAR;
+
+            /// <summary>
+            /// Unordered list style index.
+            /// </summary>
+            public const int UListItem = NativeMethods.SCE_MARKDOWN_ULIST_ITEM;
+
+            /// <summary>
+            /// Ordered list style index.
+            /// </summary>
+            public const int OListItem = NativeMethods.SCE_MARKDOWN_OLIST_ITEM;
+
+            /// <summary>
+            /// Blockquote style index.
+            /// </summary>
+            public const int BlockQuote = NativeMethods.SCE_MARKDOWN_BLOCKQUOTE;
+
+            /// <summary>
+            /// Strikeout style index.
+            /// </summary>
+            public const int Strikeout = NativeMethods.SCE_MARKDOWN_STRIKEOUT;
+
+            /// <summary>
+            /// Horizontal rule style index.
+            /// </summary>
+            public const int HRule = NativeMethods.SCE_MARKDOWN_HRULE;
+
+            /// <summary>
+            /// Link style index.
+            /// </summary>
+            public const int Link = NativeMethods.SCE_MARKDOWN_LINK;
+
+            /// <summary>
+            /// Code type 1 style index.
+            /// </summary>
+            public const int Code = NativeMethods.SCE_MARKDOWN_CODE;
+
+            /// <summary>
+            /// Code type 2 style index.
+            /// </summary>
+            public const int Code2 = NativeMethods.SCE_MARKDOWN_CODE2;
+
+            /// <summary>
+            /// Code block style index.
+            /// </summary>
+            public const int CodeBk = NativeMethods.SCE_MARKDOWN_CODEBK;
+        }
+
+        #endregion Markdown
+
+        #region R
+
+        /// <summary>
+        /// Style constants for use with the R lexer.
+        /// </summary>
+        public static class R
+        {
+            /// <summary>
+            /// Default style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_R_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_R_COMMENT;
+
+            /// <summary>
+            /// Keyword (set 0) style index.
+            /// </summary>
+            public const int KWord = NativeMethods.SCE_R_KWORD;
+
+            /// <summary>
+            /// Base keyword (set 1) style index.
+            /// </summary>
+            public const int BaseKWord = NativeMethods.SCE_R_BASEKWORD;
+
+            /// <summary>
+            /// Other keyword (set 2) style index.
+            /// </summary>
+            public const int OtherKWord = NativeMethods.SCE_R_OTHERKWORD;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_R_NUMBER;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_R_STRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int String2 = NativeMethods.SCE_R_STRING2;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_R_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_R_IDENTIFIER;
+
+            /// <summary>
+            /// Infix style index.
+            /// </summary>
+            public const int Infix = NativeMethods.SCE_R_INFIX;
+
+            /// <summary>
+            /// Unclosed infix EOL style index.
+            /// </summary>
+            public const int InfixEol = NativeMethods.SCE_R_INFIXEOL;
+        }
+
+        #endregion R
+
+        #region Vb
+
+        /// <summary>
+        /// Style constants for use with the Vb lexer.
+        /// </summary>
+        public static class Vb
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_B_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_B_COMMENT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_B_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_B_KEYWORD;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_B_STRING;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_B_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
+
+            /// <summary>
+            /// Date style index.
+            /// </summary>
+            public const int Date = NativeMethods.SCE_B_DATE;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
+
+            /// <summary>
+            /// Keyword list 2 (index 1) style index.
+            /// </summary>
+            public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
+
+            /// <summary>
+            /// Keyword list 3 (index 2) style index.
+            /// </summary>
+            public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
+
+            /// <summary>
+            /// Keyword list 4 (index 3) style index.
+            /// </summary>
+            public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
+
+            /// <summary>
+            /// Constant style index.
+            /// </summary>
+            public const int Constant = NativeMethods.SCE_B_CONSTANT;
+
+            /// <summary>
+            /// Inline assembler style index.
+            /// </summary>
+            public const int Asm = NativeMethods.SCE_B_ASM;
+
+            /// <summary>
+            /// Label style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_B_LABEL;
+
+            /// <summary>
+            /// Error style index.
+            /// </summary>
+            public const int Error = NativeMethods.SCE_B_ERROR;
+
+            /// <summary>
+            /// Hexadecimal number style index.
+            /// </summary>
+            public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
+
+            /// <summary>
+            /// Binary number style index.
+            /// </summary>
+            public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
+
+            /// <summary>
+            /// Block comment style index.
+            /// </summary>
+            public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
+
+            /// <summary>
+            /// Documentation line style index.
+            /// </summary>
+            public const int DocLine = NativeMethods.SCE_B_DOCLINE;
+
+            /// <summary>
+            /// Documentation block style index.
+            /// </summary>
+            public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
+
+            /// <summary>
+            /// Documentation keyword style index.
+            /// </summary>
+            public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
+        }
+
+        #endregion Vb
+
+        #region VbScript
+
+        /// <summary>
+        /// Style constants for use with the VbScript lexer.
+        /// </summary>
+        public static class VbScript
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_B_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_B_COMMENT;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_B_NUMBER;
+
+            /// <summary>
+            /// Keyword style index.
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_B_KEYWORD;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_B_STRING;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_B_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
+
+            /// <summary>
+            /// Date style index.
+            /// </summary>
+            public const int Date = NativeMethods.SCE_B_DATE;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
+
+            /// <summary>
+            /// Keyword list 2 (index 1) style index.
+            /// </summary>
+            public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
+
+            /// <summary>
+            /// Keyword list 3 (index 2) style index.
+            /// </summary>
+            public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
+
+            /// <summary>
+            /// Keyword list 4 (index 3) style index.
+            /// </summary>
+            public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
+
+            /// <summary>
+            /// Constant style index.
+            /// </summary>
+            public const int Constant = NativeMethods.SCE_B_CONSTANT;
+
+            /// <summary>
+            /// Inline assembler style index.
+            /// </summary>
+            public const int Asm = NativeMethods.SCE_B_ASM;
+
+            /// <summary>
+            /// Label style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_B_LABEL;
+
+            /// <summary>
+            /// Error style index.
+            /// </summary>
+            public const int Error = NativeMethods.SCE_B_ERROR;
+
+            /// <summary>
+            /// Hexadecimal number style index.
+            /// </summary>
+            public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
+
+            /// <summary>
+            /// Binary number style index.
+            /// </summary>
+            public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
+
+            /// <summary>
+            /// Block comment style index.
+            /// </summary>
+            public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
+
+            /// <summary>
+            /// Documentation line style index.
+            /// </summary>
+            public const int DocLine = NativeMethods.SCE_B_DOCLINE;
+
+            /// <summary>
+            /// Documentation block style index.
+            /// </summary>
+            public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
+
+            /// <summary>
+            /// Documentation keyword style index.
+            /// </summary>
+            public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
+        }
+
+        #endregion VbScript
+
+        #region Verilog
+
+        /// <summary>
+        /// Style constants for use with the Verilog lexer.
+        /// </summary>
+        public static class Verilog
+        {
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_V_DEFAULT;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_V_COMMENT;
+
+            /// <summary>
+            /// Comment line style index.
+            /// </summary>
+            public const int CommentLine = NativeMethods.SCE_V_COMMENTLINE;
+
+            /// <summary>
+            /// Comment line bang (exclamation) style index.
+            /// </summary>
+            public const int CommentLineBang = NativeMethods.SCE_V_COMMENTLINEBANG;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_V_NUMBER;
+
+            /// <summary>
+            /// Keyword (set 0) style index.
+            /// </summary>
+            public const int Word = NativeMethods.SCE_V_WORD;
+
+            /// <summary>
+            /// String style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_V_STRING;
+
+            /// <summary>
+            /// Keyword (set 1) style index.
+            /// </summary>
+            public const int Word2 = NativeMethods.SCE_V_WORD2;
+
+            /// <summary>
+            /// Keyword (set 2) style index.
+            /// </summary>
+            public const int Word3 = NativeMethods.SCE_V_WORD3;
+
+            /// <summary>
+            /// Preprocessor style index.
+            /// </summary>
+            public const int Preprocessor = NativeMethods.SCE_V_PREPROCESSOR;
+
+            /// <summary>
+            /// Operator style index.
+            /// </summary>
+            public const int Operator = NativeMethods.SCE_V_OPERATOR;
+
+            /// <summary>
+            /// Identifier style index.
+            /// </summary>
+            public const int Identifier = NativeMethods.SCE_V_IDENTIFIER;
+
+            /// <summary>
+            /// Unclosed string EOL style index.
+            /// </summary>
+            public const int StringEol = NativeMethods.SCE_V_STRINGEOL;
+
+            /// <summary>
+            /// User word (set 3) style index.
+            /// </summary>
+            public const int User = NativeMethods.SCE_V_USER;
+
+            /// <summary>
+            /// Comment word (set 4) style index.
+            /// </summary>
+            public const int CommentWord = NativeMethods.SCE_V_COMMENT_WORD;
+
+            /// <summary>
+            /// Input style index.
+            /// </summary>
+            public const int Input = NativeMethods.SCE_V_INPUT;
+
+            /// <summary>
+            /// Output style index.
+            /// </summary>
+            public const int Output = NativeMethods.SCE_V_OUTPUT;
+
+            /// <summary>
+            /// In-out style index.
+            /// </summary>
+            public const int InOut = NativeMethods.SCE_V_INOUT;
+
+            /// <summary>
+            /// Port connect style index.
+            /// </summary>
+            public const int PortConnect = NativeMethods.SCE_V_PORT_CONNECT;
+        }
+
+        #endregion Verilog
+
+        #region Xml
+
+        /// <summary>
+        /// Style constants for use with the Xml lexer.
+        /// </summary>
+        public static class Xml
+        {
+            /// <summary>
+            /// Content style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_H_DEFAULT;
+
+            /// <summary>
+            /// Tag style index.
+            /// </summary>
+            public const int Tag = NativeMethods.SCE_H_TAG;
+
+            /// <summary>
+            /// Unknown tag style index.
+            /// </summary>
+            public const int TagUnknown = NativeMethods.SCE_H_TAGUNKNOWN;
+
+            /// <summary>
+            /// Attribute style index.
+            /// </summary>
+            public const int Attribute = NativeMethods.SCE_H_ATTRIBUTE;
+
+            /// <summary>
+            /// Unknown attribute style index.
+            /// </summary>
+            public const int AttributeUnknown = NativeMethods.SCE_H_ATTRIBUTEUNKNOWN;
+
+            /// <summary>
+            /// Number style index.
+            /// </summary>
+            public const int Number = NativeMethods.SCE_H_NUMBER;
+
+            /// <summary>
+            /// Double-quoted string style index.
+            /// </summary>
+            public const int DoubleString = NativeMethods.SCE_H_DOUBLESTRING;
+
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int SingleString = NativeMethods.SCE_H_SINGLESTRING;
+
+            /// <summary>
+            /// Other tag content (not elements or attributes) style index.
+            /// </summary>
+            public const int Other = NativeMethods.SCE_H_OTHER;
+
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_H_COMMENT;
+
+            /// <summary>
+            /// Entity ($nnn;) name style index.
+            /// </summary>
+            public const int Entity = NativeMethods.SCE_H_ENTITY;
+
+            /// <summary>
+            /// End-tag style index.
+            /// </summary>
+            public const int TagEnd = NativeMethods.SCE_H_TAGEND;
+
+            /// <summary>
+            /// Start of XML declaration (&lt;?xml&gt;) style index.
+            /// </summary>
+            public const int XmlStart = NativeMethods.SCE_H_XMLSTART;
+
+            /// <summary>
+            /// End of XML declaration (?&gt;) style index.
+            /// </summary>
+            public const int XmlEnd = NativeMethods.SCE_H_XMLEND;
+
+            /// <summary>
+            /// Script tag (&lt;script&gt;) style index.
+            /// </summary>
+            public const int Script = NativeMethods.SCE_H_SCRIPT;
+
+            /// <summary>
+            /// ASP-like script engine block (&lt;%) style index.
+            /// </summary>
+            public const int Asp = NativeMethods.SCE_H_ASP;
+
+            /// <summary>
+            /// ASP-like language declaration (&lt;%@) style index.
+            /// </summary>
+            public const int AspAt = NativeMethods.SCE_H_ASPAT;
+
+            /// <summary>
+            /// CDATA section style index.
+            /// </summary>
+            public const int CData = NativeMethods.SCE_H_CDATA;
+
+            /// <summary>
+            /// Question mark style index.
+            /// </summary>
+            public const int Question = NativeMethods.SCE_H_QUESTION;
+
+            /// <summary>
+            /// Value style index.
+            /// </summary>
+            public const int Value = NativeMethods.SCE_H_VALUE;
+
+            /// <summary>
+            /// Script engine comment (&lt;%--) style index.
+            /// </summary>
+            public const int XcComment = NativeMethods.SCE_H_XCCOMMENT;
+        }
+
+        #endregion Xml
     }
-
-    #endregion Properties
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instances of the <see cref="Style" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this style.</param>
-    /// <param name="index">The index of this style within the <see cref="StyleCollection" /> that created it.</param>
-    public Style(Scintilla scintilla, int index)
-    {
-        this.scintilla = scintilla;
-        Index = index;
-    }
-
-    #endregion Constructors
-
-    #region Ada
-
-    /// <summary>
-    /// Style constants for use with the Ada lexer.
-    /// </summary>
-    public static class Ada
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_ADA_DEFAULT;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_ADA_COMMENTLINE;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_ADA_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_ADA_WORD;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_ADA_STRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_ADA_CHARACTER;
-
-        /// <summary>
-        /// Delimiter style index.
-        /// </summary>
-        public const int Delimiter = NativeMethods.SCE_ADA_DELIMITER;
-
-        /// <summary>
-        /// Label style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_ADA_LABEL;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_ADA_IDENTIFIER;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_ADA_STRINGEOL;
-
-        /// <summary>
-        /// Unclosed character EOL style index.
-        /// </summary>
-        public const int CharacterEol = NativeMethods.SCE_ADA_CHARACTEREOL;
-
-        /// <summary>
-        /// Illegal identifier or keyword style index.
-        /// </summary>
-        public const int Illegal = NativeMethods.SCE_ADA_ILLEGAL;
-    }
-
-    #endregion Ada
-
-    #region Asm
-
-    /// <summary>
-    /// Style constants for use with the Asm lexer.
-    /// </summary>
-    public static class Asm
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_ASM_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_ASM_COMMENT;
-
-        /// <summary>
-        /// Comment block style index.
-        /// </summary>
-        public const int CommentBlock = NativeMethods.SCE_ASM_COMMENTBLOCK;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_ASM_NUMBER;
-
-        /// <summary>
-        /// Math instruction (keword list 1) style index.
-        /// </summary>
-        public const int MathInstruction = NativeMethods.SCE_ASM_MATHINSTRUCTION;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_ASM_STRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_ASM_CHARACTER;
-
-        /// <summary>
-        /// CPU instruction (keyword list 0) style index.
-        /// </summary>
-        public const int CpuInstruction = NativeMethods.SCE_ASM_CPUINSTRUCTION;
-
-        /// <summary>
-        /// Register (keyword list 2) style index.
-        /// </summary>
-        public const int Register = NativeMethods.SCE_ASM_REGISTER;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_ASM_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_ASM_IDENTIFIER;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_ASM_STRINGEOL;
-
-        /// <summary>
-        /// Directive (keyword list 3) string style index.
-        /// </summary>
-        public const int Directive = NativeMethods.SCE_ASM_DIRECTIVE;
-
-        /// <summary>
-        /// Directive operand (keyword list 4) style index.
-        /// </summary>
-        public const int DirectiveOperand = NativeMethods.SCE_ASM_DIRECTIVEOPERAND;
-
-        /// <summary>
-        /// Extended instruction (keyword list 5) style index.
-        /// </summary>
-        public const int ExtInstruction = NativeMethods.SCE_ASM_EXTINSTRUCTION;
-
-        /// <summary>
-        /// Comment directive style index.
-        /// </summary>
-        public const int CommentDirective = NativeMethods.SCE_ASM_COMMENTDIRECTIVE;
-    }
-
-    #endregion Asm
-
-    #region BlitzBasic
-
-    /// <summary>
-    /// Style constants for use with the BlitzBasic lexer.
-    /// </summary>
-    public static class BlitzBasic
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_B_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_B_COMMENT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_B_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_B_KEYWORD;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_B_STRING;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_B_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
-
-        /// <summary>
-        /// Date style index.
-        /// </summary>
-        public const int Date = NativeMethods.SCE_B_DATE;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
-
-        /// <summary>
-        /// Keyword list 2 (index 1) style index.
-        /// </summary>
-        public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
-
-        /// <summary>
-        /// Keyword list 3 (index 2) style index.
-        /// </summary>
-        public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
-
-        /// <summary>
-        /// Keyword list 4 (index 3) style index.
-        /// </summary>
-        public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
-
-        /// <summary>
-        /// Constant style index.
-        /// </summary>
-        public const int Constant = NativeMethods.SCE_B_CONSTANT;
-
-        /// <summary>
-        /// Inline assembler style index.
-        /// </summary>
-        public const int Asm = NativeMethods.SCE_B_ASM;
-
-        /// <summary>
-        /// Label style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_B_LABEL;
-
-        /// <summary>
-        /// Error style index.
-        /// </summary>
-        public const int Error = NativeMethods.SCE_B_ERROR;
-
-        /// <summary>
-        /// Hexadecimal number style index.
-        /// </summary>
-        public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
-
-        /// <summary>
-        /// Binary number style index.
-        /// </summary>
-        public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
-
-        /// <summary>
-        /// Block comment style index.
-        /// </summary>
-        public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
-
-        /// <summary>
-        /// Documentation line style index.
-        /// </summary>
-        public const int DocLine = NativeMethods.SCE_B_DOCLINE;
-
-        /// <summary>
-        /// Documentation block style index.
-        /// </summary>
-        public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
-
-        /// <summary>
-        /// Documentation keyword style index.
-        /// </summary>
-        public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
-    }
-
-    #endregion BlitzBasic
-
-    #region Batch
-
-    /// <summary>
-    /// Style constants for use with the Batch lexer.
-    /// </summary>
-    public static class Batch
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_BAT_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_BAT_COMMENT;
-
-        /// <summary>
-        /// Keyword (list 0) style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_BAT_WORD;
-
-        /// <summary>
-        /// Label style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_BAT_LABEL;
-
-        /// <summary>
-        /// Hide (@ECHO OFF/ON) style index.
-        /// </summary>
-        public const int Hide = NativeMethods.SCE_BAT_HIDE;
-
-        /// <summary>
-        /// External command (keyword list 1) style index.
-        /// </summary>
-        public const int Command = NativeMethods.SCE_BAT_COMMAND;
-
-        /// <summary>
-        /// Identifier string style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_BAT_IDENTIFIER;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_BAT_OPERATOR;
-    }
-
-    #endregion Batch
-
-    #region Clw
-
-    /// <summary>
-    /// Style constants for use with the Clw lexer.
-    /// </summary>
-    public static class CLW
-    {
-        /// <summary>
-        /// Attributes style index
-        /// </summary>
-        public const int Attributes = NativeMethods.SCE_CLW_ATTRIBUTE;
-
-        /// <summary>
-        /// Built in procedures function style index.
-        /// </summary>
-        public const int BuiltInProceduresFunction = NativeMethods.SCE_CLW_BUILTIN_PROCEDURES_FUNCTION;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_CLW_COMMENT;
-
-        /// <summary>
-        /// Compiler directive style index
-        /// </summary>
-        public const int CompilerDirective = NativeMethods.SCE_CLW_COMPILER_DIRECTIVE;
-
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_CLW_DEFAULT;
-
-        /// <summary>
-        /// Depreciated style index
-        /// </summary>
-        public const int Depreciated = NativeMethods.SCE_CLW_DEPRECATED;
-
-        /// <summary>
-        /// Error style index
-        /// </summary>
-        public const int Error = NativeMethods.SCE_CLW_ERROR;
-
-        /// <summary>
-        /// Integer Constant style index.
-        /// </summary>
-        public const int IntegerConstant = NativeMethods.SCE_CLW_INTEGER_CONSTANT;
-
-        /// <summary>
-        /// Keyword style index
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_CLW_KEYWORD;
-
-        /// <summary>
-        /// Label string style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_CLW_LABEL;
-
-        /// <summary>
-        /// Real Constant style index.
-        /// </summary>
-        public const int PictureString = NativeMethods.SCE_CLW_PICTURE_STRING;
-
-        /// <summary>
-        /// Real Constant style index.
-        /// </summary>
-        public const int RealConstant = NativeMethods.SCE_CLW_REAL_CONSTANT;
-
-        /// <summary>
-        /// Runtime expressions style index
-        /// </summary>
-        public const int RuntimeExpressions = NativeMethods.SCE_CLW_RUNTIME_EXPRESSIONS;
-
-        /// <summary>
-        /// Standard equates style index
-        /// </summary>
-        public const int StandardEquates = NativeMethods.SCE_CLW_STANDARD_EQUATE;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_CLW_STRING;
-
-        /// <summary>
-        /// Structure data type style index.
-        /// </summary>
-        public const int StructureDataTypes = NativeMethods.SCE_CLW_STRUCTURE_DATA_TYPE;
-
-        /// <summary>
-        /// User Identifier style index.
-        /// </summary>
-        public const int UserIdentifier = NativeMethods.SCE_CLW_USER_IDENTIFIER;
-    }
-
-    #endregion Clw
-
-    #region Cpp
-
-    /// <summary>
-    /// Style constants for use with the Cpp lexer.
-    /// </summary>
-    public static class Cpp
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_C_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_C_COMMENT;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_C_COMMENTLINE;
-
-        /// <summary>
-        /// Documentation comment style index.
-        /// </summary>
-        public const int CommentDoc = NativeMethods.SCE_C_COMMENTDOC;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_C_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_C_WORD;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_C_STRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_C_CHARACTER;
-
-        /// <summary>
-        /// UUID style index.
-        /// </summary>
-        public const int Uuid = NativeMethods.SCE_C_UUID;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_C_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_C_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_C_IDENTIFIER;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_C_STRINGEOL;
-
-        /// <summary>
-        /// Verbatim string style index.
-        /// </summary>
-        public const int Verbatim = NativeMethods.SCE_C_VERBATIM;
-
-        /// <summary>
-        /// Regular expression style index.
-        /// </summary>
-        public const int Regex = NativeMethods.SCE_C_REGEX;
-
-        /// <summary>
-        /// Documentation comment line style index.
-        /// </summary>
-        public const int CommentLineDoc = NativeMethods.SCE_C_COMMENTLINEDOC;
-
-        /// <summary>
-        /// Keyword style 2 index.
-        /// </summary>
-        public const int Word2 = NativeMethods.SCE_C_WORD2;
-
-        /// <summary>
-        /// Comment keyword style index.
-        /// </summary>
-        public const int CommentDocKeyword = NativeMethods.SCE_C_COMMENTDOCKEYWORD;
-
-        /// <summary>
-        /// Comment keyword error style index.
-        /// </summary>
-        public const int CommentDocKeywordError = NativeMethods.SCE_C_COMMENTDOCKEYWORDERROR;
-
-        /// <summary>
-        /// Global class style index.
-        /// </summary>
-        public const int GlobalClass = NativeMethods.SCE_C_GLOBALCLASS;
-
-        /// <summary>
-        /// Raw string style index.
-        /// </summary>
-        public const int StringRaw = NativeMethods.SCE_C_STRINGRAW;
-
-        /// <summary>
-        /// Triple-quoted string style index.
-        /// </summary>
-        public const int TripleVerbatim = NativeMethods.SCE_C_TRIPLEVERBATIM;
-
-        /// <summary>
-        /// Hash-quoted string style index.
-        /// </summary>
-        public const int HashQuotedString = NativeMethods.SCE_C_HASHQUOTEDSTRING;
-
-        /// <summary>
-        /// Preprocessor comment style index.
-        /// </summary>
-        public const int PreprocessorComment = NativeMethods.SCE_C_PREPROCESSORCOMMENT;
-
-        /// <summary>
-        /// Preprocessor documentation comment style index.
-        /// </summary>
-        public const int PreprocessorCommentDoc = NativeMethods.SCE_C_PREPROCESSORCOMMENTDOC;
-
-        /// <summary>
-        /// User-defined literal style index.
-        /// </summary>
-        public const int UserLiteral = NativeMethods.SCE_C_USERLITERAL;
-
-        /// <summary>
-        /// Task marker style index.
-        /// </summary>
-        public const int TaskMarker = NativeMethods.SCE_C_TASKMARKER;
-
-        /// <summary>
-        /// Escape sequence style index.
-        /// </summary>
-        public const int EscapeSequence = NativeMethods.SCE_C_ESCAPESEQUENCE;
-    }
-
-    #endregion Cpp
-
-    #region Css
-
-    /// <summary>
-    /// Style constants for use with the Css lexer.
-    /// </summary>
-    public static class Css
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_CSS_DEFAULT;
-
-        /// <summary>
-        /// Tag style index.
-        /// </summary>
-        public const int Tag = NativeMethods.SCE_CSS_TAG;
-
-        /// <summary>
-        /// Class style index.
-        /// </summary>
-        public const int Class = NativeMethods.SCE_CSS_CLASS;
-
-        /// <summary>
-        /// Pseudo class style index.
-        /// </summary>
-        public const int PseudoClass = NativeMethods.SCE_CSS_PSEUDOCLASS;
-
-        /// <summary>
-        /// Unknown pseudo class style index.
-        /// </summary>
-        public const int UnknownPseudoClass = NativeMethods.SCE_CSS_UNKNOWN_PSEUDOCLASS;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_CSS_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_CSS_IDENTIFIER;
-
-        /// <summary>
-        /// Unknown identifier style index.
-        /// </summary>
-        public const int UnknownIdentifier = NativeMethods.SCE_CSS_UNKNOWN_IDENTIFIER;
-
-        /// <summary>
-        /// Value style index.
-        /// </summary>
-        public const int Value = NativeMethods.SCE_CSS_VALUE;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_CSS_COMMENT;
-
-        /// <summary>
-        /// ID style index.
-        /// </summary>
-        public const int Id = NativeMethods.SCE_CSS_ID;
-
-        /// <summary>
-        /// Important style index.
-        /// </summary>
-        public const int Important = NativeMethods.SCE_CSS_IMPORTANT;
-
-        /// <summary>
-        /// Directive style index.
-        /// </summary>
-        public const int Directive = NativeMethods.SCE_CSS_DIRECTIVE;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int DoubleString = NativeMethods.SCE_CSS_DOUBLESTRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int SingleString = NativeMethods.SCE_CSS_SINGLESTRING;
-
-        /// <summary>
-        /// Identifier style 2 index.
-        /// </summary>
-        public const int Identifier2 = NativeMethods.SCE_CSS_IDENTIFIER2;
-
-        /// <summary>
-        /// Attribute style index.
-        /// </summary>
-        public const int Attribute = NativeMethods.SCE_CSS_ATTRIBUTE;
-
-        /// <summary>
-        /// Identifier style 3 index.
-        /// </summary>
-        public const int Identifier3 = NativeMethods.SCE_CSS_IDENTIFIER3;
-
-        /// <summary>
-        /// Pseudo element style index.
-        /// </summary>
-        public const int PseudoElement = NativeMethods.SCE_CSS_PSEUDOELEMENT;
-
-        /// <summary>
-        /// Extended identifier style index.
-        /// </summary>
-        public const int ExtendedIdentifier = NativeMethods.SCE_CSS_EXTENDED_IDENTIFIER;
-
-        /// <summary>
-        /// Extended pseudo class style index.
-        /// </summary>
-        public const int ExtendedPseudoClass = NativeMethods.SCE_CSS_EXTENDED_PSEUDOCLASS;
-
-        /// <summary>
-        /// Extended pseudo element style index.
-        /// </summary>
-        public const int ExtendedPseudoElement = NativeMethods.SCE_CSS_EXTENDED_PSEUDOELEMENT;
-
-        /// <summary>
-        /// Media style index.
-        /// </summary>
-        public const int Media = NativeMethods.SCE_CSS_MEDIA;
-
-        /// <summary>
-        /// Variable style index.
-        /// </summary>
-        public const int Variable = NativeMethods.SCE_CSS_VARIABLE;
-    }
-
-    #endregion Css
-
-    #region Fortran
-
-    /// <summary>
-    /// Style constants for use with the Fortran lexer.
-    /// </summary>
-    public static class Fortran
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_F_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_F_COMMENT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_F_NUMBER;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int String1 = NativeMethods.SCE_F_STRING1;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String2 = NativeMethods.SCE_F_STRING2;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_F_STRINGEOL;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_F_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_F_IDENTIFIER;
-
-        /// <summary>
-        /// Keyword (list 0) style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_F_WORD;
-
-        /// <summary>
-        /// Keyword 2 (list 1) style index.
-        /// </summary>
-        public const int Word2 = NativeMethods.SCE_F_WORD2;
-
-        /// <summary>
-        /// Keyword 3 (list 2) style index.
-        /// </summary>
-        public const int Word3 = NativeMethods.SCE_F_WORD3;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_F_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator 2 style index.
-        /// </summary>
-        public const int Operator2 = NativeMethods.SCE_F_OPERATOR2;
-
-        /// <summary>
-        /// Label string style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_F_LABEL;
-
-        /// <summary>
-        /// Continuation style index.
-        /// </summary>
-        public const int Continuation = NativeMethods.SCE_F_CONTINUATION;
-    }
-
-    #endregion Fortran
-
-    #region FreeBasic
-
-    /// <summary>
-    /// Style constants for use with the FreeBasic lexer.
-    /// </summary>
-    public static class FreeBasic
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_B_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_B_COMMENT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_B_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_B_KEYWORD;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_B_STRING;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_B_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
-
-        /// <summary>
-        /// Date style index.
-        /// </summary>
-        public const int Date = NativeMethods.SCE_B_DATE;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
-
-        /// <summary>
-        /// Keyword list 2 (index 1) style index.
-        /// </summary>
-        public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
-
-        /// <summary>
-        /// Keyword list 3 (index 2) style index.
-        /// </summary>
-        public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
-
-        /// <summary>
-        /// Keyword list 4 (index 3) style index.
-        /// </summary>
-        public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
-
-        /// <summary>
-        /// Constant style index.
-        /// </summary>
-        public const int Constant = NativeMethods.SCE_B_CONSTANT;
-
-        /// <summary>
-        /// Inline assembler style index.
-        /// </summary>
-        public const int Asm = NativeMethods.SCE_B_ASM;
-
-        /// <summary>
-        /// Label style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_B_LABEL;
-
-        /// <summary>
-        /// Error style index.
-        /// </summary>
-        public const int Error = NativeMethods.SCE_B_ERROR;
-
-        /// <summary>
-        /// Hexadecimal number style index.
-        /// </summary>
-        public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
-
-        /// <summary>
-        /// Binary number style index.
-        /// </summary>
-        public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
-
-        /// <summary>
-        /// Block comment style index.
-        /// </summary>
-        public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
-
-        /// <summary>
-        /// Documentation line style index.
-        /// </summary>
-        public const int DocLine = NativeMethods.SCE_B_DOCLINE;
-
-        /// <summary>
-        /// Documentation block style index.
-        /// </summary>
-        public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
-
-        /// <summary>
-        /// Documentation keyword style index.
-        /// </summary>
-        public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
-    }
-
-    #endregion FreeBasic
-
-    #region Html
-
-    /// <summary>
-    /// Style constants for use with the Html lexer.
-    /// </summary>
-    public static class Html
-    {
-        /// <summary>
-        /// Content style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_H_DEFAULT;
-
-        /// <summary>
-        /// Tag style index.
-        /// </summary>
-        public const int Tag = NativeMethods.SCE_H_TAG;
-
-        /// <summary>
-        /// Unknown tag style index.
-        /// </summary>
-        public const int TagUnknown = NativeMethods.SCE_H_TAGUNKNOWN;
-
-        /// <summary>
-        /// Attribute style index.
-        /// </summary>
-        public const int Attribute = NativeMethods.SCE_H_ATTRIBUTE;
-
-        /// <summary>
-        /// Unknown attribute style index.
-        /// </summary>
-        public const int AttributeUnknown = NativeMethods.SCE_H_ATTRIBUTEUNKNOWN;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_H_NUMBER;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int DoubleString = NativeMethods.SCE_H_DOUBLESTRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int SingleString = NativeMethods.SCE_H_SINGLESTRING;
-
-        /// <summary>
-        /// Other tag content (not elements or attributes) style index.
-        /// </summary>
-        public const int Other = NativeMethods.SCE_H_OTHER;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_H_COMMENT;
-
-        /// <summary>
-        /// Entity ($nnn;) name style index.
-        /// </summary>
-        public const int Entity = NativeMethods.SCE_H_ENTITY;
-
-        /// <summary>
-        /// End-tag style index.
-        /// </summary>
-        public const int TagEnd = NativeMethods.SCE_H_TAGEND;
-
-        /// <summary>
-        /// Start of XML declaration (&lt;?xml&gt;) style index.
-        /// </summary>
-        public const int XmlStart = NativeMethods.SCE_H_XMLSTART;
-
-        /// <summary>
-        /// End of XML declaration (?&gt;) style index.
-        /// </summary>
-        public const int XmlEnd = NativeMethods.SCE_H_XMLEND;
-
-        /// <summary>
-        /// Script tag (&lt;script&gt;) style index.
-        /// </summary>
-        public const int Script = NativeMethods.SCE_H_SCRIPT;
-
-        /// <summary>
-        /// ASP-like script engine block (&lt;%) style index.
-        /// </summary>
-        public const int Asp = NativeMethods.SCE_H_ASP;
-
-        /// <summary>
-        /// ASP-like language declaration (&lt;%@) style index.
-        /// </summary>
-        public const int AspAt = NativeMethods.SCE_H_ASPAT;
-
-        /// <summary>
-        /// CDATA section style index.
-        /// </summary>
-        public const int CData = NativeMethods.SCE_H_CDATA;
-
-        /// <summary>
-        /// Question mark style index.
-        /// </summary>
-        public const int Question = NativeMethods.SCE_H_QUESTION;
-
-        /// <summary>
-        /// Value style index.
-        /// </summary>
-        public const int Value = NativeMethods.SCE_H_VALUE;
-
-        /// <summary>
-        /// Script engine comment (&lt;%--) style index.
-        /// </summary>
-        public const int XcComment = NativeMethods.SCE_H_XCCOMMENT;
-    }
-
-    #endregion Html
-
-    #region JavaScript
-
-    /// <summary>
-    /// Embedded JavaScript style constants for use with the JavaScript lexer.
-    /// </summary>
-    public static class JavaScript
-    {
-        /// <summary>
-        /// Start style index (allows EOL filled background to not start on same line as SCRIPT tag).
-        /// </summary>
-        public const int Start = NativeMethods.SCE_HJ_START;
-
-        /// <summary>
-        /// Default style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_HJ_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_HJ_COMMENT;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_HJ_COMMENTLINE;
-
-        /// <summary>
-        /// Doc comment style index.
-        /// </summary>
-        public const int CommentDoc = NativeMethods.SCE_HJ_COMMENTDOC;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_HJ_NUMBER;
-
-        /// <summary>
-        /// Word style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_HJ_WORD;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_HJ_KEYWORD;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int DoubleString = NativeMethods.SCE_HJ_DOUBLESTRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int SingleString = NativeMethods.SCE_HJ_SINGLESTRING;
-
-        /// <summary>
-        /// Symbols style index.
-        /// </summary>
-        public const int Symbols = NativeMethods.SCE_HJ_SYMBOLS;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_HJ_STRINGEOL;
-
-        /// <summary>
-        /// Regular expression style index.
-        /// </summary>
-        public const int Regex = NativeMethods.SCE_HJ_REGEX;
-    }
-
-    #endregion JavaScript
-
-    #region Json
-
-    /// <summary>
-    /// Style constants for use with the Json lexer.
-    /// </summary>
-    public static class Json
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_JSON_DEFAULT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_JSON_NUMBER;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_JSON_STRING;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_JSON_STRINGEOL;
-
-        /// <summary>
-        /// Property name style index.
-        /// </summary>
-        public const int PropertyName = NativeMethods.SCE_JSON_PROPERTYNAME;
-
-        /// <summary>
-        /// Escape sequence style index.
-        /// </summary>
-        public const int EscapeSequence = NativeMethods.SCE_JSON_ESCAPESEQUENCE;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int LineComment = NativeMethods.SCE_JSON_LINECOMMENT;
-
-        /// <summary>
-        /// Block comment style index.
-        /// </summary>
-        public const int BlockComment = NativeMethods.SCE_JSON_BLOCKCOMMENT;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_JSON_OPERATOR;
-
-        /// <summary>
-        /// URI style index.
-        /// </summary>
-        public const int Uri = NativeMethods.SCE_JSON_URI;
-
-        /// <summary>
-        /// Compact Internationalized Resource Identifier (IRI) style index.
-        /// </summary>
-        public const int CompactIRI = NativeMethods.SCE_JSON_COMPACTIRI;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_JSON_KEYWORD;
-
-        /// <summary>
-        /// Linked data (LD) keyword style index.
-        /// </summary>
-        public const int LdKeyword = NativeMethods.SCE_JSON_LDKEYWORD;
-
-        /// <summary>
-        /// Error style index.
-        /// </summary>
-        public const int Error = NativeMethods.SCE_JSON_ERROR;
-    }
-
-    #endregion Json
-
-    #region Lisp
-
-    /// <summary>
-    /// Style constants for use with the Lisp lexer.
-    /// </summary>
-    public static class Lisp
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_LISP_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_LISP_COMMENT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_LISP_NUMBER;
-
-        /// <summary>
-        /// Functions and special operators (list 0) style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_LISP_KEYWORD;
-
-        /// <summary>
-        /// Keywords (list 1) style index.
-        /// </summary>
-        public const int KeywordKw = NativeMethods.SCE_LISP_KEYWORD_KW;
-
-        /// <summary>
-        /// Symbol style index.
-        /// </summary>
-        public const int Symbol = NativeMethods.SCE_LISP_SYMBOL;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_LISP_STRING;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_LISP_STRINGEOL;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_LISP_IDENTIFIER;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_LISP_OPERATOR;
-
-        /// <summary>
-        /// Special character style index.
-        /// </summary>
-        public const int Special = NativeMethods.SCE_LISP_SPECIAL;
-
-        /// <summary>
-        /// Multi-line comment style index.
-        /// </summary>
-        public const int MultiComment = NativeMethods.SCE_LISP_MULTI_COMMENT;
-    }
-
-    #endregion Lisp
-
-    #region Lua
-
-    /// <summary>
-    /// Style constants for use with the Lua lexer.
-    /// </summary>
-    public static class Lua
-    {
-        /// <summary>
-        /// Default style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_LUA_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_LUA_COMMENT;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_LUA_COMMENTLINE;
-
-        /// <summary>
-        /// Documentation comment style index.
-        /// </summary>
-        public const int CommentDoc = NativeMethods.SCE_LUA_COMMENTDOC;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_LUA_NUMBER;
-
-        /// <summary>
-        /// Keyword list 1 (index 0) style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_LUA_WORD;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_LUA_STRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_LUA_CHARACTER;
-
-        /// <summary>
-        /// Literal string style index.
-        /// </summary>
-        public const int LiteralString = NativeMethods.SCE_LUA_LITERALSTRING;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_LUA_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_LUA_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_LUA_IDENTIFIER;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_LUA_STRINGEOL;
-
-        /// <summary>
-        /// Keywords list 2 (index 1) style index.
-        /// </summary>
-        public const int Word2 = NativeMethods.SCE_LUA_WORD2;
-
-        /// <summary>
-        /// Keywords list 3 (index 2) style index.
-        /// </summary>
-        public const int Word3 = NativeMethods.SCE_LUA_WORD3;
-
-        /// <summary>
-        /// Keywords list 4 (index 3) style index.
-        /// </summary>
-        public const int Word4 = NativeMethods.SCE_LUA_WORD4;
-
-        /// <summary>
-        /// Keywords list 5 (index 4) style index.
-        /// </summary>
-        public const int Word5 = NativeMethods.SCE_LUA_WORD5;
-
-        /// <summary>
-        /// Keywords list 6 (index 5) style index.
-        /// </summary>
-        public const int Word6 = NativeMethods.SCE_LUA_WORD6;
-
-        /// <summary>
-        /// Keywords list 7 (index 6) style index.
-        /// </summary>
-        public const int Word7 = NativeMethods.SCE_LUA_WORD7;
-
-        /// <summary>
-        /// Keywords list 8 (index 7) style index.
-        /// </summary>
-        public const int Word8 = NativeMethods.SCE_LUA_WORD8;
-
-        /// <summary>
-        /// Label style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_LUA_LABEL;
-    }
-
-    #endregion Lua
-
-    #region Matlab
-
-    /// <summary>
-    /// Style constants for use with the Matlab lexer.
-    /// </summary>
-    public static class Matlab
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_MATLAB_DEFAULT;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_MATLAB_COMMENT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_MATLAB_NUMBER;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_MATLAB_STRING;
-
-        /// <summary>
-        /// Command style index.
-        /// </summary>
-        public const int Command = NativeMethods.SCE_MATLAB_COMMAND;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_MATLAB_KEYWORD;
-
-        /// <summary>
-        /// Double quote string style index.
-        /// </summary>
-        public const int DoubleQuoteString = NativeMethods.SCE_MATLAB_DOUBLEQUOTESTRING;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_MATLAB_IDENTIFIER;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_MATLAB_OPERATOR;
-    }
-
-    #endregion Matlab
-
-    #region Pascal
-
-    /// <summary>
-    /// Style constants for use with the Pascal lexer.
-    /// </summary>
-    public static class Pascal
-    {
-        /// <summary>
-        /// Default style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_PAS_DEFAULT;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_PAS_IDENTIFIER;
-
-        /// <summary>
-        /// Comment style '{' index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_PAS_COMMENT;
-
-        /// <summary>
-        /// Comment style 2 "(*" index.
-        /// </summary>
-        public const int Comment2 = NativeMethods.SCE_PAS_COMMENT2;
-
-        /// <summary>
-        /// Comment line style "//" index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_PAS_COMMENTLINE;
-
-        /// <summary>
-        /// Preprocessor style "{$" index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_PAS_PREPROCESSOR;
-
-        /// <summary>
-        /// Preprocessor style 2 "(*$" index.
-        /// </summary>
-        public const int Preprocessor2 = NativeMethods.SCE_PAS_PREPROCESSOR2;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_PAS_NUMBER;
-
-        /// <summary>
-        /// Hexadecimal number style index.
-        /// </summary>
-        public const int HexNumber = NativeMethods.SCE_PAS_HEXNUMBER;
-
-        /// <summary>
-        /// Word (keyword set 0) style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_PAS_WORD;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_PAS_STRING;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_PAS_STRINGEOL;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_PAS_CHARACTER;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_PAS_OPERATOR;
-
-        /// <summary>
-        /// Assembly style index.
-        /// </summary>
-        public const int Asm = NativeMethods.SCE_PAS_ASM;
-    }
-
-    #endregion Pascal
-
-    #region Perl
-
-    /// <summary>
-    /// Style constants for use with the Perl lexer.
-    /// </summary>
-    public static class Perl
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_PL_DEFAULT;
-
-        /// <summary>
-        /// Error style index.
-        /// </summary>
-        public const int Error = NativeMethods.SCE_PL_ERROR;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_PL_COMMENTLINE;
-
-        /// <summary>
-        /// POD style index.
-        /// </summary>
-        public const int Pod = NativeMethods.SCE_PL_POD;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_PL_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_PL_WORD;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_PL_STRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_PL_CHARACTER;
-
-        /// <summary>
-        /// Punctuation style index.
-        /// </summary>
-        public const int Punctuation = NativeMethods.SCE_PL_PUNCTUATION;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_PL_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_PL_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_PL_IDENTIFIER;
-
-        /// <summary>
-        /// Scalar style index.
-        /// </summary>
-        public const int Scalar = NativeMethods.SCE_PL_SCALAR;
-
-        /// <summary>
-        /// Array style index.
-        /// </summary>
-        public const int Array = NativeMethods.SCE_PL_ARRAY;
-
-        /// <summary>
-        /// Hash style index.
-        /// </summary>
-        public const int Hash = NativeMethods.SCE_PL_HASH;
-
-        /// <summary>
-        /// Symbol table style index.
-        /// </summary>
-        public const int SymbolTable = NativeMethods.SCE_PL_SYMBOLTABLE;
-
-        /// <summary>
-        /// Variable indexer index.
-        /// </summary>
-        public const int VariableIndexer = NativeMethods.SCE_PL_VARIABLE_INDEXER;
-
-        /// <summary>
-        /// Regular expression style index.
-        /// </summary>
-        public const int Regex = NativeMethods.SCE_PL_REGEX;
-
-        /// <summary>
-        /// RegSubst style index.
-        /// </summary>
-        public const int RegSubst = NativeMethods.SCE_PL_REGSUBST;
-
-        // public const int LongQuote = NativeMethods.SCE_PL_LONGQUOTE;
-
-        /// <summary>
-        /// Backtick (grave accent, backquote) style index.
-        /// </summary>
-        public const int BackTicks = NativeMethods.SCE_PL_BACKTICKS;
-
-        /// <summary>
-        /// Data section style index.
-        /// </summary>
-        public const int DataSection = NativeMethods.SCE_PL_DATASECTION;
-
-        /// <summary>
-        /// HereDoc delimiter style index.
-        /// </summary>
-        public const int HereDelim = NativeMethods.SCE_PL_HERE_DELIM;
-
-        /// <summary>
-        /// HereDoc single-quote style index.
-        /// </summary>
-        public const int HereQ = NativeMethods.SCE_PL_HERE_Q;
-
-        /// <summary>
-        /// HereDoc double-quote style index.
-        /// </summary>
-        public const int HereQq = NativeMethods.SCE_PL_HERE_QQ;
-
-        /// <summary>
-        /// HereDoc backtick style index.
-        /// </summary>
-        public const int HereQx = NativeMethods.SCE_PL_HERE_QX;
-
-        /// <summary>
-        /// Q quote style index.
-        /// </summary>
-        public const int StringQ = NativeMethods.SCE_PL_STRING_Q;
-
-        /// <summary>
-        /// QQ quote style index.
-        /// </summary>
-        public const int StringQq = NativeMethods.SCE_PL_STRING_QQ;
-
-        /// <summary>
-        /// QZ quote style index.
-        /// </summary>
-        public const int StringQx = NativeMethods.SCE_PL_STRING_QX;
-
-        /// <summary>
-        /// QR quote style index.
-        /// </summary>
-        public const int StringQr = NativeMethods.SCE_PL_STRING_QR;
-
-        /// <summary>
-        /// QW quote style index.
-        /// </summary>
-        public const int StringQw = NativeMethods.SCE_PL_STRING_QW;
-
-        /// <summary>
-        /// POD verbatim style index.
-        /// </summary>
-        public const int PodVerb = NativeMethods.SCE_PL_POD_VERB;
-
-        /// <summary>
-        /// Subroutine prototype style index.
-        /// </summary>
-        public const int SubPrototype = NativeMethods.SCE_PL_SUB_PROTOTYPE;
-
-        /// <summary>
-        /// Format identifier style index.
-        /// </summary>
-        public const int FormatIdent = NativeMethods.SCE_PL_FORMAT_IDENT;
-
-        /// <summary>
-        /// Format style index.
-        /// </summary>
-        public const int Format = NativeMethods.SCE_PL_FORMAT;
-
-        /// <summary>
-        /// String variable style index.
-        /// </summary>
-        public const int StringVar = NativeMethods.SCE_PL_STRING_VAR;
-
-        /// <summary>
-        /// XLAT style index.
-        /// </summary>
-        public const int XLat = NativeMethods.SCE_PL_XLAT;
-
-        /// <summary>
-        /// Regular expression variable style index.
-        /// </summary>
-        public const int RegexVar = NativeMethods.SCE_PL_REGEX_VAR;
-
-        /// <summary>
-        /// RegSubst variable style index.
-        /// </summary>
-        public const int RegSubstVar = NativeMethods.SCE_PL_REGSUBST_VAR;
-
-        /// <summary>
-        /// Backticks variable style index.
-        /// </summary>
-        public const int BackticksVar = NativeMethods.SCE_PL_BACKTICKS_VAR;
-
-        /// <summary>
-        /// HereDoc QQ quote variable style index.
-        /// </summary>
-        public const int HereQqVar = NativeMethods.SCE_PL_HERE_QQ_VAR;
-
-        /// <summary>
-        /// HereDoc QX quote variable style index.
-        /// </summary>
-        public const int HereQxVar = NativeMethods.SCE_PL_HERE_QX_VAR;
-
-        /// <summary>
-        /// QQ quote variable style index.
-        /// </summary>
-        public const int StringQqVar = NativeMethods.SCE_PL_STRING_QQ_VAR;
-
-        /// <summary>
-        /// QX quote variable style index.
-        /// </summary>
-        public const int StringQxVar = NativeMethods.SCE_PL_STRING_QX_VAR;
-
-        /// <summary>
-        /// QR quote variable style index.
-        /// </summary>
-        public const int StringQrVar = NativeMethods.SCE_PL_STRING_QR_VAR;
-    }
-
-    #endregion Perl
-
-    #region PhpScript
-
-    /// <summary>
-    /// Style constants for use with the PhpScript lexer.
-    /// </summary>
-    public static class PhpScript
-    {
-        /// <summary>
-        /// Complex Variable style index.
-        /// </summary>
-        public const int ComplexVariable = NativeMethods.SCE_HPHP_COMPLEX_VARIABLE;
-
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_HPHP_DEFAULT;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int HString = NativeMethods.SCE_HPHP_HSTRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int SimpleString = NativeMethods.SCE_HPHP_SIMPLESTRING;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_HPHP_WORD;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_HPHP_NUMBER;
-
-        /// <summary>
-        /// Variable style index.
-        /// </summary>
-        public const int Variable = NativeMethods.SCE_HPHP_VARIABLE;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_HPHP_COMMENT;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_HPHP_COMMENTLINE;
-
-        /// <summary>
-        /// Double-quoted string variable style index.
-        /// </summary>
-        public const int HStringVariable = NativeMethods.SCE_HPHP_HSTRING_VARIABLE;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_HPHP_OPERATOR;
-    }
-
-    #endregion PhpScript
-
-    #region PowerShell
-
-    /// <summary>
-    /// Style constants for use with the PowerShell lexer.
-    /// </summary>
-    public static class PowerShell
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_POWERSHELL_DEFAULT;
-
-        /// <summary>
-        /// Line comment style index
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_POWERSHELL_COMMENT;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_POWERSHELL_STRING;
-
-        /// <summary>
-        /// Character style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_POWERSHELL_CHARACTER;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_POWERSHELL_NUMBER;
-
-        /// <summary>
-        /// Variable style index.
-        /// </summary>
-        public const int Variable = NativeMethods.SCE_POWERSHELL_VARIABLE;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_POWERSHELL_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_POWERSHELL_IDENTIFIER;
-
-        /// <summary>
-        /// Keyword (set 0) style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_POWERSHELL_KEYWORD;
-
-        /// <summary>
-        /// Cmdlet (set 1) style index.
-        /// </summary>
-        public const int Cmdlet = NativeMethods.SCE_POWERSHELL_CMDLET;
-
-        /// <summary>
-        /// Alias (set 2) style index.
-        /// </summary>
-        public const int Alias = NativeMethods.SCE_POWERSHELL_ALIAS;
-
-        /// <summary>
-        /// Function (set 3) style index.
-        /// </summary>
-        public const int Function = NativeMethods.SCE_POWERSHELL_FUNCTION;
-
-        /// <summary>
-        /// User word (set 4) style index.
-        /// </summary>
-        public const int User1 = NativeMethods.SCE_POWERSHELL_USER1;
-
-        /// <summary>
-        /// Multi-line comment style index.
-        /// </summary>
-        public const int CommentStream = NativeMethods.SCE_POWERSHELL_COMMENTSTREAM;
-
-        /// <summary>
-        /// Here string style index.
-        /// </summary>
-        public const int HereString = NativeMethods.SCE_POWERSHELL_HERE_STRING;
-
-        /// <summary>
-        /// Here character style index.
-        /// </summary>
-        public const int HereCharacter = NativeMethods.SCE_POWERSHELL_HERE_CHARACTER;
-
-        /// <summary>
-        /// Comment based help keyword style index.
-        /// </summary>
-        public const int CommentDocKeyword = NativeMethods.SCE_POWERSHELL_COMMENTDOCKEYWORD;
-    }
-
-    #endregion PowerShell
-
-    #region Properties
-
-    /// <summary>
-    /// Style constants for use with the Properties lexer.
-    /// </summary>
-    public static class Properties
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_PROPS_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_PROPS_COMMENT;
-
-        /// <summary>
-        /// Section style index.
-        /// </summary>
-        public const int Section = NativeMethods.SCE_PROPS_SECTION;
-
-        /// <summary>
-        /// Assignment operator index.
-        /// </summary>
-        public const int Assignment = NativeMethods.SCE_PROPS_ASSIGNMENT;
-
-        /// <summary>
-        /// Default (registry-only) value index.
-        /// </summary>
-        public const int DefVal = NativeMethods.SCE_PROPS_DEFVAL;
-
-        /// <summary>
-        /// Key style index.
-        /// </summary>
-        public const int Key = NativeMethods.SCE_PROPS_KEY;
-    }
-
-    #endregion Properties
-
-    #region PureBasic
-
-    /// <summary>
-    /// Style constants for use with the PureBasic lexer.
-    /// </summary>
-    public static class PureBasic
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_B_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_B_COMMENT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_B_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_B_KEYWORD;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_B_STRING;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_B_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
-
-        /// <summary>
-        /// Date style index.
-        /// </summary>
-        public const int Date = NativeMethods.SCE_B_DATE;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
-
-        /// <summary>
-        /// Keyword list 2 (index 1) style index.
-        /// </summary>
-        public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
-
-        /// <summary>
-        /// Keyword list 3 (index 2) style index.
-        /// </summary>
-        public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
-
-        /// <summary>
-        /// Keyword list 4 (index 3) style index.
-        /// </summary>
-        public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
-
-        /// <summary>
-        /// Constant style index.
-        /// </summary>
-        public const int Constant = NativeMethods.SCE_B_CONSTANT;
-
-        /// <summary>
-        /// Inline assembler style index.
-        /// </summary>
-        public const int Asm = NativeMethods.SCE_B_ASM;
-
-        /// <summary>
-        /// Label style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_B_LABEL;
-
-        /// <summary>
-        /// Error style index.
-        /// </summary>
-        public const int Error = NativeMethods.SCE_B_ERROR;
-
-        /// <summary>
-        /// Hexadecimal number style index.
-        /// </summary>
-        public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
-
-        /// <summary>
-        /// Binary number style index.
-        /// </summary>
-        public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
-
-        /// <summary>
-        /// Block comment style index.
-        /// </summary>
-        public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
-
-        /// <summary>
-        /// Documentation line style index.
-        /// </summary>
-        public const int DocLine = NativeMethods.SCE_B_DOCLINE;
-
-        /// <summary>
-        /// Documentation block style index.
-        /// </summary>
-        public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
-
-        /// <summary>
-        /// Documentation keyword style index.
-        /// </summary>
-        public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
-    }
-
-    #endregion PureBasic
-
-    #region Python
-
-    /// <summary>
-    /// Style constants for use with the Python lexer.
-    /// </summary>
-    public static class Python
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_P_DEFAULT;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_P_COMMENTLINE;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_P_NUMBER;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_P_STRING;
-
-        /// <summary>
-        /// Single-quote style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_P_CHARACTER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_P_WORD;
-
-        /// <summary>
-        /// Triple single-quote style index.
-        /// </summary>
-        public const int Triple = NativeMethods.SCE_P_TRIPLE;
-
-        /// <summary>
-        /// Triple double-quote style index.
-        /// </summary>
-        public const int TripleDouble = NativeMethods.SCE_P_TRIPLEDOUBLE;
-
-        /// <summary>
-        /// Class name style index.
-        /// </summary>
-        public const int ClassName = NativeMethods.SCE_P_CLASSNAME;
-
-        /// <summary>
-        /// Function or method name style index.
-        /// </summary>
-        public const int DefName = NativeMethods.SCE_P_DEFNAME;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_P_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_P_IDENTIFIER;
-
-        /// <summary>
-        /// Block comment style index.
-        /// </summary>
-        public const int CommentBlock = NativeMethods.SCE_P_COMMENTBLOCK;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_P_STRINGEOL;
-
-        /// <summary>
-        /// Keyword style 2 index.
-        /// </summary>
-        public const int Word2 = NativeMethods.SCE_P_WORD2;
-
-        /// <summary>
-        /// Decorator style index.
-        /// </summary>
-        public const int Decorator = NativeMethods.SCE_P_DECORATOR;
-    }
-
-    #endregion Python
-
-    #region Ruby
-
-    /// <summary>
-    /// Style constants for use with the Ruby lexer.
-    /// </summary>
-    public static class Ruby
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_RB_DEFAULT;
-
-        /// <summary>
-        /// Error style index.
-        /// </summary>
-        public const int Error = NativeMethods.SCE_RB_ERROR;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_RB_COMMENTLINE;
-
-        /// <summary>
-        /// POD style index.
-        /// </summary>
-        public const int Pod = NativeMethods.SCE_RB_POD;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_RB_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_RB_WORD;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_RB_STRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_RB_CHARACTER;
-
-        /// <summary>
-        /// Class name style index.
-        /// </summary>
-        public const int ClassName = NativeMethods.SCE_RB_CLASSNAME;
-
-        /// <summary>
-        /// Definition style index.
-        /// </summary>
-        public const int DefName = NativeMethods.SCE_RB_DEFNAME;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_RB_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_RB_IDENTIFIER;
-
-        /// <summary>
-        /// Regular expression style index.
-        /// </summary>
-        public const int Regex = NativeMethods.SCE_RB_REGEX;
-
-        /// <summary>
-        /// Global style index.
-        /// </summary>
-        public const int Global = NativeMethods.SCE_RB_GLOBAL;
-
-        /// <summary>
-        /// Symbol style index.
-        /// </summary>
-        public const int Symbol = NativeMethods.SCE_RB_SYMBOL;
-
-        /// <summary>
-        /// Module name style index.
-        /// </summary>
-        public const int ModuleName = NativeMethods.SCE_RB_MODULE_NAME;
-
-        /// <summary>
-        /// Instance variable style index.
-        /// </summary>
-        public const int InstanceVar = NativeMethods.SCE_RB_INSTANCE_VAR;
-
-        /// <summary>
-        /// Class variable style index.
-        /// </summary>
-        public const int ClassVar = NativeMethods.SCE_RB_CLASS_VAR;
-
-        /// <summary>
-        /// Backticks style index.
-        /// </summary>
-        public const int BackTicks = NativeMethods.SCE_RB_BACKTICKS;
-
-        /// <summary>
-        /// Data section style index.
-        /// </summary>
-        public const int DataSection = NativeMethods.SCE_RB_DATASECTION;
-
-        /// <summary>
-        /// HereDoc delimiter style index.
-        /// </summary>
-        public const int HereDelim = NativeMethods.SCE_RB_HERE_DELIM;
-
-        /// <summary>
-        /// HereDoc Q quote style index.
-        /// </summary>
-        public const int HereQ = NativeMethods.SCE_RB_HERE_Q;
-
-        /// <summary>
-        /// HereDoc QQ quote style index.
-        /// </summary>
-        public const int HereQq = NativeMethods.SCE_RB_HERE_QQ;
-
-        /// <summary>
-        /// HereDoc QX quote style index.
-        /// </summary>
-        public const int HereQx = NativeMethods.SCE_RB_HERE_QX;
-
-        /// <summary>
-        /// Q quote string style index.
-        /// </summary>
-        public const int StringQ = NativeMethods.SCE_RB_STRING_Q;
-
-        /// <summary>
-        /// QQ quote string style index.
-        /// </summary>
-        public const int StringQq = NativeMethods.SCE_RB_STRING_QQ;
-
-        /// <summary>
-        /// QX quote string style index.
-        /// </summary>
-        public const int StringQx = NativeMethods.SCE_RB_STRING_QX;
-
-        /// <summary>
-        /// QR quote string style index.
-        /// </summary>
-        public const int StringQr = NativeMethods.SCE_RB_STRING_QR;
-
-        /// <summary>
-        /// QW quote style index.
-        /// </summary>
-        public const int StringQw = NativeMethods.SCE_RB_STRING_QW;
-
-        /// <summary>
-        /// Demoted keyword style index.
-        /// </summary>
-        public const int WordDemoted = NativeMethods.SCE_RB_WORD_DEMOTED;
-
-        /// <summary>
-        /// Standard-in style index.
-        /// </summary>
-        public const int StdIn = NativeMethods.SCE_RB_STDIN;
-
-        /// <summary>
-        /// Standard-out style index.
-        /// </summary>
-        public const int StdOut = NativeMethods.SCE_RB_STDOUT;
-
-        /// <summary>
-        /// Standard-error style index.
-        /// </summary>
-        public const int StdErr = NativeMethods.SCE_RB_STDERR;
-
-        // public const int UpperBound = NativeMethods.SCE_RB_UPPER_BOUND;
-    }
-
-    #endregion Ruby
-
-    #region Smalltalk
-
-    /// <summary>
-    /// Style constants for use with the Smalltalk lexer.
-    /// </summary>
-    public static class Smalltalk
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_ST_DEFAULT;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_ST_STRING;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_ST_NUMBER;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_ST_COMMENT;
-
-        /// <summary>
-        /// Symbol style index.
-        /// </summary>
-        public const int Symbol = NativeMethods.SCE_ST_SYMBOL;
-
-        /// <summary>
-        /// Binary style index.
-        /// </summary>
-        public const int Binary = NativeMethods.SCE_ST_BINARY;
-
-        /// <summary>
-        /// Bool style index.
-        /// </summary>
-        public const int Bool = NativeMethods.SCE_ST_BOOL;
-
-        /// <summary>
-        /// Self style index.
-        /// </summary>
-        public const int Self = NativeMethods.SCE_ST_SELF;
-
-        /// <summary>
-        /// Super style index.
-        /// </summary>
-        public const int Super = NativeMethods.SCE_ST_SUPER;
-
-        /// <summary>
-        /// NIL style index.
-        /// </summary>
-        public const int Nil = NativeMethods.SCE_ST_NIL;
-
-        /// <summary>
-        /// Global style index.
-        /// </summary>
-        public const int Global = NativeMethods.SCE_ST_GLOBAL;
-
-        /// <summary>
-        /// Return style index.
-        /// </summary>
-        public const int Return = NativeMethods.SCE_ST_RETURN;
-
-        /// <summary>
-        /// Special style index.
-        /// </summary>
-        public const int Special = NativeMethods.SCE_ST_SPECIAL;
-
-        /// <summary>
-        /// KWS End style index.
-        /// </summary>
-        public const int KwsEnd = NativeMethods.SCE_ST_KWSEND;
-
-        /// <summary>
-        /// Assign style index.
-        /// </summary>
-        public const int Assign = NativeMethods.SCE_ST_ASSIGN;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_ST_CHARACTER;
-
-        /// <summary>
-        /// Special selector style index.
-        /// </summary>
-        public const int SpecSel = NativeMethods.SCE_ST_SPEC_SEL;
-    }
-
-    #endregion Smalltalk
-
-    #region Sql
-
-    /// <summary>
-    /// Style constants for use with the Sql lexer.
-    /// </summary>
-    public static class Sql
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_SQL_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_SQL_COMMENT;
-
-        /// <summary>
-        /// Line comment style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_SQL_COMMENTLINE;
-
-        /// <summary>
-        /// Documentation comment style index.
-        /// </summary>
-        public const int CommentDoc = NativeMethods.SCE_SQL_COMMENTDOC;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_SQL_NUMBER;
-
-        /// <summary>
-        /// Keyword list 1 (index 0) style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_SQL_WORD;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_SQL_STRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int Character = NativeMethods.SCE_SQL_CHARACTER;
-
-        /// <summary>
-        /// Keyword from the SQL*Plus list (index 3) style index.
-        /// </summary>
-        public const int SqlPlus = NativeMethods.SCE_SQL_SQLPLUS;
-
-        /// <summary>
-        /// SQL*Plus prompt style index.
-        /// </summary>
-        public const int SqlPlusPrompt = NativeMethods.SCE_SQL_SQLPLUS_PROMPT;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_SQL_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_SQL_IDENTIFIER;
-
-        /// <summary>
-        /// SQL*Plus comment style index.
-        /// </summary>
-        public const int SqlPlusComment = NativeMethods.SCE_SQL_SQLPLUS_COMMENT;
-
-        /// <summary>
-        /// Documentation line comment style index.
-        /// </summary>
-        public const int CommentLineDoc = NativeMethods.SCE_SQL_COMMENTLINEDOC;
-
-        /// <summary>
-        /// Keyword list 2 (index 1) style index.
-        /// </summary>
-        public const int Word2 = NativeMethods.SCE_SQL_WORD2;
-
-        /// <summary>
-        /// Documentation (Doxygen) keyword style index.
-        /// </summary>
-        public const int CommentDocKeyword = NativeMethods.SCE_SQL_COMMENTDOCKEYWORD;
-
-        /// <summary>
-        /// Documentation (Doxygen) keyword error style index.
-        /// </summary>
-        public const int CommentDocKeywordError = NativeMethods.SCE_SQL_COMMENTDOCKEYWORDERROR;
-
-        /// <summary>
-        /// Keyword user-list 1 (index 4) style index.
-        /// </summary>
-        public const int User1 = NativeMethods.SCE_SQL_USER1;
-
-        /// <summary>
-        /// Keyword user-list 2 (index 5) style index.
-        /// </summary>
-        public const int User2 = NativeMethods.SCE_SQL_USER2;
-
-        /// <summary>
-        /// Keyword user-list 3 (index 6) style index.
-        /// </summary>
-        public const int User3 = NativeMethods.SCE_SQL_USER3;
-
-        /// <summary>
-        /// Keyword user-list 4 (index 7) style index.
-        /// </summary>
-        public const int User4 = NativeMethods.SCE_SQL_USER4;
-
-        /// <summary>
-        /// Quoted identifier style index.
-        /// </summary>
-        public const int QuotedIdentifier = NativeMethods.SCE_SQL_QUOTEDIDENTIFIER;
-
-        /// <summary>
-        /// Q operator style index.
-        /// </summary>
-        public const int QOperator = NativeMethods.SCE_SQL_QOPERATOR;
-    }
-
-    #endregion Sql
-
-    #region Markdown
-
-    /// <summary>
-    /// Style constants for use with the Markdown lexer.
-    /// </summary>
-    public static class Markdown
-    {
-        /// <summary>
-        /// Default text style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_MARKDOWN_DEFAULT;
-
-        /// <summary>
-        /// Line begin style index.
-        /// </summary>
-        public const int LineBegin = NativeMethods.SCE_MARKDOWN_LINE_BEGIN;
-
-        /// <summary>
-        /// Strong type 1 style index.
-        /// </summary>
-        public const int Strong1 = NativeMethods.SCE_MARKDOWN_STRONG1;
-
-        /// <summary>
-        /// Strong type 2 style index.
-        /// </summary>
-        public const int Strong2 = NativeMethods.SCE_MARKDOWN_STRONG2;
-
-        /// <summary>
-        /// Empasis type 1 style index.
-        /// </summary>
-        public const int Em1 = NativeMethods.SCE_MARKDOWN_EM1;
-
-        /// <summary>
-        /// Empasis type 2 style index.
-        /// </summary>
-        public const int Em2 = NativeMethods.SCE_MARKDOWN_EM2;
-
-        /// <summary>
-        /// Header type 1 style index.
-        /// </summary>
-        public const int Header1 = NativeMethods.SCE_MARKDOWN_HEADER1;
-
-        /// <summary>
-        /// Header type 2 style index.
-        /// </summary>
-        public const int Header2 = NativeMethods.SCE_MARKDOWN_HEADER2;
-
-        /// <summary>
-        /// Header type 3 style index.
-        /// </summary>
-        public const int Header3 = NativeMethods.SCE_MARKDOWN_HEADER3;
-
-        /// <summary>
-        /// Header type 4 style index.
-        /// </summary>
-        public const int Header4 = NativeMethods.SCE_MARKDOWN_HEADER4;
-
-        /// <summary>
-        /// Header type 5 style index.
-        /// </summary>
-        public const int Header5 = NativeMethods.SCE_MARKDOWN_HEADER5;
-
-        /// <summary>
-        /// Header type 6 style index.
-        /// </summary>
-        public const int Header6 = NativeMethods.SCE_MARKDOWN_HEADER6;
-
-        /// <summary>
-        /// Pre char style index.
-        /// </summary>
-        public const int PreChar = NativeMethods.SCE_MARKDOWN_PRECHAR;
-
-        /// <summary>
-        /// Unordered list style index.
-        /// </summary>
-        public const int UListItem = NativeMethods.SCE_MARKDOWN_ULIST_ITEM;
-
-        /// <summary>
-        /// Ordered list style index.
-        /// </summary>
-        public const int OListItem = NativeMethods.SCE_MARKDOWN_OLIST_ITEM;
-
-        /// <summary>
-        /// Blockquote style index.
-        /// </summary>
-        public const int BlockQuote = NativeMethods.SCE_MARKDOWN_BLOCKQUOTE;
-
-        /// <summary>
-        /// Strikeout style index.
-        /// </summary>
-        public const int Strikeout = NativeMethods.SCE_MARKDOWN_STRIKEOUT;
-
-        /// <summary>
-        /// Horizontal rule style index.
-        /// </summary>
-        public const int HRule = NativeMethods.SCE_MARKDOWN_HRULE;
-
-        /// <summary>
-        /// Link style index.
-        /// </summary>
-        public const int Link = NativeMethods.SCE_MARKDOWN_LINK;
-
-        /// <summary>
-        /// Code type 1 style index.
-        /// </summary>
-        public const int Code = NativeMethods.SCE_MARKDOWN_CODE;
-
-        /// <summary>
-        /// Code type 2 style index.
-        /// </summary>
-        public const int Code2 = NativeMethods.SCE_MARKDOWN_CODE2;
-
-        /// <summary>
-        /// Code block style index.
-        /// </summary>
-        public const int CodeBk = NativeMethods.SCE_MARKDOWN_CODEBK;
-    }
-
-    #endregion Markdown
-
-    #region R
-
-    /// <summary>
-    /// Style constants for use with the R lexer.
-    /// </summary>
-    public static class R
-    {
-        /// <summary>
-        /// Default style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_R_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_R_COMMENT;
-
-        /// <summary>
-        /// Keyword (set 0) style index.
-        /// </summary>
-        public const int KWord = NativeMethods.SCE_R_KWORD;
-
-        /// <summary>
-        /// Base keyword (set 1) style index.
-        /// </summary>
-        public const int BaseKWord = NativeMethods.SCE_R_BASEKWORD;
-
-        /// <summary>
-        /// Other keyword (set 2) style index.
-        /// </summary>
-        public const int OtherKWord = NativeMethods.SCE_R_OTHERKWORD;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_R_NUMBER;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_R_STRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int String2 = NativeMethods.SCE_R_STRING2;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_R_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_R_IDENTIFIER;
-
-        /// <summary>
-        /// Infix style index.
-        /// </summary>
-        public const int Infix = NativeMethods.SCE_R_INFIX;
-
-        /// <summary>
-        /// Unclosed infix EOL style index.
-        /// </summary>
-        public const int InfixEol = NativeMethods.SCE_R_INFIXEOL;
-    }
-
-    #endregion R
-
-    #region Vb
-
-    /// <summary>
-    /// Style constants for use with the Vb lexer.
-    /// </summary>
-    public static class Vb
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_B_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_B_COMMENT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_B_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_B_KEYWORD;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_B_STRING;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_B_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
-
-        /// <summary>
-        /// Date style index.
-        /// </summary>
-        public const int Date = NativeMethods.SCE_B_DATE;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
-
-        /// <summary>
-        /// Keyword list 2 (index 1) style index.
-        /// </summary>
-        public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
-
-        /// <summary>
-        /// Keyword list 3 (index 2) style index.
-        /// </summary>
-        public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
-
-        /// <summary>
-        /// Keyword list 4 (index 3) style index.
-        /// </summary>
-        public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
-
-        /// <summary>
-        /// Constant style index.
-        /// </summary>
-        public const int Constant = NativeMethods.SCE_B_CONSTANT;
-
-        /// <summary>
-        /// Inline assembler style index.
-        /// </summary>
-        public const int Asm = NativeMethods.SCE_B_ASM;
-
-        /// <summary>
-        /// Label style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_B_LABEL;
-
-        /// <summary>
-        /// Error style index.
-        /// </summary>
-        public const int Error = NativeMethods.SCE_B_ERROR;
-
-        /// <summary>
-        /// Hexadecimal number style index.
-        /// </summary>
-        public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
-
-        /// <summary>
-        /// Binary number style index.
-        /// </summary>
-        public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
-
-        /// <summary>
-        /// Block comment style index.
-        /// </summary>
-        public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
-
-        /// <summary>
-        /// Documentation line style index.
-        /// </summary>
-        public const int DocLine = NativeMethods.SCE_B_DOCLINE;
-
-        /// <summary>
-        /// Documentation block style index.
-        /// </summary>
-        public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
-
-        /// <summary>
-        /// Documentation keyword style index.
-        /// </summary>
-        public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
-    }
-
-    #endregion Vb
-
-    #region VbScript
-
-    /// <summary>
-    /// Style constants for use with the VbScript lexer.
-    /// </summary>
-    public static class VbScript
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_B_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_B_COMMENT;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_B_NUMBER;
-
-        /// <summary>
-        /// Keyword style index.
-        /// </summary>
-        public const int Keyword = NativeMethods.SCE_B_KEYWORD;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_B_STRING;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_B_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_B_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_B_IDENTIFIER;
-
-        /// <summary>
-        /// Date style index.
-        /// </summary>
-        public const int Date = NativeMethods.SCE_B_DATE;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_B_STRINGEOL;
-
-        /// <summary>
-        /// Keyword list 2 (index 1) style index.
-        /// </summary>
-        public const int Keyword2 = NativeMethods.SCE_B_KEYWORD2;
-
-        /// <summary>
-        /// Keyword list 3 (index 2) style index.
-        /// </summary>
-        public const int Keyword3 = NativeMethods.SCE_B_KEYWORD3;
-
-        /// <summary>
-        /// Keyword list 4 (index 3) style index.
-        /// </summary>
-        public const int Keyword4 = NativeMethods.SCE_B_KEYWORD4;
-
-        /// <summary>
-        /// Constant style index.
-        /// </summary>
-        public const int Constant = NativeMethods.SCE_B_CONSTANT;
-
-        /// <summary>
-        /// Inline assembler style index.
-        /// </summary>
-        public const int Asm = NativeMethods.SCE_B_ASM;
-
-        /// <summary>
-        /// Label style index.
-        /// </summary>
-        public const int Label = NativeMethods.SCE_B_LABEL;
-
-        /// <summary>
-        /// Error style index.
-        /// </summary>
-        public const int Error = NativeMethods.SCE_B_ERROR;
-
-        /// <summary>
-        /// Hexadecimal number style index.
-        /// </summary>
-        public const int HexNumber = NativeMethods.SCE_B_HEXNUMBER;
-
-        /// <summary>
-        /// Binary number style index.
-        /// </summary>
-        public const int BinNumber = NativeMethods.SCE_B_BINNUMBER;
-
-        /// <summary>
-        /// Block comment style index.
-        /// </summary>
-        public const int CommentBlock = NativeMethods.SCE_B_COMMENTBLOCK;
-
-        /// <summary>
-        /// Documentation line style index.
-        /// </summary>
-        public const int DocLine = NativeMethods.SCE_B_DOCLINE;
-
-        /// <summary>
-        /// Documentation block style index.
-        /// </summary>
-        public const int DocBlock = NativeMethods.SCE_B_DOCBLOCK;
-
-        /// <summary>
-        /// Documentation keyword style index.
-        /// </summary>
-        public const int DocKeyword = NativeMethods.SCE_B_DOCKEYWORD;
-    }
-
-    #endregion VbScript
-
-    #region Verilog
-
-    /// <summary>
-    /// Style constants for use with the Verilog lexer.
-    /// </summary>
-    public static class Verilog
-    {
-        /// <summary>
-        /// Default (whitespace) style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_V_DEFAULT;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_V_COMMENT;
-
-        /// <summary>
-        /// Comment line style index.
-        /// </summary>
-        public const int CommentLine = NativeMethods.SCE_V_COMMENTLINE;
-
-        /// <summary>
-        /// Comment line bang (exclamation) style index.
-        /// </summary>
-        public const int CommentLineBang = NativeMethods.SCE_V_COMMENTLINEBANG;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_V_NUMBER;
-
-        /// <summary>
-        /// Keyword (set 0) style index.
-        /// </summary>
-        public const int Word = NativeMethods.SCE_V_WORD;
-
-        /// <summary>
-        /// String style index.
-        /// </summary>
-        public const int String = NativeMethods.SCE_V_STRING;
-
-        /// <summary>
-        /// Keyword (set 1) style index.
-        /// </summary>
-        public const int Word2 = NativeMethods.SCE_V_WORD2;
-
-        /// <summary>
-        /// Keyword (set 2) style index.
-        /// </summary>
-        public const int Word3 = NativeMethods.SCE_V_WORD3;
-
-        /// <summary>
-        /// Preprocessor style index.
-        /// </summary>
-        public const int Preprocessor = NativeMethods.SCE_V_PREPROCESSOR;
-
-        /// <summary>
-        /// Operator style index.
-        /// </summary>
-        public const int Operator = NativeMethods.SCE_V_OPERATOR;
-
-        /// <summary>
-        /// Identifier style index.
-        /// </summary>
-        public const int Identifier = NativeMethods.SCE_V_IDENTIFIER;
-
-        /// <summary>
-        /// Unclosed string EOL style index.
-        /// </summary>
-        public const int StringEol = NativeMethods.SCE_V_STRINGEOL;
-
-        /// <summary>
-        /// User word (set 3) style index.
-        /// </summary>
-        public const int User = NativeMethods.SCE_V_USER;
-
-        /// <summary>
-        /// Comment word (set 4) style index.
-        /// </summary>
-        public const int CommentWord = NativeMethods.SCE_V_COMMENT_WORD;
-
-        /// <summary>
-        /// Input style index.
-        /// </summary>
-        public const int Input = NativeMethods.SCE_V_INPUT;
-
-        /// <summary>
-        /// Output style index.
-        /// </summary>
-        public const int Output = NativeMethods.SCE_V_OUTPUT;
-
-        /// <summary>
-        /// In-out style index.
-        /// </summary>
-        public const int InOut = NativeMethods.SCE_V_INOUT;
-
-        /// <summary>
-        /// Port connect style index.
-        /// </summary>
-        public const int PortConnect = NativeMethods.SCE_V_PORT_CONNECT;
-    }
-
-    #endregion Verilog
-
-    #region Xml
-
-    /// <summary>
-    /// Style constants for use with the Xml lexer.
-    /// </summary>
-    public static class Xml
-    {
-        /// <summary>
-        /// Content style index.
-        /// </summary>
-        public const int Default = NativeMethods.SCE_H_DEFAULT;
-
-        /// <summary>
-        /// Tag style index.
-        /// </summary>
-        public const int Tag = NativeMethods.SCE_H_TAG;
-
-        /// <summary>
-        /// Unknown tag style index.
-        /// </summary>
-        public const int TagUnknown = NativeMethods.SCE_H_TAGUNKNOWN;
-
-        /// <summary>
-        /// Attribute style index.
-        /// </summary>
-        public const int Attribute = NativeMethods.SCE_H_ATTRIBUTE;
-
-        /// <summary>
-        /// Unknown attribute style index.
-        /// </summary>
-        public const int AttributeUnknown = NativeMethods.SCE_H_ATTRIBUTEUNKNOWN;
-
-        /// <summary>
-        /// Number style index.
-        /// </summary>
-        public const int Number = NativeMethods.SCE_H_NUMBER;
-
-        /// <summary>
-        /// Double-quoted string style index.
-        /// </summary>
-        public const int DoubleString = NativeMethods.SCE_H_DOUBLESTRING;
-
-        /// <summary>
-        /// Single-quoted string style index.
-        /// </summary>
-        public const int SingleString = NativeMethods.SCE_H_SINGLESTRING;
-
-        /// <summary>
-        /// Other tag content (not elements or attributes) style index.
-        /// </summary>
-        public const int Other = NativeMethods.SCE_H_OTHER;
-
-        /// <summary>
-        /// Comment style index.
-        /// </summary>
-        public const int Comment = NativeMethods.SCE_H_COMMENT;
-
-        /// <summary>
-        /// Entity ($nnn;) name style index.
-        /// </summary>
-        public const int Entity = NativeMethods.SCE_H_ENTITY;
-
-        /// <summary>
-        /// End-tag style index.
-        /// </summary>
-        public const int TagEnd = NativeMethods.SCE_H_TAGEND;
-
-        /// <summary>
-        /// Start of XML declaration (&lt;?xml&gt;) style index.
-        /// </summary>
-        public const int XmlStart = NativeMethods.SCE_H_XMLSTART;
-
-        /// <summary>
-        /// End of XML declaration (?&gt;) style index.
-        /// </summary>
-        public const int XmlEnd = NativeMethods.SCE_H_XMLEND;
-
-        /// <summary>
-        /// Script tag (&lt;script&gt;) style index.
-        /// </summary>
-        public const int Script = NativeMethods.SCE_H_SCRIPT;
-
-        /// <summary>
-        /// ASP-like script engine block (&lt;%) style index.
-        /// </summary>
-        public const int Asp = NativeMethods.SCE_H_ASP;
-
-        /// <summary>
-        /// ASP-like language declaration (&lt;%@) style index.
-        /// </summary>
-        public const int AspAt = NativeMethods.SCE_H_ASPAT;
-
-        /// <summary>
-        /// CDATA section style index.
-        /// </summary>
-        public const int CData = NativeMethods.SCE_H_CDATA;
-
-        /// <summary>
-        /// Question mark style index.
-        /// </summary>
-        public const int Question = NativeMethods.SCE_H_QUESTION;
-
-        /// <summary>
-        /// Value style index.
-        /// </summary>
-        public const int Value = NativeMethods.SCE_H_VALUE;
-
-        /// <summary>
-        /// Script engine comment (&lt;%--) style index.
-        /// </summary>
-        public const int XcComment = NativeMethods.SCE_H_XCCOMMENT;
-    }
-
-    #endregion Xml
 }

--- a/Scintilla.NET/StyleCase.cs
+++ b/Scintilla.NET/StyleCase.cs
@@ -1,27 +1,28 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The possible casing styles of a style.
-/// </summary>
-public enum StyleCase
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Display the text normally.
+    /// The possible casing styles of a style.
     /// </summary>
-    Mixed = NativeMethods.SC_CASE_MIXED,
+    public enum StyleCase
+    {
+        /// <summary>
+        /// Display the text normally.
+        /// </summary>
+        Mixed = NativeMethods.SC_CASE_MIXED,
 
-    /// <summary>
-    /// Display the text in upper case.
-    /// </summary>
-    Upper = NativeMethods.SC_CASE_UPPER,
+        /// <summary>
+        /// Display the text in upper case.
+        /// </summary>
+        Upper = NativeMethods.SC_CASE_UPPER,
 
-    /// <summary>
-    /// Display the text in lower case.
-    /// </summary>
-    Lower = NativeMethods.SC_CASE_LOWER,
+        /// <summary>
+        /// Display the text in lower case.
+        /// </summary>
+        Lower = NativeMethods.SC_CASE_LOWER,
 
-    /// <summary>
-    /// Display the text in camel case.
-    /// </summary>
-    Camel = NativeMethods.SC_CASE_CAMEL
+        /// <summary>
+        /// Display the text in camel case.
+        /// </summary>
+        Camel = NativeMethods.SC_CASE_CAMEL
+    }
 }

--- a/Scintilla.NET/StyleCollection.cs
+++ b/Scintilla.NET/StyleCollection.cs
@@ -1,66 +1,67 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// An immutable collection of style definitions in a <see cref="Scintilla" /> control.
-/// </summary>
-public class StyleCollection : IEnumerable<Style>
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-
     /// <summary>
-    /// Provides an enumerator that iterates through the collection.
+    /// An immutable collection of style definitions in a <see cref="Scintilla" /> control.
     /// </summary>
-    /// <returns>An object that contains all <see cref="Style" /> objects within the <see cref="StyleCollection" />.</returns>
-    public IEnumerator<Style> GetEnumerator()
+    public class StyleCollection : IEnumerable<Style>
     {
-        int count = Count;
-        for (int i = 0; i < count; i++)
-            yield return this[i];
+        private readonly Scintilla scintilla;
 
-        yield break;
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    /// <summary>
-    /// Gets the number of styles.
-    /// </summary>
-    /// <returns>The number of styles in the <see cref="StyleCollection" />.</returns>
-    public int Count
-    {
-        get
+        /// <summary>
+        /// Provides an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An object that contains all <see cref="Style" /> objects within the <see cref="StyleCollection" />.</returns>
+        public IEnumerator<Style> GetEnumerator()
         {
-            return NativeMethods.STYLE_MAX + 1;
-        }
-    }
+            int count = Count;
+            for (int i = 0; i < count; i++)
+                yield return this[i];
 
-    /// <summary>
-    /// Gets a <see cref="Style" /> object at the specified index.
-    /// </summary>
-    /// <param name="index">The style definition index.</param>
-    /// <returns>An object representing the style definition at the specified <paramref name="index" />.</returns>
-    /// <remarks>Styles 32 through 39 have special significance.</remarks>
-    public Style this[int index]
-    {
-        get
+            yield break;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            index = Helpers.Clamp(index, 0, Count - 1);
-            return new Style(this.scintilla, index);
+            return GetEnumerator();
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="StyleCollection" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
-    public StyleCollection(Scintilla scintilla)
-    {
-        this.scintilla = scintilla;
+        /// <summary>
+        /// Gets the number of styles.
+        /// </summary>
+        /// <returns>The number of styles in the <see cref="StyleCollection" />.</returns>
+        public int Count
+        {
+            get
+            {
+                return NativeMethods.STYLE_MAX + 1;
+            }
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Style" /> object at the specified index.
+        /// </summary>
+        /// <param name="index">The style definition index.</param>
+        /// <returns>An object representing the style definition at the specified <paramref name="index" />.</returns>
+        /// <remarks>Styles 32 through 39 have special significance.</remarks>
+        public Style this[int index]
+        {
+            get
+            {
+                index = Helpers.Clamp(index, 0, Count - 1);
+                return new Style(this.scintilla, index);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StyleCollection" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that created this collection.</param>
+        public StyleCollection(Scintilla scintilla)
+        {
+            this.scintilla = scintilla;
+        }
     }
 }

--- a/Scintilla.NET/StyleNeededEventArgs.cs
+++ b/Scintilla.NET/StyleNeededEventArgs.cs
@@ -1,39 +1,40 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.StyleNeeded" /> event.
-/// </summary>
-public class StyleNeededEventArgs : EventArgs
+namespace ScintillaNET
 {
-    private readonly Scintilla scintilla;
-    private readonly int bytePosition;
-    private int? position;
-
     /// <summary>
-    /// Gets the document position where styling should end. The <see cref="Scintilla.GetEndStyled" /> method
-    /// indicates the last position styled correctly and the starting place for where styling should begin.
+    /// Provides data for the <see cref="Scintilla.StyleNeeded" /> event.
     /// </summary>
-    /// <returns>The zero-based position within the document to perform styling up to.</returns>
-    public int Position
+    public class StyleNeededEventArgs : EventArgs
     {
-        get
+        private readonly Scintilla scintilla;
+        private readonly int bytePosition;
+        private int? position;
+
+        /// <summary>
+        /// Gets the document position where styling should end. The <see cref="Scintilla.GetEndStyled" /> method
+        /// indicates the last position styled correctly and the starting place for where styling should begin.
+        /// </summary>
+        /// <returns>The zero-based position within the document to perform styling up to.</returns>
+        public int Position
         {
-            this.position ??= this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
+            get
+            {
+                this.position = this.position ?? this.scintilla.Lines.ByteToCharPosition(this.bytePosition);
 
-            return (int)this.position;
+                return (int)this.position;
+            }
         }
-    }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="StyleNeededEventArgs" /> class.
-    /// </summary>
-    /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
-    /// <param name="bytePosition">The zero-based byte position within the document to stop styling.</param>
-    public StyleNeededEventArgs(Scintilla scintilla, int bytePosition)
-    {
-        this.scintilla = scintilla;
-        this.bytePosition = bytePosition;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StyleNeededEventArgs" /> class.
+        /// </summary>
+        /// <param name="scintilla">The <see cref="Scintilla" /> control that generated this event.</param>
+        /// <param name="bytePosition">The zero-based byte position within the document to stop styling.</param>
+        public StyleNeededEventArgs(Scintilla scintilla, int bytePosition)
+        {
+            this.scintilla = scintilla;
+            this.bytePosition = bytePosition;
+        }
     }
 }

--- a/Scintilla.NET/TabDrawMode.cs
+++ b/Scintilla.NET/TabDrawMode.cs
@@ -1,17 +1,18 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Specifies how tab characters are drawn when whitespace is visible.
-/// </summary>
-public enum TabDrawMode
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// The default mode of an arrow stretching until the tabstop.
+    /// Specifies how tab characters are drawn when whitespace is visible.
     /// </summary>
-    LongArrow = NativeMethods.SCTD_LONGARROW,
+    public enum TabDrawMode
+    {
+        /// <summary>
+        /// The default mode of an arrow stretching until the tabstop.
+        /// </summary>
+        LongArrow = NativeMethods.SCTD_LONGARROW,
 
-    /// <summary>
-    /// A horizontal line stretching until the tabstop.
-    /// </summary>
-    Strikeout = NativeMethods.SCTD_STRIKEOUT
+        /// <summary>
+        /// A horizontal line stretching until the tabstop.
+        /// </summary>
+        Strikeout = NativeMethods.SCTD_STRIKEOUT
+    }
 }

--- a/Scintilla.NET/Technology.cs
+++ b/Scintilla.NET/Technology.cs
@@ -1,18 +1,19 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The rendering technology used in a <see cref="Scintilla" /> control.
-/// </summary>
-public enum Technology
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Renders text using GDI. This is the default.
+    /// The rendering technology used in a <see cref="Scintilla" /> control.
     /// </summary>
-    Default = NativeMethods.SC_TECHNOLOGY_DEFAULT,
+    public enum Technology
+    {
+        /// <summary>
+        /// Renders text using GDI. This is the default.
+        /// </summary>
+        Default = NativeMethods.SC_TECHNOLOGY_DEFAULT,
 
-    /// <summary>
-    /// Renders text using Direct2D/DirectWrite. Since Direct2D buffers drawing,
-    /// Scintilla's buffering can be turned off with <see cref="Scintilla.BufferedDraw" />.
-    /// </summary>
-    DirectWrite = NativeMethods.SC_TECHNOLOGY_DIRECTWRITE
+        /// <summary>
+        /// Renders text using Direct2D/DirectWrite. Since Direct2D buffers drawing,
+        /// Scintilla's buffering can be turned off with <see cref="Scintilla.BufferedDraw" />.
+        /// </summary>
+        DirectWrite = NativeMethods.SC_TECHNOLOGY_DIRECTWRITE
+    }
 }

--- a/Scintilla.NET/UpdateChange.cs
+++ b/Scintilla.NET/UpdateChange.cs
@@ -1,31 +1,32 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Specifies the change that triggered a <see cref="Scintilla.UpdateUI" /> event.
-/// </summary>
-/// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
-[Flags]
-public enum UpdateChange
+namespace ScintillaNET
 {
     /// <summary>
-    /// Contents, styling or markers have been changed.
+    /// Specifies the change that triggered a <see cref="Scintilla.UpdateUI" /> event.
     /// </summary>
-    Content = NativeMethods.SC_UPDATE_CONTENT,
+    /// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
+    [Flags]
+    public enum UpdateChange
+    {
+        /// <summary>
+        /// Contents, styling or markers have been changed.
+        /// </summary>
+        Content = NativeMethods.SC_UPDATE_CONTENT,
 
-    /// <summary>
-    /// Selection has been changed.
-    /// </summary>
-    Selection = NativeMethods.SC_UPDATE_SELECTION,
+        /// <summary>
+        /// Selection has been changed.
+        /// </summary>
+        Selection = NativeMethods.SC_UPDATE_SELECTION,
 
-    /// <summary>
-    /// Scrolled vertically.
-    /// </summary>
-    VScroll = NativeMethods.SC_UPDATE_V_SCROLL,
+        /// <summary>
+        /// Scrolled vertically.
+        /// </summary>
+        VScroll = NativeMethods.SC_UPDATE_V_SCROLL,
 
-    /// <summary>
-    /// Scrolled horizontally.
-    /// </summary>
-    HScroll = NativeMethods.SC_UPDATE_H_SCROLL
+        /// <summary>
+        /// Scrolled horizontally.
+        /// </summary>
+        HScroll = NativeMethods.SC_UPDATE_H_SCROLL
+    }
 }

--- a/Scintilla.NET/UpdateUIEventArgs.cs
+++ b/Scintilla.NET/UpdateUIEventArgs.cs
@@ -1,32 +1,33 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Provides data for the <see cref="Scintilla.UpdateUI" /> event.
-/// </summary>
-public class UpdateUIEventArgs : EventArgs
+namespace ScintillaNET
 {
-    #region Properties
-
     /// <summary>
-    /// The UI update that occurred.
+    /// Provides data for the <see cref="Scintilla.UpdateUI" /> event.
     /// </summary>
-    /// <returns>A bitwise combination of <see cref="UpdateChange" /> values specifying the UI update that occurred.</returns>
-    public UpdateChange Change { get; private set; }
-
-    #endregion Properties
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UpdateUIEventArgs" /> class.
-    /// </summary>
-    /// <param name="change">A bitwise combination of <see cref="UpdateChange" /> values specifying the reason to update the UI.</param>
-    public UpdateUIEventArgs(UpdateChange change)
+    public class UpdateUIEventArgs : EventArgs
     {
-        Change = change;
-    }
+        #region Properties
 
-    #endregion Constructors
+        /// <summary>
+        /// The UI update that occurred.
+        /// </summary>
+        /// <returns>A bitwise combination of <see cref="UpdateChange" /> values specifying the UI update that occurred.</returns>
+        public UpdateChange Change { get; private set; }
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateUIEventArgs" /> class.
+        /// </summary>
+        /// <param name="change">A bitwise combination of <see cref="UpdateChange" /> values specifying the reason to update the UI.</param>
+        public UpdateUIEventArgs(UpdateChange change)
+        {
+            Change = change;
+        }
+
+        #endregion Constructors
+    }
 }

--- a/Scintilla.NET/VirtualSpace.cs
+++ b/Scintilla.NET/VirtualSpace.cs
@@ -1,31 +1,32 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// Enables virtual space for rectangular selections or in other circumstances or in both.
-/// </summary>
-/// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
-[Flags]
-public enum VirtualSpace
+namespace ScintillaNET
 {
     /// <summary>
-    /// Virtual space is not enabled. This is the default.
+    /// Enables virtual space for rectangular selections or in other circumstances or in both.
     /// </summary>
-    None = NativeMethods.SCVS_NONE,
+    /// <remarks>This enumeration has a FlagsAttribute attribute that allows a bitwise combination of its member values.</remarks>
+    [Flags]
+    public enum VirtualSpace
+    {
+        /// <summary>
+        /// Virtual space is not enabled. This is the default.
+        /// </summary>
+        None = NativeMethods.SCVS_NONE,
 
-    /// <summary>
-    /// Virtual space is enabled for rectangular selections.
-    /// </summary>
-    RectangularSelection = NativeMethods.SCVS_RECTANGULARSELECTION,
+        /// <summary>
+        /// Virtual space is enabled for rectangular selections.
+        /// </summary>
+        RectangularSelection = NativeMethods.SCVS_RECTANGULARSELECTION,
 
-    /// <summary>
-    /// Virtual space is user accessible.
-    /// </summary>
-    UserAccessible = NativeMethods.SCVS_USERACCESSIBLE,
+        /// <summary>
+        /// Virtual space is user accessible.
+        /// </summary>
+        UserAccessible = NativeMethods.SCVS_USERACCESSIBLE,
 
-    /// <summary>
-    /// Prevents left arrow movement and selection from wrapping to the previous line.
-    /// </summary>
-    NoWrapLineStart = NativeMethods.SCVS_NOWRAPLINESTART
+        /// <summary>
+        /// Prevents left arrow movement and selection from wrapping to the previous line.
+        /// </summary>
+        NoWrapLineStart = NativeMethods.SCVS_NOWRAPLINESTART
+    }
 }

--- a/Scintilla.NET/WhitespaceMode.cs
+++ b/Scintilla.NET/WhitespaceMode.cs
@@ -1,28 +1,29 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Specifies the display mode of whitespace characters.
-/// </summary>
-public enum WhitespaceMode
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// The normal display mode with whitespace displayed as an empty background color.
+    /// Specifies the display mode of whitespace characters.
     /// </summary>
-    Invisible = NativeMethods.SCWS_INVISIBLE,
+    public enum WhitespaceMode
+    {
+        /// <summary>
+        /// The normal display mode with whitespace displayed as an empty background color.
+        /// </summary>
+        Invisible = NativeMethods.SCWS_INVISIBLE,
 
-    /// <summary>
-    /// Whitespace characters are drawn as dots and arrows.
-    /// </summary>
-    VisibleAlways = NativeMethods.SCWS_VISIBLEALWAYS,
+        /// <summary>
+        /// Whitespace characters are drawn as dots and arrows.
+        /// </summary>
+        VisibleAlways = NativeMethods.SCWS_VISIBLEALWAYS,
 
-    /// <summary>
-    /// Whitespace used for indentation is displayed normally but after the first visible character,
-    /// it is shown as dots and arrows.
-    /// </summary>
-    VisibleAfterIndent = NativeMethods.SCWS_VISIBLEAFTERINDENT,
+        /// <summary>
+        /// Whitespace used for indentation is displayed normally but after the first visible character,
+        /// it is shown as dots and arrows.
+        /// </summary>
+        VisibleAfterIndent = NativeMethods.SCWS_VISIBLEAFTERINDENT,
 
-    /// <summary>
-    /// Whitespace used for indentation is displayed as dots and arrows.
-    /// </summary>
-    VisibleOnlyIndent = NativeMethods.SCWS_VISIBLEONLYININDENT
+        /// <summary>
+        /// Whitespace used for indentation is displayed as dots and arrows.
+        /// </summary>
+        VisibleOnlyIndent = NativeMethods.SCWS_VISIBLEONLYININDENT
+    }
 }

--- a/Scintilla.NET/WinApiHelper.cs
+++ b/Scintilla.NET/WinApiHelper.cs
@@ -1,34 +1,35 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace ScintillaNET;
-
-internal static class WinApiHelpers
+namespace ScintillaNET
 {
-    internal static IntPtr SetWindowLongPtr(this IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+    internal static class WinApiHelpers
     {
-        if (Environment.Is64BitProcess)
+        internal static IntPtr SetWindowLongPtr(this IntPtr hWnd, int nIndex, IntPtr dwNewLong)
         {
-            return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
+            if (Environment.Is64BitProcess)
+            {
+                return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
+            }
+
+            return new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
         }
 
-        return new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
+        internal static IntPtr GetWindowLongPtr(this IntPtr hWnd, int nIndex)
+        {
+            return GetWindowLong(hWnd, nIndex);
+        }
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
+        private static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+        private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
+        private static extern IntPtr GetWindowLong(IntPtr hWnd, int nIndex);
+
+        internal const long WS_EX_LAYOUTRTL = 0x00400000L;
+        internal const int GWL_EXSTYLE = -20;
     }
-
-    internal static IntPtr GetWindowLongPtr(this IntPtr hWnd, int nIndex)
-    {
-        return GetWindowLong(hWnd, nIndex);
-    }
-
-    [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
-    private static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
-
-    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
-    private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
-
-    [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
-    private static extern IntPtr GetWindowLong(IntPtr hWnd, int nIndex);
-
-    internal const long WS_EX_LAYOUTRTL = 0x00400000L;
-    internal const int GWL_EXSTYLE = -20;
 }

--- a/Scintilla.NET/WrapIndentMode.cs
+++ b/Scintilla.NET/WrapIndentMode.cs
@@ -1,23 +1,24 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Indenting behavior of wrapped sublines.
-/// </summary>
-public enum WrapIndentMode
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Wrapped sublines aligned to left of window plus the amount set by <see cref="ScintillaNET.Scintilla.WrapStartIndent" />.
-    /// This is the default.
+    /// Indenting behavior of wrapped sublines.
     /// </summary>
-    Fixed,
+    public enum WrapIndentMode
+    {
+        /// <summary>
+        /// Wrapped sublines aligned to left of window plus the amount set by <see cref="ScintillaNET.Scintilla.WrapStartIndent" />.
+        /// This is the default.
+        /// </summary>
+        Fixed,
 
-    /// <summary>
-    /// Wrapped sublines are aligned to first subline indent.
-    /// </summary>
-    Same,
+        /// <summary>
+        /// Wrapped sublines are aligned to first subline indent.
+        /// </summary>
+        Same,
 
-    /// <summary>
-    /// Wrapped sublines are aligned to first subline indent plus one more level of indentation.
-    /// </summary>
-    Indent = NativeMethods.SC_WRAPINDENT_INDENT
+        /// <summary>
+        /// Wrapped sublines are aligned to first subline indent plus one more level of indentation.
+        /// </summary>
+        Indent = NativeMethods.SC_WRAPINDENT_INDENT
+    }
 }

--- a/Scintilla.NET/WrapMode.cs
+++ b/Scintilla.NET/WrapMode.cs
@@ -1,27 +1,28 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// The line wrapping strategy.
-/// </summary>
-public enum WrapMode
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Line wrapping is disabled. This is the default.
+    /// The line wrapping strategy.
     /// </summary>
-    None = NativeMethods.SC_WRAP_NONE,
+    public enum WrapMode
+    {
+        /// <summary>
+        /// Line wrapping is disabled. This is the default.
+        /// </summary>
+        None = NativeMethods.SC_WRAP_NONE,
 
-    /// <summary>
-    /// Lines are wrapped on word or style boundaries.
-    /// </summary>
-    Word = NativeMethods.SC_WRAP_WORD,
+        /// <summary>
+        /// Lines are wrapped on word or style boundaries.
+        /// </summary>
+        Word = NativeMethods.SC_WRAP_WORD,
 
-    /// <summary>
-    /// Lines are wrapped between any character.
-    /// </summary>
-    Char = NativeMethods.SC_WRAP_CHAR,
+        /// <summary>
+        /// Lines are wrapped between any character.
+        /// </summary>
+        Char = NativeMethods.SC_WRAP_CHAR,
 
-    /// <summary>
-    /// Lines are wrapped on whitespace.
-    /// </summary>
-    Whitespace = NativeMethods.SC_WRAP_WHITESPACE
+        /// <summary>
+        /// Lines are wrapped on whitespace.
+        /// </summary>
+        Whitespace = NativeMethods.SC_WRAP_WHITESPACE
+    }
 }

--- a/Scintilla.NET/WrapVisualFlagLocation.cs
+++ b/Scintilla.NET/WrapVisualFlagLocation.cs
@@ -1,22 +1,23 @@
-﻿namespace ScintillaNET;
-
-/// <summary>
-/// Additional location options for line wrapping visual indicators.
-/// </summary>
-public enum WrapVisualFlagLocation
+﻿namespace ScintillaNET
 {
     /// <summary>
-    /// Wrap indicators are drawn near the border. This is the default.
+    /// Additional location options for line wrapping visual indicators.
     /// </summary>
-    Default = NativeMethods.SC_WRAPVISUALFLAGLOC_DEFAULT,
+    public enum WrapVisualFlagLocation
+    {
+        /// <summary>
+        /// Wrap indicators are drawn near the border. This is the default.
+        /// </summary>
+        Default = NativeMethods.SC_WRAPVISUALFLAGLOC_DEFAULT,
 
-    /// <summary>
-    /// Wrap indicators are drawn at the end of sublines near the text.
-    /// </summary>
-    EndByText = NativeMethods.SC_WRAPVISUALFLAGLOC_END_BY_TEXT,
+        /// <summary>
+        /// Wrap indicators are drawn at the end of sublines near the text.
+        /// </summary>
+        EndByText = NativeMethods.SC_WRAPVISUALFLAGLOC_END_BY_TEXT,
 
-    /// <summary>
-    /// Wrap indicators are drawn at the beginning of sublines near the text.
-    /// </summary>
-    StartByText = NativeMethods.SC_WRAPVISUALFLAGLOC_START_BY_TEXT
+        /// <summary>
+        /// Wrap indicators are drawn at the beginning of sublines near the text.
+        /// </summary>
+        StartByText = NativeMethods.SC_WRAPVISUALFLAGLOC_START_BY_TEXT
+    }
 }

--- a/Scintilla.NET/WrapVisualFlags.cs
+++ b/Scintilla.NET/WrapVisualFlags.cs
@@ -1,31 +1,32 @@
 ﻿using System;
 
-namespace ScintillaNET;
-
-/// <summary>
-/// The visual indicator used on a wrapped line.
-/// </summary>
-[Flags]
-public enum WrapVisualFlags
+namespace ScintillaNET
 {
     /// <summary>
-    /// No visual indicator is displayed. This the default.
+    /// The visual indicator used on a wrapped line.
     /// </summary>
-    None = NativeMethods.SC_WRAPVISUALFLAG_NONE,
+    [Flags]
+    public enum WrapVisualFlags
+    {
+        /// <summary>
+        /// No visual indicator is displayed. This the default.
+        /// </summary>
+        None = NativeMethods.SC_WRAPVISUALFLAG_NONE,
 
-    /// <summary>
-    /// A visual indicator is displayed at th end of a wrapped subline.
-    /// </summary>
-    End = NativeMethods.SC_WRAPVISUALFLAG_END,
+        /// <summary>
+        /// A visual indicator is displayed at th end of a wrapped subline.
+        /// </summary>
+        End = NativeMethods.SC_WRAPVISUALFLAG_END,
 
-    /// <summary>
-    /// A visual indicator is displayed at the beginning of a subline.
-    /// The subline is indented by 1 pixel to make room for the display.
-    /// </summary>
-    Start = NativeMethods.SC_WRAPVISUALFLAG_START,
+        /// <summary>
+        /// A visual indicator is displayed at the beginning of a subline.
+        /// The subline is indented by 1 pixel to make room for the display.
+        /// </summary>
+        Start = NativeMethods.SC_WRAPVISUALFLAG_START,
 
-    /// <summary>
-    /// A visual indicator is displayed in the number margin.
-    /// </summary>
-    Margin = NativeMethods.SC_WRAPVISUALFLAG_MARGIN
+        /// <summary>
+        /// A visual indicator is displayed in the number margin.
+        /// </summary>
+        Margin = NativeMethods.SC_WRAPVISUALFLAG_MARGIN
+    }
 }


### PR DESCRIPTION
I'm not really sure if this is worth merging. We can just set `<LangVersion>12.0</LangVersion>` and tell people to use an up-to-date .NET SDK to build instead. What do you think @desjarlais?