### PR TITLE
Fix #155: Overhaul unicode handling

### DIFF
--- a/Scintilla.NET-All.sln
+++ b/Scintilla.NET-All.sln
@@ -7,7 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scintilla.NET", "Scintilla.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BE874649-2B00-415E-8C80-82A42D949696}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\dotnet-desktop.yml = .github\workflows\dotnet-desktop.yml
+		.github\workflows\dotnet-desktop-build.yml = .github\workflows\dotnet-desktop-build.yml
+		.github\workflows\dotnet-nuget-release.yml = .github\workflows\dotnet-nuget-release.yml
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Scintilla.NET-All.sln
+++ b/Scintilla.NET-All.sln
@@ -1,9 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.9.34728.123
+VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scintilla.NET.TestApp", "Scintilla.NET.TestApp.csproj", "{F25685EC-098A-4080-95A9-445268609806}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scintilla.NET", "Scintilla.NET\Scintilla.NET.csproj", "{22AE2386-60F1-476E-9303-61CDB0AAC4CF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BE874649-2B00-415E-8C80-82A42D949696}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\dotnet-desktop.yml = .github\workflows\dotnet-desktop.yml
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scintilla.NET.TestApp", "Scintilla.NET.TestApp\Scintilla.NET.TestApp.csproj", "{F25685EC-098A-4080-95A9-445268609806}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,6 +25,18 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|ARM64.Build.0 = Release|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|x64.ActiveCfg = Release|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|x86.ActiveCfg = Release|Any CPU
 		{F25685EC-098A-4080-95A9-445268609806}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F25685EC-098A-4080-95A9-445268609806}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F25685EC-098A-4080-95A9-445268609806}.Debug|ARM64.ActiveCfg = Debug|ARM64
@@ -38,6 +58,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {E766EE0E-C870-4452-97F5-7399674B4570}
+		SolutionGuid = {4F3357AC-6BCF-4130-8AFE-E860012E8C1D}
 	EndGlobalSection
 EndGlobal

--- a/Scintilla.NET.TestApp/Scintilla.NET.TestApp-Common.targets
+++ b/Scintilla.NET.TestApp/Scintilla.NET.TestApp-Common.targets
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net48</TargetFramework>
     <AssemblyTitle>ScintillaNET.TestApp</AssemblyTitle>
-    <Copyright>Copyright © desjarlais 2023</Copyright>
+    <Copyright>Copyright © desjarlais 2023, Ahmet Sait 2025</Copyright>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <Authors>desjarlais</Authors>
     <Description>A test application to validate that the ScintillaNET control is working.</Description>

--- a/Scintilla.NET.TestApp/Scintilla.NET.TestApp-Common.targets
+++ b/Scintilla.NET.TestApp/Scintilla.NET.TestApp-Common.targets
@@ -1,0 +1,50 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{F25685EC-098A-4080-95A9-445268609806}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <AssemblyTitle>ScintillaNET.TestApp</AssemblyTitle>
+    <Copyright>Copyright © desjarlais 2023</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <Authors>desjarlais</Authors>
+    <Description>A test application to validate that the ScintillaNET control is working.</Description>
+    <UseWindowsForms>true</UseWindowsForms>
+    <LangVersion>latest</LangVersion>
+    <PlatformTarget>$(Platform)</PlatformTarget>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <RootNamespace>ScintillaNET.TestApp</RootNamespace>
+    <Nullable>enable</Nullable>
+    <Platforms>AnyCPU;x86;x64;ARM64</Platforms>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Update="FormMain.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="FormMain.Designer.cs">
+      <DependentUpon>FormMain.cs</DependentUpon>
+    </Compile>
+    <EmbeddedResource Update="FormMain.resx">
+      <DependentUpon>FormMain.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/Scintilla.NET.TestApp/Scintilla.NET.TestApp-Nuget.csproj
+++ b/Scintilla.NET.TestApp/Scintilla.NET.TestApp-Nuget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="Scintilla.NET.TestApp-Common.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\Scintilla.NET\Scintilla.NET.csproj" />
+    <PackageReference Include="Scintilla5.NET" Version="*-*" />
   </ItemGroup>
 </Project>

