### PR TITLE
1. Added ~Scintilla() finalizer — ensures Dispose(false) is called by…

### DIFF
--- a/Scintilla.NET/Scintilla.cs
+++ b/Scintilla.NET/Scintilla.cs
@@ -1016,15 +1016,23 @@ namespace ScintillaNET
                     if (IsHandleCreated)
                         DestroyHandle();
                 }
+            }
 
-                if (this.fillUpChars != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(this.fillUpChars);
-                    this.fillUpChars = IntPtr.Zero;
-                }
+            if (this.fillUpChars != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(this.fillUpChars);
+                this.fillUpChars = IntPtr.Zero;
             }
 
             base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources held by this instance.
+        /// </summary>
+        ~Scintilla()
+        {
+            Dispose(false);
         }
 
         /// <summary>


### PR DESCRIPTION
… the GC if the consumer never calls Dispose() explicitly.

2. Moved fillUpChars cleanup outside if (disposing) — fillUpChars is an unmanaged resource (Marshal.AllocHGlobal), so it must be freed in both the explicit (disposing = true) and finalizer (disposing = false) paths. Previously it was only freed when disposing was true, meaning the finalizer path would leak the memory.