### PR TITLE
Target both .NET 6 and .NET 8

### DIFF
--- a/Scintilla.NET/Scintilla.NET.csproj
+++ b/Scintilla.NET/Scintilla.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<ProjectGuid>{22AE2386-60F1-476E-9303-61CDB0AAC4CF}</ProjectGuid>
-		<TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
+		<TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<Description>Source Editing Component based on Scintilla 5 series.</Description>
 		<Copyright>Copyright (c) Jacob Slusser 2018, VPKSoft, cyber960 2022, desjarlais 2023.</Copyright>


### PR DESCRIPTION
I realize [.NET 6 is now out-of-support](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). However, we have users of our app who are not yet able to upgrade to .NET 8 for reasons, and since Scintilla.NET no longer explicitly targets .NET 6 starting from v. 5.6.3, we're unfortunately not able to update our app to use the latest Scintilla.NET NuGet.

I hope you will consider targeting both .NET 6 and .NET 8 for the time being.