--- a/Scintilla.NET.TestApp/Scintilla.NET.TestApp-Nuget.sln
+++ b/Scintilla.NET.TestApp/Scintilla.NET.TestApp-Nuget.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scintilla.NET.TestApp", "Scintilla.NET.TestApp-Nuget.csproj", "{F25685EC-098A-4080-95A9-445268609806}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|ARM64.Build.0 = Debug|ARM64
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|x64.ActiveCfg = Debug|x64
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|x64.Build.0 = Debug|x64
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|x86.ActiveCfg = Debug|x86
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|x86.Build.0 = Debug|x86
+		{F25685EC-098A-4080-95A9-445268609806}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F25685EC-098A-4080-95A9-445268609806}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F25685EC-098A-4080-95A9-445268609806}.Release|ARM64.ActiveCfg = Release|ARM64
+		{F25685EC-098A-4080-95A9-445268609806}.Release|ARM64.Build.0 = Release|ARM64
+		{F25685EC-098A-4080-95A9-445268609806}.Release|x64.ActiveCfg = Release|x64
+		{F25685EC-098A-4080-95A9-445268609806}.Release|x64.Build.0 = Release|x64
+		{F25685EC-098A-4080-95A9-445268609806}.Release|x86.ActiveCfg = Release|x86
+		{F25685EC-098A-4080-95A9-445268609806}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E766EE0E-C870-4452-97F5-7399674B4570}
+	EndGlobalSection
+EndGlobal

--- a/Scintilla.NET.TestApp/Scintilla.NET.TestApp.csproj
+++ b/Scintilla.NET.TestApp/Scintilla.NET.TestApp.csproj
@@ -10,10 +10,11 @@
     <Description>A test application to validate that the ScintillaNET control is working.</Description>
     <UseWindowsForms>true</UseWindowsForms>
     <LangVersion>latest</LangVersion>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>$(Platform)</PlatformTarget>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <RootNamespace>ScintillaNET.TestApp</RootNamespace>
     <Nullable>enable</Nullable>
+    <Platforms>AnyCPU;x86;x64;ARM64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="FormMain.cs">

--- a/Scintilla.NET.TestApp/Scintilla.NET.TestApp.sln
+++ b/Scintilla.NET.TestApp/Scintilla.NET.TestApp.sln
@@ -8,13 +8,31 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F25685EC-098A-4080-95A9-445268609806}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F25685EC-098A-4080-95A9-445268609806}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|ARM64.Build.0 = Debug|ARM64
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|x64.ActiveCfg = Debug|x64
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|x64.Build.0 = Debug|x64
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|x86.ActiveCfg = Debug|x86
+		{F25685EC-098A-4080-95A9-445268609806}.Debug|x86.Build.0 = Debug|x86
 		{F25685EC-098A-4080-95A9-445268609806}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F25685EC-098A-4080-95A9-445268609806}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F25685EC-098A-4080-95A9-445268609806}.Release|ARM64.ActiveCfg = Release|ARM64
+		{F25685EC-098A-4080-95A9-445268609806}.Release|ARM64.Build.0 = Release|ARM64
+		{F25685EC-098A-4080-95A9-445268609806}.Release|x64.ActiveCfg = Release|x64
+		{F25685EC-098A-4080-95A9-445268609806}.Release|x64.Build.0 = Release|x64
+		{F25685EC-098A-4080-95A9-445268609806}.Release|x86.ActiveCfg = Release|x86
+		{F25685EC-098A-4080-95A9-445268609806}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Scintilla.NET.sln
+++ b/Scintilla.NET.sln
@@ -14,19 +14,25 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|ARM64.Build.0 = Debug|Any CPU
 		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|ARM64.Build.0 = Release|Any CPU
 		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|x64.ActiveCfg = Release|Any CPU
 		{22AE2386-60F1-476E-9303-61CDB0AAC4CF}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection

--- a/Scintilla.NET.sln
+++ b/Scintilla.NET.sln
@@ -7,7 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scintilla.NET", "Scintilla.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BE874649-2B00-415E-8C80-82A42D949696}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\dotnet-desktop.yml = .github\workflows\dotnet-desktop.yml
+		.github\workflows\dotnet-desktop-build.yml = .github\workflows\dotnet-desktop-build.yml
+		.github\workflows\dotnet-nuget-release.yml = .github\workflows\dotnet-nuget-release.yml
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Scintilla.NET/CharToBytePositionInfo.cs
+++ b/Scintilla.NET/CharToBytePositionInfo.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace ScintillaNET;
+
+internal readonly struct CharToBytePositionInfo(int bytePosition, int charPosition, bool lowSurrogate, int nextCodePointBytePosition) : IEquatable<CharToBytePositionInfo>
+{
+    public readonly int BytePosition = bytePosition;
+    public readonly int CharPosition = charPosition;
+    public readonly bool LowSurrogate = lowSurrogate;
+    public readonly int NextCodePointBytePosition = nextCodePointBytePosition;
+
+    /// <summary>
+    /// Length of this code point.
+    /// </summary>
+    public int Length => NextCodePointBytePosition - BytePosition;
+
+    /// <summary>
+    /// Returns <see cref="NextCodePointBytePosition"/> if <see cref="LowSurrogate"/> is true. In other
+    /// words, returns the next code point position in bytes if this <see cref="CharPosition"/>
+    /// points to the middle of a code point.
+    /// </summary>
+    public int RoundToNext => LowSurrogate ? NextCodePointBytePosition : BytePosition;
+
+    /// <summary>
+    /// Returns <c><see cref="CharPosition"/> + 1</c> if <see cref="LowSurrogate"/> is true. In other
+    /// words, returns the next UTF-16 char position if this <see cref="CharPosition"/>
+    /// points to the middle of a code point.
+    /// </summary>
+    public int RoundToNextChar => LowSurrogate ? CharPosition + 1 : CharPosition;
+
+    public CharToBytePositionInfo(int bytePosition) : this(bytePosition, -1, false, -1) { }
+
+    public CharToBytePositionInfo(int bytePosition, int charPosition) : this(bytePosition, charPosition, false, -1) { }
+
+    public override bool Equals(object obj)
+    {
+        return obj is CharToBytePositionInfo info && Equals(info);
+    }
+
+    public bool Equals(CharToBytePositionInfo other)
+    {
+        return this.BytePosition == other.BytePosition &&
+               this.CharPosition == other.CharPosition &&
+               this.LowSurrogate == other.LowSurrogate &&
+               this.NextCodePointBytePosition == other.NextCodePointBytePosition;
+    }
+
+    public override int GetHashCode()
+    {
+        int hashCode = 873051011;
+        hashCode = hashCode * -1521134295 + this.BytePosition.GetHashCode();
+        hashCode = hashCode * -1521134295 + this.CharPosition.GetHashCode();
+        hashCode = hashCode * -1521134295 + this.LowSurrogate.GetHashCode();
+        hashCode = hashCode * -1521134295 + this.NextCodePointBytePosition.GetHashCode();
+        return hashCode;
+    }
+
+    public static bool operator ==(CharToBytePositionInfo left, CharToBytePositionInfo right) => left.Equals(right);
+    public static bool operator !=(CharToBytePositionInfo left, CharToBytePositionInfo right) => !(left == right);
+}

--- a/Scintilla.NET/FlagsConverter.cs
+++ b/Scintilla.NET/FlagsConverter.cs
@@ -32,14 +32,14 @@ internal class FlagsConverter : TypeConverter
             ulong bits = 0;
             List<Enum> enums = [];
             var items = Enum.GetValues(enumType).Cast<Enum>()
-                .Select(e => new { @enum = e, bits = Convert.ToUInt64(e), bitCount = Helpers.PopCount(Convert.ToUInt64(e))})
+                .Select(e => new { @enum = e, bits = Convert.ToUInt64(e), bitCount = Helpers.PopCount(Convert.ToUInt64(e)) })
                 .Where(e => e.bits != 0 && e.bitCount > 0)
                 .ToList();
             int maxIterations = items.Count;
             for (int i = 0; i < maxIterations && bits != valueBits && items.Count > 0; i++)
             {
                 int maxIndex = items
-                    .Select(e => new { contrib = Helpers.PopCount(e.bits & valueBits & ~bits), item = e})
+                    .Select(e => new { contrib = Helpers.PopCount(e.bits & valueBits & ~bits), item = e })
                     .MaxIndex(
                         (x, y) =>                                                                    // Select one that:
                         (x.contrib != y.contrib) ? (x.contrib - y.contrib) :                         // Contributes most bits

--- a/Scintilla.NET/Helpers.cs
+++ b/Scintilla.NET/Helpers.cs
@@ -130,8 +130,12 @@ internal static class Helpers
         return value;
     }
 
-    public static void Copy(Scintilla scintilla, CopyFormat format, bool useSelection, bool allowLine, int startBytePos, int endBytePos)
+    public static void Copy(Scintilla scintilla, CopyFormat format, bool useSelection, bool allowLine, CharToBytePositionInfo startPos, CharToBytePositionInfo endPos)
     {
+        // FIXME: Surrogate pair handling
+        int startBytePos = startPos.BytePosition;
+        int endBytePos = endPos.BytePosition;
+
         // Plain text
         if ((format & CopyFormat.Text) > 0)
         {
@@ -773,10 +777,14 @@ internal static class Helpers
         }
     }
 
-    public static string GetHtml(Scintilla scintilla, int startBytePos, int endBytePos)
+    public static string GetHtml(Scintilla scintilla, CharToBytePositionInfo startPos, CharToBytePositionInfo endPos)
     {
         // If we ever allow more than UTF-8, this will have to be revisited
         Debug.Assert(scintilla.DirectMessage(NativeMethods.SCI_GETCODEPAGE).ToInt32() == NativeMethods.SC_CP_UTF8);
+
+        // FIXME: Surrogate pair handling
+        int startBytePos = startPos.BytePosition;
+        int endBytePos = endPos.RoundToNext;
 
         if (startBytePos == endBytePos)
             return string.Empty;

--- a/Scintilla.NET/Helpers.cs
+++ b/Scintilla.NET/Helpers.cs
@@ -137,7 +137,7 @@ internal static class Helpers
         int endBytePos = endPos.BytePosition;
 
         // Plain text
-        if ((format & CopyFormat.Text) > 0)
+        if (format.HasFlag(CopyFormat.Text))
         {
             if (useSelection)
             {
@@ -153,7 +153,7 @@ internal static class Helpers
         }
 
         // RTF and/or HTML
-        if ((format & (CopyFormat.Rtf | CopyFormat.Html)) > 0)
+        if ((format & (CopyFormat.Rtf | CopyFormat.Html)) != 0)
         {
             // If we ever allow more than UTF-8, this will have to be revisited
             Debug.Assert(scintilla.DirectMessage(NativeMethods.SCI_GETCODEPAGE).ToInt32() == NativeMethods.SC_CP_UTF8);
@@ -744,7 +744,7 @@ internal static class Helpers
     public static unsafe byte[] GetBytes(string text, Encoding encoding, bool zeroTerminated)
     {
         if (string.IsNullOrEmpty(text))
-            return zeroTerminated ? new byte[] { 0 } : new byte[0];
+            return zeroTerminated ? [0] : [];
 
         int count = encoding.GetByteCount(text);
         byte[] buffer = new byte[count + (zeroTerminated ? 1 : 0)];
@@ -763,10 +763,10 @@ internal static class Helpers
 
     public static unsafe byte[] GetBytes(char[] text, int length, Encoding encoding, bool zeroTerminated)
     {
+        int count = encoding.GetByteCount(text);
+        byte[] buffer = new byte[count + (zeroTerminated ? 1 : 0)];
         fixed (char* cp = text)
         {
-            int count = encoding.GetByteCount(cp, length);
-            byte[] buffer = new byte[count + (zeroTerminated ? 1 : 0)];
             fixed (byte* bp = buffer)
                 encoding.GetBytes(cp, length, bp, buffer.Length);
 

--- a/Scintilla.NET/Indicator.cs
+++ b/Scintilla.NET/Indicator.cs
@@ -45,7 +45,7 @@ public class Indicator
     public int End(int position)
     {
         position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
-        position = this.scintilla.Lines.CharToBytePosition(position);
+        position = this.scintilla.Lines.CharToBytePosition(position).BytePosition;
         position = this.scintilla.DirectMessage(NativeMethods.SCI_INDICATOREND, new IntPtr(Index), new IntPtr(position)).ToInt32();
         return this.scintilla.Lines.ByteToCharPosition(position);
     }
@@ -64,7 +64,7 @@ public class Indicator
     public int Start(int position)
     {
         position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
-        position = this.scintilla.Lines.CharToBytePosition(position);
+        position = this.scintilla.Lines.CharToBytePosition(position).RoundToNext;
         position = this.scintilla.DirectMessage(NativeMethods.SCI_INDICATORSTART, new IntPtr(Index), new IntPtr(position)).ToInt32();
         return this.scintilla.Lines.ByteToCharPosition(position);
     }
@@ -77,7 +77,7 @@ public class Indicator
     public int ValueAt(int position)
     {
         position = Helpers.Clamp(position, 0, this.scintilla.TextLength);
-        position = this.scintilla.Lines.CharToBytePosition(position);
+        position = this.scintilla.Lines.CharToBytePosition(position).BytePosition;
 
         return this.scintilla.DirectMessage(NativeMethods.SCI_INDICATORVALUEAT, new IntPtr(Index), new IntPtr(position)).ToInt32();
     }

--- a/Scintilla.NET/NativeMethods.cs
+++ b/Scintilla.NET/NativeMethods.cs
@@ -544,6 +544,7 @@ public static class NativeMethods
     public const int SCI_GETLINEINDENTPOSITION = 2128;
     public const int SCI_GETCOLUMN = 2129;
     public const int SCI_COUNTCHARACTERS = 2633;
+    public const int SCI_COUNTCODEUNITS = 2715;
     public const int SCI_SETHSCROLLBAR = 2130;
     public const int SCI_GETHSCROLLBAR = 2131;
     public const int SCI_SETINDENTATIONGUIDES = 2132;
@@ -826,6 +827,7 @@ public static class NativeMethods
     // public const int SCI_POSITIONBEFORE = 2417; // Bad, bad, bad. Don't use these...
     // public const int SCI_POSITIONAFTER = 2418;  // they treat \r\n as one character.
     public const int SCI_POSITIONRELATIVE = 2670;
+    public const int SCI_POSITIONRELATIVECODEUNITS = 2716;
     public const int SCI_COPYRANGE = 2419;
     public const int SCI_COPYTEXT = 2420;
     public const int SCI_SETSELECTIONMODE = 2422;

--- a/Scintilla.NET/NativeMethods.cs
+++ b/Scintilla.NET/NativeMethods.cs
@@ -682,7 +682,9 @@ public static class NativeMethods
     public const int SCI_SETVSCROLLBAR = 2280;
     public const int SCI_GETVSCROLLBAR = 2281;
     public const int SCI_APPENDTEXT = 2282;
+    [Obsolete("Use SCI_GETPHASESDRAW instead.")]
     public const int SCI_GETTWOPHASEDRAW = 2283;
+    [Obsolete("Use SCI_SETPHASESDRAW instead.")]
     public const int SCI_SETTWOPHASEDRAW = 2284;
     public const int SCI_GETPHASESDRAW = 2673;
     public const int SCI_SETPHASESDRAW = 2674;

--- a/Scintilla.NET/ProjectionEqualityComparer.cs
+++ b/Scintilla.NET/ProjectionEqualityComparer.cs
@@ -95,7 +95,7 @@ internal class ProjectionEqualityComparer<TSource, TKey> : IEqualityComparer<TSo
     public ProjectionEqualityComparer(Func<TSource, TKey> projection, IEqualityComparer<TKey> comparer)
     {
         this.comparer = comparer ?? EqualityComparer<TKey>.Default;
-        this.projection = projection ?? throw new ArgumentNullException("projection");
+        this.projection = projection ?? throw new ArgumentNullException(nameof(projection));
     }
 
     /// <summary>
@@ -127,7 +127,7 @@ internal class ProjectionEqualityComparer<TSource, TKey> : IEqualityComparer<TSo
     {
         if (obj == null)
         {
-            throw new ArgumentNullException("obj");
+            throw new ArgumentNullException(nameof(obj));
         }
 
         return this.comparer.GetHashCode(this.projection(obj));

--- a/Scintilla.NET/Scintilla.NET.csproj
+++ b/Scintilla.NET/Scintilla.NET.csproj
@@ -4,8 +4,8 @@
 		<TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<Description>Source Editing Component based on Scintilla 5 series.</Description>
-		<Copyright>Copyright (c) Jacob Slusser 2018, VPKSoft, cyber960 2022, desjarlais 2023.</Copyright>
-		<Version>5.6.6</Version>
+		<Copyright>Copyright (c) Jacob Slusser 2018, VPKSoft, cyber960 2022, desjarlais 2023, Ahmet Sait 2025</Copyright>
+		<Version>6.0.0</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<UseWindowsForms>true</UseWindowsForms>
@@ -29,7 +29,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<RootNamespace>ScintillaNET</RootNamespace>
-		<Authors>Jacob Slusser, VPKSoft, cyber960, desjarlais</Authors>
+		<Authors>Jacob Slusser, VPKSoft, cyber960, desjarlais, Ahmet Sait</Authors>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>scintilla5.net.snk</AssemblyOriginatorKeyFile>

--- a/Scintilla.NET/Scintilla.cs
+++ b/Scintilla.NET/Scintilla.cs
@@ -1097,7 +1097,7 @@ namespace ScintillaNET
         }
 
         /// <summary>
-        /// Returns the character as the specified document position.
+        /// Returns the character at the specified document position.
         /// </summary>
         /// <param name="position">The zero-based document position of the character to get.</param>
         /// <returns>The character at the specified <paramref name="position" />.</returns>
@@ -1362,8 +1362,7 @@ namespace ScintillaNET
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public string GetLexerIDFromLexer(Lexer lexer)
         {
-            return lexer switch
-            {
+            return lexer switch {
                 Lexer.SCLEX_A68K => "a68k",
                 Lexer.SCLEX_ADPL => "apdl",
                 Lexer.SCLEX_ASYMPTOTE => "asy",
@@ -1709,7 +1708,7 @@ namespace ScintillaNET
         public unsafe void InsertText(int position, string text)
         {
             if (position < -1)
-                throw new ArgumentOutOfRangeException("position", "Position must be greater or equal to zero, or -1.");
+                throw new ArgumentOutOfRangeException(nameof(position), "Position must be greater or equal to zero, or -1.");
 
             byte[] textBytes = Helpers.GetBytes(text ?? string.Empty, Encoding, zeroTerminated: true);
 
@@ -1722,7 +1721,7 @@ namespace ScintillaNET
             {
                 int textLength = TextLength;
                 if (position > textLength)
-                    throw new ArgumentOutOfRangeException("position", "Position cannot exceed document length.");
+                    throw new ArgumentOutOfRangeException(nameof(position), "Position cannot exceed document length.");
 
                 var pos = Lines.CharToBytePosition(position);
                 if (pos.LowSurrogate)
@@ -2621,8 +2620,8 @@ namespace ScintillaNET
             start = Lines.CharToBytePosition(start).BytePosition;
             end = Lines.CharToBytePosition(end).RoundToNext;
 
-            // The arguments would  seem reverse from Scintilla documentation
-            // but empirical  evidence suggests this is correct....
+            // The arguments would seem reverse from Scintilla documentation but
+            // empirical evidence suggests this is correct...
             DirectMessage(NativeMethods.SCI_SCROLLRANGE, new IntPtr(start), new IntPtr(end));
         }
 
@@ -2959,11 +2958,11 @@ namespace ScintillaNET
             int textLength = TextLength;
 
             if (length < 0)
-                throw new ArgumentOutOfRangeException("length", "Length cannot be less than zero.");
+                throw new ArgumentOutOfRangeException(nameof(length), "Length cannot be less than zero.");
             if (this.stylingPosition + length > textLength)
-                throw new ArgumentOutOfRangeException("length", "Position and length must refer to a range within the document.");
+                throw new ArgumentOutOfRangeException(nameof(length), "Position and length must refer to a range within the document.");
             if (style < 0 || style >= Styles.Count)
-                throw new ArgumentOutOfRangeException("style", "Style must be non-negative and less than the size of the collection.");
+                throw new ArgumentOutOfRangeException(nameof(style), "Style must be non-negative and less than the size of the collection.");
 
             var pos = Lines.CharToBytePosition(this.stylingPosition + length);
             int endPos = pos.RoundToNextChar;
@@ -3254,7 +3253,7 @@ namespace ScintillaNET
                 windowRect.right - borderSize.Width,
                 windowRect.bottom - borderSize.Height);
 
-            if (m.WParam != (IntPtr)1)
+            if (m.WParam != new IntPtr(1))
                 NativeMethods.CombineRgn(clipRegion, clipRegion, m.WParam, NativeMethods.RGN_AND);
 
             // Call default proc to get the scrollbars, etc... painted
@@ -4251,7 +4250,7 @@ namespace ScintillaNET
                 if (this.borderStyle != value)
                 {
                     if (!Enum.IsDefined(typeof(BorderStyle), value))
-                        throw new InvalidEnumArgumentException("value", (int)value, typeof(BorderStyle));
+                        throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(BorderStyle));
 
                     this.borderStyle = value;
                     UpdateStyles();

--- a/Scintilla.NET/Scintilla.cs
+++ b/Scintilla.NET/Scintilla.cs
@@ -886,31 +886,37 @@ namespace ScintillaNET
             }
         }
 
-        internal IntPtr DirectMessage(int msg)
-        {
-            return DirectMessage(msg, IntPtr.Zero, IntPtr.Zero);
-        }
-
-        internal IntPtr DirectMessage(int msg, IntPtr wParam)
-        {
-            return DirectMessage(msg, wParam, IntPtr.Zero);
-        }
-
         /// <summary>
         /// Sends the specified message directly to the native Scintilla window,
         /// bypassing any managed APIs.
         /// </summary>
         /// <param name="msg">The message ID.</param>
-        /// <param name="wParam">The message <c>wparam</c> field.</param>
-        /// <param name="lParam">The message <c>lparam</c> field.</param>
         /// <returns>An <see cref="IntPtr"/> representing the result of the message request.</returns>
         /// <remarks>This API supports the Scintilla infrastructure and is not intended to be used directly from your code.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public IntPtr DirectMessage(int msg)
+        {
+            return DirectMessage(msg, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        /// <inheritdoc cref="DirectMessage(int)"/>
+        /// <param name="msg"></param>
+        /// <param name="wParam">The message <c>wparam</c> field.</param>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public IntPtr DirectMessage(int msg, IntPtr wParam)
+        {
+            return DirectMessage(msg, wParam, IntPtr.Zero);
+        }
+
+        /// <inheritdoc cref="DirectMessage(int, IntPtr)"/>
+        /// <param name="msg"></param>
+        /// <param name="wParam"></param>
+        /// <param name="lParam">The message <c>lparam</c> field.</param>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public virtual IntPtr DirectMessage(int msg, IntPtr wParam, IntPtr lParam)
         {
             // If the control handle, ptr, direct function, etc... hasn't been created yet, it will be now.
-            IntPtr result = DirectMessage(SciPointer, msg, wParam, lParam);
-            return result;
+            return DirectMessage(SciPointer, msg, wParam, lParam);
         }
 
         private static IntPtr DirectMessage(IntPtr sciPtr, int msg, IntPtr wParam, IntPtr lParam)

--- a/Scintilla.NET/Selection.cs
+++ b/Scintilla.NET/Selection.cs
@@ -26,7 +26,7 @@ public class Selection
         set
         {
             value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
-            value = this.scintilla.Lines.CharToBytePosition(value);
+            value = this.scintilla.Lines.CharToBytePosition(value).BytePosition;
             this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNANCHOR, new IntPtr(Index), new IntPtr(value));
         }
     }
@@ -65,7 +65,7 @@ public class Selection
         set
         {
             value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
-            value = this.scintilla.Lines.CharToBytePosition(value);
+            value = this.scintilla.Lines.CharToBytePosition(value).BytePosition;
             this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNCARET, new IntPtr(Index), new IntPtr(value));
         }
     }
@@ -104,7 +104,7 @@ public class Selection
         set
         {
             value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
-            value = this.scintilla.Lines.CharToBytePosition(value);
+            value = this.scintilla.Lines.CharToBytePosition(value).BytePosition;
             this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNEND, new IntPtr(Index), new IntPtr(value));
         }
     }
@@ -132,7 +132,7 @@ public class Selection
         set
         {
             value = Helpers.Clamp(value, 0, this.scintilla.TextLength);
-            value = this.scintilla.Lines.CharToBytePosition(value);
+            value = this.scintilla.Lines.CharToBytePosition(value).BytePosition;
             this.scintilla.DirectMessage(NativeMethods.SCI_SETSELECTIONNSTART, new IntPtr(Index), new IntPtr(value));
         }
     }

--- a/Scintilla.NET/UnicodeConstants.cs
+++ b/Scintilla.NET/UnicodeConstants.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ScintillaNET
+{
+    /// <summary>
+    /// Includes various unicode constants and common code points such as "Replacement Character".
+    /// </summary>
+    public static class UnicodeConstants
+    {
+        /// <summary>
+        /// Unicode "Replacement Character" (�) as char.
+        /// </summary>
+        public const char replacementCharacter = '�';
+        /// <summary>
+        /// Unicode "Replacement Character" (�) as string.
+        /// </summary>
+        public const string replacementCharacterString = "�";
+        /// <summary>
+        /// Unicode "Replacement Character" (�) as UTF-8 encoded bytes.
+        /// </summary>
+        public static readonly byte[] replacementCharacterUtf8 = [0xEF, 0xBF, 0xBD];
+        /// <summary>
+        /// Unicode "Replacement Character" (�) as UTF-8 encoded null-terminated bytes.
+        /// </summary>
+        public static readonly byte[] replacementCharacterUtf8z = [0xEF, 0xBF, 0xBD, 0x00];
+    }
+}

--- a/Scintilla.NET/WinApiHelper.cs
+++ b/Scintilla.NET/WinApiHelper.cs
@@ -64,8 +64,7 @@ internal static class WinApiHelpers
     internal static Architecture GetProcessArchitecture()
     {
         GetSystemInfo(out SYSTEM_INFO sysInfo);
-        return sysInfo.wProcessorArchitecture switch
-        {
+        return sysInfo.wProcessorArchitecture switch {
             PROCESSOR_ARCHITECTURE_INTEL => Architecture.X86,
             PROCESSOR_ARCHITECTURE_AMD64 => Architecture.X64,
             PROCESSOR_ARCHITECTURE_ARM => Architecture.Arm,


### PR DESCRIPTION
This PR brings proper unicode handling consistent with how `string` works in .NET Framework.

New API:
- `GetCodePointAt` returns UTF-32 character at the specified index.

Breaking changes:
- `GetCharAt` returns `char` instead of `int`.
- `GetWideTextRange` is removed.
- Some text related functions behave differently.